### PR TITLE
ui: season tabs carry their episode count, and a tick once you are through

### DIFF
--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -77,10 +77,26 @@ pub(crate) struct Episode {
     pub(crate) acodec: String, // Media[0].audioCodec
 }
 
+#[derive(Default)]
 pub(crate) struct Season {
     pub(crate) rk: String,
     pub(crate) index: i64,
     pub(crate) title: String,
+    /// episodes in this season (`leafCount`); 0 when the server sent no count
+    pub(crate) leaf_count: i64,
+    /// how many of those are watched (`viewedLeafCount`)
+    pub(crate) viewed_leaf_count: i64,
+}
+
+impl Season {
+    /// Every episode of this season is watched — the season-scope form of the container rule
+    /// `fetch_detail` applies to a show (`viewed >= leaf && leaf > 0`). It lives here, on the data,
+    /// so the season tab's tick and the coming "Mark Season Watched" row read ONE truth instead of
+    /// each re-deriving the comparison at its own site. The `leaf_count > 0` half is load-bearing:
+    /// a season the server sent no counts for is `0 >= 0`, which would otherwise read as watched.
+    pub(crate) fn watched(&self) -> bool {
+        self.leaf_count > 0 && self.viewed_leaf_count >= self.leaf_count
+    }
 }
 
 pub(crate) struct Related {
@@ -558,6 +574,8 @@ fn fetch_seasons(rk: &str) -> Vec<Season> {
             rk: x.rating_key.clone(),
             index: x.index,
             title: x.title.clone(),
+            leaf_count: x.leaf_count,
+            viewed_leaf_count: x.viewed_leaf_count,
         })
         .collect()
 }
@@ -1076,8 +1094,8 @@ mod tests {
                 rk: rk.to_string(),
                 is_show: true,
                 seasons: vec![
-                    Season { rk: "sk1".to_string(), index: 1, title: "Season 1".to_string() },
-                    Season { rk: "sk2".to_string(), index: 2, title: "Season 2".to_string() },
+                    Season { rk: "sk1".to_string(), index: 1, title: "Season 1".to_string(), ..Default::default() },
+                    Season { rk: "sk2".to_string(), index: 2, title: "Season 2".to_string(), ..Default::default() },
                 ],
                 episodes: eps.iter().map(|e| episode(e)).collect(),
                 cur_season: cur,
@@ -1179,5 +1197,28 @@ mod tests {
         assert!(!season_loading(), "but it still settles the spinner");
 
         clear();
+    }
+
+    /// The season-scope watched rule. Pure (no crate global, so no `testlock` here) and worth its
+    /// own test because two very different call sites depend on it — the season tab draws a tick
+    /// off it, and "Mark Season Watched" will decide which way to scrobble off it. The counts are
+    /// the ones a live `/library/metadata/{show}/children` returned: `idx=1 leaves=10 viewed=10`
+    /// and `idx=2 leaves=10 viewed=1`.
+    #[test]
+    fn a_season_is_watched_only_when_the_server_counted_episodes_and_all_of_them_are_seen() {
+        let season = |leaf: i64, viewed: i64| Season {
+            leaf_count: leaf,
+            viewed_leaf_count: viewed,
+            ..Default::default()
+        };
+        assert!(season(10, 10).watched(), "every episode seen");
+        assert!(!season(10, 1).watched(), "one episode in is not watched");
+        assert!(!season(10, 0).watched(), "never started");
+        // A season the server sent no counts for is 0 >= 0 — the `leaf_count > 0` half of the rule
+        // is the only thing keeping "we don't know" from reporting as "fully watched".
+        assert!(!season(0, 0).watched(), "no counts is not a watched season");
+        // viewedLeafCount can lead leafCount right after a scrobble of a season being re-indexed;
+        // more-watched-than-exists is still watched, never a negative remainder.
+        assert!(season(10, 11).watched(), "an over-count is still watched");
     }
 }

--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -77,7 +77,9 @@ pub(crate) struct Episode {
     pub(crate) acodec: String, // Media[0].audioCodec
 }
 
-#[derive(Default)]
+// Deliberately NOT `Default`: every construction site spells every field, so adding one to a
+// season is a compile error at each of them rather than a silent zero (the counts below are
+// exactly the kind of field that reads as a legitimate value when it defaults).
 pub(crate) struct Season {
     pub(crate) rk: String,
     pub(crate) index: i64,
@@ -1094,8 +1096,8 @@ mod tests {
                 rk: rk.to_string(),
                 is_show: true,
                 seasons: vec![
-                    Season { rk: "sk1".to_string(), index: 1, title: "Season 1".to_string(), ..Default::default() },
-                    Season { rk: "sk2".to_string(), index: 2, title: "Season 2".to_string(), ..Default::default() },
+                    Season { rk: "sk1".to_string(), index: 1, title: "Season 1".to_string(), leaf_count: 0, viewed_leaf_count: 0 },
+                    Season { rk: "sk2".to_string(), index: 2, title: "Season 2".to_string(), leaf_count: 0, viewed_leaf_count: 0 },
                 ],
                 episodes: eps.iter().map(|e| episode(e)).collect(),
                 cur_season: cur,
@@ -1207,9 +1209,11 @@ mod tests {
     #[test]
     fn a_season_is_watched_only_when_the_server_counted_episodes_and_all_of_them_are_seen() {
         let season = |leaf: i64, viewed: i64| Season {
+            rk: String::new(),
+            index: 0,
+            title: String::new(),
             leaf_count: leaf,
             viewed_leaf_count: viewed,
-            ..Default::default()
         };
         assert!(season(10, 10).watched(), "every episode seen");
         assert!(!season(10, 1).watched(), "one episode in is not watched");

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -464,6 +464,13 @@ impl TabLay {
 /// Each tab carries a quiet second fact past its name: how many episodes the season holds, or a
 /// tick once they are all watched (`metadata::Season::watched` is the ONE rule for that, shared
 /// with the item-level watched state). A season the server sent no `leafCount` for shows neither.
+///
+/// COST: this is uncached and runs on the draw path (and again per frame while the tab row holds
+/// focus, through `tab_focus_geom`), so it is one `CString` + one `text_width` per season per call
+/// — and the count adds a second of each. Both are cheap now that `text::text_width` is a
+/// `TTF_SizeUTF8` metrics walk rather than a rasterize+upload, but a many-season strip (Top Gear)
+/// is the shape that would want the fingerprinted cache `ep_meta_h` uses, and no FPS scene covers
+/// it: `fps:detail-transition` is a MOVIE, which returns from `draw_tabs` before reaching here.
 fn tabs_layout(d: &crate::metadata::Detail) -> Vec<TabLay> {
     let mut x = MARGIN_X;
     let mut out = Vec::with_capacity(d.seasons.len());

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -11,7 +11,7 @@ use crate::ui::card_row::{self, CardRow, RowStyle};
 use crate::ui::consts::*;
 use crate::ui::text_view::TextView;
 use crate::ui::theme;
-use crate::ui::widgets::{resolve_tex, Art, Button, CircleButton, ControlStyle};
+use crate::ui::widgets::{resolve_tex, Art, Button, CircleButton, ControlStyle, TabNote, TabPill};
 use crate::ui::{hero_alpha, on_axis, Column, Env, Painter, Rect, ScrollColumn, Spring, View}; // View: Button/CircleButton::draw
 use std::ffi::CString;
 use std::os::raw::c_int;
@@ -432,19 +432,53 @@ pub(crate) fn move_focus(sym: c_int) {
     }
 }
 
-/// ONE source of truth for the season-tab strip's layout: per tab, its index, content-space
-/// label x, label width, and the label CString — the draw pass and the focus/scroll geometry
-/// both walk this, so their x-advance can't drift. A label that can't be a CString (interior
-/// NUL — never in practice) is skipped entirely (not drawn, no advance).
-fn tabs_layout(d: &crate::metadata::Detail) -> Vec<(usize, f32, f32, CString)> {
+/// ONE season tab's resolved layout: its index, content-space label x, the tab's CONTENT width
+/// (label plus whatever trailing note it carries), the label CString and the note's own pieces.
+struct TabLay {
+    i: usize,
+    x: f32,
+    w: f32,
+    label: CString,
+    /// the season's episode count, pre-rendered; empty when the tab shows no count
+    count: CString,
+    /// every episode of the season is watched → the note is a tick, not a count
+    done: bool,
+}
+impl TabLay {
+    /// This tab's trailing note. Borrows `count`, so it must not outlive the layout entry.
+    fn note(&self) -> TabNote {
+        if self.done {
+            TabNote::Done
+        } else if self.count.as_bytes().is_empty() {
+            TabNote::None
+        } else {
+            TabNote::Count(self.count.as_ptr())
+        }
+    }
+}
+
+/// ONE source of truth for the season-tab strip's layout — the draw pass and the focus/scroll
+/// geometry both walk this, so their x-advance can't drift. A label that can't be a CString
+/// (interior NUL — never in practice) is skipped entirely (not drawn, no advance).
+///
+/// Each tab carries a quiet second fact past its name: how many episodes the season holds, or a
+/// tick once they are all watched (`metadata::Season::watched` is the ONE rule for that, shared
+/// with the item-level watched state). A season the server sent no `leafCount` for shows neither.
+fn tabs_layout(d: &crate::metadata::Detail) -> Vec<TabLay> {
     let mut x = MARGIN_X;
     let mut out = Vec::with_capacity(d.seasons.len());
     for (i, s) in d.seasons.iter().enumerate() {
         let label = if s.title.is_empty() { format!("Season {}", s.index) } else { s.title.clone() };
         if let Ok(lc) = CString::new(label) {
-            let w = crate::text::text_width(lc.as_ptr(), theme::size::BODY, 1);
-            out.push((i, x, w, lc));
-            x += w + TAB_ADVANCE;
+            let count = if s.watched() || s.leaf_count <= 0 {
+                CString::default()
+            } else {
+                CString::new(s.leaf_count.to_string()).unwrap_or_default()
+            };
+            let mut lay = TabLay { i, x, w: 0.0, label: lc, count, done: s.watched() };
+            lay.w = crate::text::text_width(lay.label.as_ptr(), theme::size::BODY, 1) + TabPill::note_w(lay.note());
+            x += lay.w + TAB_ADVANCE;
+            out.push(lay);
         }
     }
     out
@@ -458,11 +492,11 @@ fn tab_focus_geom() -> (f32, f32) {
     };
     let col = view().col.max(0) as usize;
     let mut x_end = MARGIN_X;
-    for (i, x, w, _lc) in tabs_layout(d) {
-        if i == col {
-            return (x, w);
+    for lay in tabs_layout(d) {
+        if lay.i == col {
+            return (lay.x, lay.w);
         }
-        x_end = x + w + TAB_ADVANCE;
+        x_end = lay.x + lay.w + TAB_ADVANCE;
     }
     (x_end, 0.0)
 }
@@ -902,16 +936,18 @@ fn draw_tabs(p: Painter) {
     // segmented control: the *selected* season carries a subtle pill (bright ACCENT while the tab row
     // is focused); non-selected seasons are plain dim text. (TabPill handles the state → look.)
     let e = Env::inert();
-    for (i, x, w, lc) in tabs_layout(d) {
-        let selected = i == d.cur_season;
-        let focused = sec == 1 && col == i as c_int;
-        // pill sized to the (bold) label — text sits at x, pill padded ±18, tabs advance by label
-        // width + TAB_ADVANCE (see tabs_layout). The pill fills the block height (TAB_ROW_H == the
-        // hero-button CD), so tabs and buttons read as one control family.
-        if on_axis(x - 18.0 - sx, w + 36.0, SCR_W, 0.0) {
-            crate::ui::widgets::TabPill::new(lc.as_ptr(), theme::size::BODY, Rect::new(x - 18.0, tab_y, w + 36.0, TAB_ROW_H))
+    for lay in tabs_layout(d) {
+        let selected = lay.i == d.cur_season;
+        let focused = sec == 1 && col == lay.i as c_int;
+        // pill sized to the (bold) label plus its trailing note — content sits at x, pill padded
+        // ±18, tabs advance by that content width + TAB_ADVANCE (see tabs_layout). The pill fills
+        // the block height (TAB_ROW_H == the hero-button CD), so tabs and buttons read as one
+        // control family.
+        if on_axis(lay.x - 18.0 - sx, lay.w + 36.0, SCR_W, 0.0) {
+            TabPill::new(lay.label.as_ptr(), theme::size::BODY, Rect::new(lay.x - 18.0, tab_y, lay.w + 36.0, TAB_ROW_H))
                 .segment(selected)
                 .focused(focused)
+                .note(lay.note())
                 .draw(&e, pt);
         }
     }

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -486,7 +486,9 @@ pub struct TabPill {
     note: TabNote,
 }
 impl TabPill {
-    /// pill width for a `chars`-long label at `sz` (label advance + horizontal padding)
+    /// pill width for a `chars`-long label at `sz` (label advance + horizontal padding). Covers
+    /// the LABEL only — a pill that also carries a [`TabNote`] must add [`note_w`](Self::note_w),
+    /// or the note is drawn outside the fill.
     pub fn width(chars: usize, sz: c_int) -> f32 {
         chars as f32 * sz as f32 * 0.56 + 44.0
     }
@@ -542,8 +544,16 @@ impl View for TabPill {
         }
         // The label centres in the pill MINUS the note group, so a tab carrying a note keeps
         // label+note centred as one unit rather than shoving the label off-centre. The note then
-        // hugs the label's own right edge (its painted width, back from `Label::draw`), which is
+        // hugs the label's own PAINTED right edge (the width `Label::draw` hands back), which is
         // why this needs no knowledge of the caller's pill padding.
+        //
+        // Painted, deliberately, not the width the caller measured: a strip that sizes its tabs
+        // with the BOLD label (as the season tabs and `draw_tab_row` both do, so an advance can't
+        // move with focus) paints a NON-bold label a couple of px narrower. Anchoring off the
+        // caller's number instead would pin the note while the label's right edge slid under it,
+        // i.e. it would trade a constant label→note gap for a variable one. The gap is the
+        // relationship the eye reads here; the few px of slack left inside the pill's own padding
+        // on an unbolded tab is the same slack the label alone already had.
         let nw = Self::note_w(self.note);
         let lw = lab.draw(p, Rect::new(r.x, r.y, r.w - nw, r.h));
         let nx = r.x + (r.w - nw) * 0.5 + lw * 0.5 + NOTE_GAP;

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -450,6 +450,32 @@ enum TabStyle {
     Segment { selected: bool },
 }
 
+/// The quiet annotation a [`TabPill`] can carry after its label — the detail page's season tabs use
+/// it for "how many episodes are in here" and "you have watched them all". It is deliberately
+/// subordinate to the label: one type rung down, never bold, and a step of alpha under the label's
+/// own ink, so a tab still reads as its label first and its count second.
+#[derive(Clone, Copy, Default)]
+pub enum TabNote {
+    #[default]
+    None,
+    /// a small count after the label. Non-owning, exactly like [`TabPill::label`] — keep the
+    /// `CString` alive for the whole draw frame.
+    Count(*const c_char),
+    /// everything behind this tab is watched — a tick takes the count's place.
+    Done,
+}
+
+/// Type rung of a tab's trailing note: one below the label, still at the couch legibility floor.
+const NOTE_SZ: c_int = theme::size::CAPTION;
+/// Label → note air inside the pill.
+const NOTE_GAP: f32 = theme::space::SM;
+/// The watched tick stands as tall as the note's own rung, so a count and a tick take the same band.
+const NOTE_TICK_D: f32 = NOTE_SZ as f32;
+/// The note's ink is the pill's own ink one alpha step down — de-emphasis without a second colour
+/// role, so it stays legible in every one of [`TabStyle`]'s ink states (including the already-dim
+/// unselected segment) while never competing with the label.
+const NOTE_INK_A: f32 = 0.75;
+
 // ---- TabPill: a rounded pill with a centered label, in one of two state models (TabStyle). ----
 pub struct TabPill {
     pub frame: Rect,
@@ -457,6 +483,7 @@ pub struct TabPill {
     pub sz: c_int,
     pub focused: bool,
     style: TabStyle,
+    note: TabNote,
 }
 impl TabPill {
     /// pill width for a `chars`-long label at `sz` (label advance + horizontal padding)
@@ -464,7 +491,7 @@ impl TabPill {
         chars as f32 * sz as f32 * 0.56 + 44.0
     }
     pub fn new(label: *const c_char, sz: c_int, frame: Rect) -> Self {
-        Self { frame, label, sz, focused: false, style: TabStyle::Button }
+        Self { frame, label, sz, focused: false, style: TabStyle::Button, note: TabNote::None }
     }
     pub fn focused(mut self, f: bool) -> Self {
         self.focused = f;
@@ -474,6 +501,21 @@ impl TabPill {
     pub fn segment(mut self, selected: bool) -> Self {
         self.style = TabStyle::Segment { selected };
         self
+    }
+    /// attach a trailing [`TabNote`] (a count, or the watched tick).
+    pub fn note(mut self, note: TabNote) -> Self {
+        self.note = note;
+        self
+    }
+    /// What the note adds to a pill's CONTENT width, gap included (0 for [`TabNote::None`]). The
+    /// caller lays its tab strip out with this, so pill widths, the strip's x-advance and the note
+    /// itself can never disagree about how wide a tab is.
+    pub fn note_w(note: TabNote) -> f32 {
+        match note {
+            TabNote::None => 0.0,
+            TabNote::Count(t) => NOTE_GAP + crate::text::text_width(t, NOTE_SZ, 0),
+            TabNote::Done => NOTE_GAP + NOTE_TICK_D,
+        }
     }
 }
 impl View for TabPill {
@@ -498,7 +540,29 @@ impl View for TabPill {
         if bold {
             lab = lab.bold();
         }
-        lab.draw(p, r);
+        // The label centres in the pill MINUS the note group, so a tab carrying a note keeps
+        // label+note centred as one unit rather than shoving the label off-centre. The note then
+        // hugs the label's own right edge (its painted width, back from `Label::draw`), which is
+        // why this needs no knowledge of the caller's pill padding.
+        let nw = Self::note_w(self.note);
+        let lw = lab.draw(p, Rect::new(r.x, r.y, r.w - nw, r.h));
+        let nx = r.x + (r.w - nw) * 0.5 + lw * 0.5 + NOTE_GAP;
+        let note_ink = theme::with_a(ink, NOTE_INK_A);
+        match self.note {
+            TabNote::None => {}
+            TabNote::Count(t) => {
+                Label::new(t, NOTE_SZ, note_ink).draw(p, Rect::new(nx, r.y, 0.0, r.h));
+            }
+            TabNote::Done => {
+                let d = NOTE_TICK_D;
+                crate::ui::icons::draw(
+                    p,
+                    crate::ui::icons::Icon::Check,
+                    Rect::new(nx, r.y + (r.h - d) * 0.5, d, d),
+                    note_ink,
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Parity unit 3 (`docs/parity-gaps.md` §2 theme A / §5c): the season tabs now say how big a season is and whether you have finished it.

## What changed

- **`metadata::Season`** gains `leaf_count` / `viewed_leaf_count` — already parsed at `plex/models.rs:150-153`, previously never copied across — plus **`Season::watched()`**, the season-scope form of the container rule `fetch_detail` applies to a show (`viewed >= leaf && leaf > 0`). It lives on the data so the tab's tick and the coming *Mark Season Watched* row read one truth. The `leaf_count > 0` half is load-bearing: a season with no counts is `0 >= 0`, which would otherwise report as fully watched.
- **`ui/widgets.rs`**: `TabPill` gains a trailing **`TabNote`** — a count, or a tick — one type rung down (`size::CAPTION`), never bold, the pill's own ink one alpha step down. It is an annotation, not a second label. `TabPill::note_w` is the single width source, so pill width, the strip's x-advance and the scroll-into-view geometry cannot disagree.
- **`ui/detail.rs`**: `tabs_layout` returns a `TabLay` (was a 4-tuple) carrying the note; the label centres in the pill *minus* the note so a counted tab keeps label+note centred as one unit.

No new colour literal, no raw font size, no hand-placed text; the note is drawn through `Label` / `icons::draw` (which snaps its own origin).

## Verification

- `make check` — **59/59** (baseline 58, +1: the fully-watched rule, including the no-counts and over-count edges).
- `make` — ARM cross-build green.
- Device, under the TV lock: `./tests/run.py --fps` **5/5** (no playback cases — this is UI-only), then a `DISPLAY` capture of *The Morning Show* (`rk=437`).

Server truth vs. what rendered, from `/library/metadata/437/children`:

| season | leaves | viewed | tab shows |
|---|---|---|---|
| Season 1 | 10 | 10 | ✓ tick |
| Season 2 | 10 | 1 | `10` |

Captured in all four pill states (focused, selected-unfocused, plain, plain-watched): the count is clearly legible and clearly subordinate to the label, and the pill padding stays even on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc