### PR TITLE
ui: the account menu answers from the session, not from an empty UserRef

### DIFF
--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -106,15 +106,25 @@ impl Session {
     }
 }
 
+/// Read the persisted session and nothing else — **no minting, no write.** For readers that merely
+/// want to know what the session says (the account surfaces): [`load`]'s client-id minting means a
+/// read can turn into a `save`, and `save` truncates in place, so a file that momentarily fails to
+/// parse would be overwritten with a bare client_id — a silent sign-out. That is an acceptable
+/// trade on the boot path, which must end up with an id; it is not one on a path a keypress can
+/// reach. Falls back to the pre-relocation path (migration), same as `load`.
+pub fn peek() -> Session {
+    std::fs::read(AUTH_PATH)
+        .ok()
+        .or_else(|| std::fs::read(AUTH_PATH_OLD).ok())
+        .and_then(|b| serde_json::from_slice(&b).ok())
+        .unwrap_or_default()
+}
+
 /// Load the persisted session, ensuring a stable `client_id` exists (generated + saved on first
 /// boot). Never returns an error — a missing/corrupt file degrades to a fresh, logged-out session.
 /// Falls back to the pre-relocation path once and re-saves at the new one (migration).
 pub fn load() -> Session {
-    let mut s: Session = std::fs::read(AUTH_PATH)
-        .ok()
-        .or_else(|| std::fs::read(AUTH_PATH_OLD).ok())
-        .and_then(|b| serde_json::from_slice(&b).ok())
-        .unwrap_or_default();
+    let mut s: Session = peek();
     if s.client_id.is_empty() {
         s.client_id = new_client_id();
         save(&s);
@@ -170,4 +180,63 @@ fn new_client_id() -> String {
         "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
         b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]
     )
+}
+
+// ---- What the account surfaces are allowed to SAY about the user ----
+
+/// The account facts the UI may state — see [`Session::account`]. An account surface must word
+/// itself from THIS, never from [`current`] alone: that profile is a bare `UserRef::default()` —
+/// empty title, empty thumb — for every account **without Plex Home**, because auth's single-user
+/// path enters Home without ever writing one. Reading that emptiness as "signed out" is how a
+/// signed-in owner ends up being offered "Sign in".
+///
+/// Converted so far: `ui/account_menu.rs`. **Not yet: the Home profile chip** (`ui/widgets.rs`
+/// `profile_chip`), which still labels itself off `title.is_empty()` and so still says "Sign in"
+/// to that same owner — the remaining half of the bug, and a one-block change once this lands.
+pub struct Account {
+    /// **This device** holds a session: a plex.tv account token, or at least a server + PMS token
+    /// it can stream on. The opposite of "offer them Sign in". Note it describes the session ON
+    /// DISK, not the identity currently in use: an automated boot on `/tmp/plxnative-token` streams
+    /// on an injected token yet still reports the stored account here — deliberately, because the
+    /// stored account is exactly what a "Sign out" would clear.
+    pub signed_in: bool,
+    /// Profile switching is possible. It needs the **plex.tv account token**: both the Plex Home
+    /// roster and the per-user tokens come from plex.tv, so a server-only session cannot switch
+    /// (`auth::start_switch` refuses one outright). Deliberately NOT gated on the roster length —
+    /// see `home_users`' note on why an empty roster means "unknown", not "there are none".
+    pub can_switch: bool,
+    /// Who we may say the user is: the active managed profile, else the account owner off the
+    /// persisted roster. `None` = signed in but nameless (no roster has ever landed), which is a
+    /// missing name and not a missing user — say "Account", never "Sign in".
+    pub name: Option<String>,
+}
+
+impl Session {
+    /// The account facts for the UI, from the persisted session plus the in-memory active profile
+    /// (`active`, i.e. [`current`]). The profile is the better name once a managed user has been
+    /// picked; the persisted roster's `admin` entry is what names an owner who has no Plex Home
+    /// and therefore never got a profile written at all.
+    ///
+    /// **`home_users` being empty means "unknown", not "none".** It is only ever filled by a
+    /// sign-in or a "Change profile", and a *failed* fetch persists an empty vec
+    /// (`auth.rs`'s `home_users().unwrap_or_default()`), so "never fetched", "fetch failed" and
+    /// "genuinely empty" are one value. Anything deciding on it must treat empty as "ask" — which
+    /// is why [`Account::can_switch`] keeps the switch row: that row is what re-fetches the roster,
+    /// and hiding it on an empty one would be a one-way door out of a Plex Home created later.
+    pub fn account(&self, active: Option<&UserRef>) -> Account {
+        let named = |t: &str| Some(t.to_string()).filter(|t| !t.is_empty());
+        // the roster hop searches for a NAMED admin, then any named entry — a `find(admin)` whose
+        // hit happens to carry an empty title must not swallow the answer sitting behind it, which
+        // is the same shape of bug this whole function exists to fix.
+        let roster = || {
+            let named_admin = self.home_users.iter().find(|u| u.admin && !u.title.is_empty());
+            named_admin.or_else(|| self.home_users.iter().find(|u| !u.title.is_empty())).map(|u| u.title.clone())
+        };
+        let name = active.and_then(|u| named(&u.title)).or_else(|| named(&self.user.title)).or_else(roster);
+        Account {
+            signed_in: !self.account_token.is_empty() || self.can_go_local(),
+            can_switch: !self.account_token.is_empty(),
+            name,
+        }
+    }
 }

--- a/rust-modules/src/ui/account_menu.rs
+++ b/rust-modules/src/ui/account_menu.rs
@@ -1,8 +1,20 @@
 //! The Home **profile menu** — a small popover opened from the top-left profile chip, on the SAME
-//! animated [`TableView`] as the in-player subtitle/audio menu. Two actions: switch Plex Home
-//! profile ("Change profile" → who's-watching) or "Sign out". The menu only reports the chosen
-//! action via [`on_ok`]; `app.rs` performs the routing.
+//! animated [`TableView`] as the in-player subtitle/audio menu. Switch Plex Home profile ("Change
+//! profile" → who's-watching), "Sign out", or "Sign in". The menu only reports the chosen action
+//! via [`on_ok`]; `app.rs` performs the routing.
+//!
+//! **The rows are a function of the account state, and that state is the persisted session** —
+//! `Session::account`, read fresh at each [`open`]. It used to be `session::current().is_some()`,
+//! which is a *sentinel*, not a fact: the single-user (no Plex Home) path leaves the active profile
+//! an empty `UserRef`, so every surface deciding on its emptiness told a signed-in owner they were
+//! signed out — this popover headed itself "Account", and the chip that opens it says "Sign in".
+//!
+//! **The chip is still on the sentinel** (`ui/widgets.rs:117` `profile_chip`, `title.is_empty()`),
+//! so the two surfaces currently disagree on one screen. It is a one-block change — word the label
+//! and the avatar initial from `Session::account(current().as_ref())` inside the generation-keyed
+//! cache — left out of this pass only because that file belongs to another change in flight.
 #![allow(non_upper_case_globals)]
+use crate::plex::session::Account;
 use crate::ui::consts::*;
 use crate::ui::popover::Popover;
 use crate::ui::table::{Row, Section, TableView};
@@ -11,6 +23,7 @@ use std::os::raw::c_int;
 use std::ptr::{addr_of, addr_of_mut};
 
 /// What the highlighted row does on OK.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Action {
     None,
     ChangeProfile,
@@ -18,9 +31,15 @@ pub enum Action {
     SignOut,
 }
 
+/// Header for a session we cannot name — signed in but no roster has landed yet (and the signed-out
+/// case, where naming an account we do not have would be the same lie in reverse).
+const HEADER_FALLBACK: &str = "Account";
+
 static mut POP: Popover = Popover::new(); // shared open/appear choreography
 static mut TABLE: TableView = TableView::new(); // main-thread only
-static mut SIGNED_IN: bool = false; // captured at open() — decides which row set is shown
+/// The ordered rows captured at [`open`] — the ONE place row order lives, so [`on_ok`]'s index
+/// mapping cannot drift from what was actually drawn.
+static mut ROWS: &[Action] = &[];
 
 fn table() -> &'static mut TableView {
     unsafe { &mut *addr_of_mut!(TABLE) }
@@ -33,22 +52,50 @@ pub fn is_open() -> bool {
     unsafe { (*addr_of!(POP)).is_open() }
 }
 
+/// The rows for an account state, in order. Signed out, the only truthful action is signing in;
+/// offering "Change profile" there dead-ends in an empty who's-watching screen. Signed in, "Sign
+/// in" is a lie, so it is never offered — "Change profile" is, whenever plex.tv can serve a roster.
+fn rows_for(acc: &Account) -> &'static [Action] {
+    match (acc.signed_in, acc.can_switch) {
+        (false, _) => &[Action::SignIn],
+        (true, true) => &[Action::ChangeProfile, Action::SignOut],
+        (true, false) => &[Action::SignOut],
+    }
+}
+
+fn label(a: Action) -> &'static str {
+    match a {
+        Action::ChangeProfile => "Change profile",
+        Action::SignIn => "Sign in",
+        Action::SignOut => "Sign out",
+        Action::None => "",
+    }
+}
+
+/// Rows that leave for another screen carry the drill-in chevron; "Sign out" acts in place.
+fn drills_in(a: Action) -> bool {
+    matches!(a, Action::ChangeProfile | Action::SignIn)
+}
+
 pub fn open() {
-    // header = the signed-in profile name (owner with no Plex Home selection → "Account").
-    // Signed out (no session — e.g. the compiled dev token, or after Sign out) the only
-    // meaningful action is signing in; offering "Change profile" there dead-ended in an
-    // empty who's-watching screen.
+    // The persisted session is the file of record — a roster refresh or a sign-out anywhere in the
+    // app lands THERE, and the in-memory profile carries no account state at all — so the menu
+    // re-reads it per open (a few hundred bytes, once per key press) instead of trusting a snapshot.
+    // `peek`, not `load`: a menu opening must never be able to WRITE the session file.
+    let sess = crate::plex::session::peek();
     let cur = crate::plex::session::current();
-    let signed_in = cur.is_some();
-    unsafe { addr_of_mut!(SIGNED_IN).write(signed_in) };
-    let name = cur.map(|u| u.title).filter(|t| !t.is_empty()).unwrap_or_else(|| "Account".to_string());
-    let sec = if signed_in {
-        Section::new(name).row(Row::new("Change profile").chevron(true)).row(Row::new("Sign out"))
-    } else {
-        Section::new(name).row(Row::new("Sign in").chevron(true))
-    };
+    let acc = sess.account(cur.as_ref());
+    let rows = rows_for(&acc);
+    unsafe { addr_of_mut!(ROWS).write(rows) };
+    let mut sec = Section::new(acc.name.unwrap_or_else(|| HEADER_FALLBACK.to_string()));
+    for a in rows {
+        sec = sec.row(Row::new(label(*a)).chevron(drills_in(*a)));
+    }
     table().compact = true; // small one-word action list — BODY labels, not menu-size HEADLINE bold
     table().set_sections(vec![sec], 0, false);
+    // ROWS *is* the index→action map, so it must stay one-to-one with what was built above; a row
+    // appended here and not to `rows_for` is exactly the drift this replaced.
+    debug_assert_eq!(rows.len() as i32, table().n_rows());
     pop().open();
 }
 
@@ -92,17 +139,13 @@ pub fn move_focus(sym: c_int) {
 pub fn on_ok() -> Action {
     let sel = table().sel;
     close();
-    if !unsafe { addr_of!(SIGNED_IN).read() } {
-        return match sel {
-            0 => Action::SignIn,
-            _ => Action::None,
-        };
-    }
-    match sel {
-        0 => Action::ChangeProfile,
-        1 => Action::SignOut,
-        _ => Action::None,
-    }
+    action_at(unsafe { addr_of!(ROWS).read() }, sel)
+}
+
+/// The row list IS the mapping — a selection outside it (an empty menu, a stale index) is `None`
+/// rather than whatever action happens to sit at that position in the other row set.
+fn action_at(rows: &[Action], sel: i32) -> Action {
+    usize::try_from(sel).ok().and_then(|i| rows.get(i)).copied().unwrap_or(Action::None)
 }
 
 /// Top-left popover, tucked under the profile chip.
@@ -132,4 +175,143 @@ pub fn draw() {
     let r = panel_rect();
     p.rect(r, 24.0, theme::PANEL_TOP, theme::PANEL_BOT, 0.0);
     table().draw(p, r);
+}
+
+/// The (account state → header + rows) table, which is the whole of this bug: the words the menu
+/// says about the user, and the actions it maps them to.
+///
+/// All but one drive the pure functions — `Session::account`, [`rows_for`], [`action_at`] —
+/// with sessions built in the test, so they touch no global and need no lock; the seventh drives
+/// the live `session::set_current` and takes `crate::testlock::serial()` for its whole body.
+/// `open()` itself is not exercised: it owns `static mut TABLE`/`POP` (main-thread-only,
+/// deliberately not `Sync`), so it is unrunnable under a parallel harness. Keeping the mapping in
+/// pure functions is what makes the interesting half testable at all.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plex::session::{HomeUserRef, ServerRef, Session, UserRef};
+
+    fn owner(title: &str) -> HomeUserRef {
+        HomeUserRef { title: title.to_string(), admin: true, ..Default::default() }
+    }
+    fn managed(title: &str) -> HomeUserRef {
+        HomeUserRef { title: title.to_string(), ..Default::default() }
+    }
+    /// A session that can reach its server, i.e. one the app actually boots into Home on.
+    fn local(mut s: Session) -> Session {
+        s.server = ServerRef { address: "192.168.0.10".into(), port: 32400, token: "srv".into(), ..Default::default() };
+        s
+    }
+    fn menu(s: &Session, active: Option<&UserRef>) -> (String, Vec<&'static str>) {
+        let acc = s.account(active);
+        let rows = rows_for(&acc);
+        (acc.name.unwrap_or_else(|| HEADER_FALLBACK.to_string()), rows.iter().map(|a| label(*a)).collect())
+    }
+
+    /// No session at all: the one honest action is signing in.
+    #[test]
+    fn signed_out_offers_only_sign_in() {
+        let (name, rows) = menu(&Session::default(), None);
+        assert_eq!(name, "Account");
+        assert_eq!(rows, vec!["Sign in"]);
+    }
+
+    /// THE BUG: a signed-in account with no Plex Home never gets a profile written, so the active
+    /// UserRef is empty — which must read as "signed in, unnamed roster entry aside", never as
+    /// "signed out". The roster's admin entry is what names it.
+    #[test]
+    fn signed_in_without_plex_home_is_named_and_never_offered_sign_in() {
+        let s = local(Session { account_token: "acct".into(), home_users: vec![owner("Gleb")], ..Default::default() });
+        let (name, rows) = menu(&s, Some(&UserRef::default()));
+        assert_eq!(name, "Gleb");
+        assert_eq!(rows, vec!["Change profile", "Sign out"]);
+    }
+
+    /// A picked managed profile names the header even though the roster also could.
+    #[test]
+    fn active_profile_outranks_the_roster_owner() {
+        let s = local(Session {
+            account_token: "acct".into(),
+            home_users: vec![owner("Gleb"), managed("Kid")],
+            ..Default::default()
+        });
+        let active = UserRef { title: "Kid".into(), ..Default::default() };
+        let (name, rows) = menu(&s, Some(&active));
+        assert_eq!(name, "Kid");
+        assert_eq!(rows, vec!["Change profile", "Sign out"]);
+    }
+
+    /// The roster hop looks for a NAMED entry, admin first: an admin tile that happens to carry an
+    /// empty title must not swallow the name sitting behind it (find-then-filter, the very shape of
+    /// bug this change exists to remove).
+    #[test]
+    fn an_unnamed_admin_does_not_hide_a_named_roster_entry() {
+        let s = local(Session {
+            account_token: "acct".into(),
+            home_users: vec![owner(""), managed("Kid")],
+            ..Default::default()
+        });
+        assert_eq!(menu(&s, Some(&UserRef::default())).0, "Kid");
+    }
+
+    /// An empty roster is UNKNOWN, not "no profiles" (a failed fetch persists an empty vec), so the
+    /// row that re-fetches it stays — hiding it would strand a Plex Home created later.
+    #[test]
+    fn unknown_roster_keeps_the_switch_row_and_says_account() {
+        let s = local(Session { account_token: "acct".into(), ..Default::default() });
+        let (name, rows) = menu(&s, Some(&UserRef::default()));
+        assert_eq!(name, "Account");
+        assert_eq!(rows, vec!["Change profile", "Sign out"]);
+    }
+
+    /// A server-only session (no plex.tv token) is still signed IN — it is streaming — but cannot
+    /// switch profiles, because the roster and per-user tokens both come from plex.tv. Only a
+    /// legacy/hand-written auth.json reaches this today (`login_thread` stores the account token
+    /// before discovery), which is exactly why it is pinned rather than assumed away.
+    #[test]
+    fn server_only_session_can_sign_out_but_not_switch() {
+        let s = local(Session { user: UserRef { title: "Gleb".into(), ..Default::default() }, ..Default::default() });
+        let (name, rows) = menu(&s, None);
+        assert_eq!(name, "Gleb");
+        assert_eq!(rows, vec!["Sign out"]);
+    }
+
+    /// The seam `open()` actually uses: the crate-global active profile really does reach the
+    /// header, and clearing it (sign-out) really does fall back through the persisted session.
+    /// Takes `testlock::serial()` for the whole test — `set_current`/`current` are process-global.
+    #[test]
+    fn the_live_profile_global_feeds_the_header() {
+        let _serial = crate::testlock::serial();
+        let restore = crate::plex::session::current();
+        let s = local(Session {
+            account_token: "acct".into(),
+            home_users: vec![owner("Gleb"), managed("Kid")],
+            ..Default::default()
+        });
+        crate::plex::session::set_current(Some(UserRef { title: "Kid".into(), ..Default::default() }));
+        let picked = menu(&s, crate::plex::session::current().as_ref()).0;
+        crate::plex::session::set_current(None);
+        let cleared = menu(&s, crate::plex::session::current().as_ref()).0;
+        crate::plex::session::set_current(restore); // BEFORE the asserts: a failure must not leak
+        assert_eq!(picked, "Kid");
+        assert_eq!(cleared, "Gleb");
+    }
+
+    /// Every row set maps position → action by the list it drew, and anything off the end is None
+    /// (not the other set's action at that index, which is exactly what the old fixed 0/1 map did).
+    #[test]
+    fn selection_maps_by_the_drawn_row_list() {
+        let signed_out = rows_for(&Session::default().account(None));
+        assert_eq!(action_at(signed_out, 0), Action::SignIn);
+        assert_eq!(action_at(signed_out, 1), Action::None);
+        let s = local(Session { account_token: "acct".into(), ..Default::default() });
+        let full = rows_for(&s.account(None));
+        assert_eq!(action_at(full, 0), Action::ChangeProfile);
+        assert_eq!(action_at(full, 1), Action::SignOut);
+        assert_eq!(action_at(full, 2), Action::None);
+        assert_eq!(action_at(full, -1), Action::None);
+        let no_switch = rows_for(&local(Session::default()).account(None));
+        assert_eq!(action_at(no_switch, 0), Action::SignOut);
+        assert_eq!(action_at(no_switch, 1), Action::None);
+    }
 }


### PR DESCRIPTION
Parity-gap unit 15 — the `account` appendix entry *"A signed-in account without Plex Home managed
users is labelled 'Sign in'"* (`docs/parity-gaps.md:936`).

## The bug

The top-left account popover decided everything it said from `plex::session::current().is_some()`.
That is a **sentinel, not a fact**: `auth.rs`'s single-user path (the `users.len() > 1` else-branch,
auth.rs:341-348) enters Home without ever writing a profile, so an account **without Plex Home** is
`Some(UserRef::default())` — empty title, empty thumb. Every surface that reads that emptiness tells a
signed-in user they are signed out: this popover heads itself "Account", and the chip that opens it
(`ui/widgets.rs:131`) says "Sign in". And when `current()` genuinely *is* `None` while a session sits on
disk (the `/tmp/plxnative-token` boot never calls `set_current`), the popover offered "Sign in" to a
user who is signed in and streaming.

## The fix

`Session::account(active) -> Account { signed_in, can_switch, name }` (plex/session.rs, appended) is now
the single definition of what an account surface may say, derived from the **persisted session** — the
file of record — plus the in-memory profile:

- **`signed_in`** — a plex.tv account token, or at least a server + PMS token it can stream on.
- **`can_switch`** — switching needs the plex.tv token specifically (the roster and the per-user tokens
  both come from plex.tv); it mirrors `auth::start_switch`'s own guard, which refuses a server-only
  session outright.
- **`name`** — active managed profile → persisted profile → the roster's *named* `admin` entry. That
  last hop is what names an owner with no Plex Home, and it works for sessions **already on disk**,
  which seeding `session.user` at sign-in (the audit's suggested cure) would not.

The popover's rows follow from that state, and the ordered row list is itself the index→action map, so
`on_ok` cannot drift from what was drawn (it used to be a fixed 0/1 match against a captured
`SIGNED_IN` bool); a `debug_assert` pins `ROWS.len() == table().n_rows()`.

`open()` reads via a new `session::peek()` rather than `load()`. `load()` mints and **saves** a
client_id whenever the read *or the parse* fails, and `save()` truncates in place — so a file that
momentarily failed to parse would come back as a bare client_id, i.e. a silent sign-out. Acceptable on
the boot path, which must end up with an id; not on a path a keypress can reach.

## The ambiguity, called out rather than papered over

**`session.home_users` being empty means "unknown", not "none".** It is only ever filled by a sign-in or
a "Change profile", and a *failed* fetch persists an empty vec (auth.rs:327,
`home_users().unwrap_or_default()`), so "never fetched", "fetch failed" and "genuinely empty" are one
value. So `can_switch` is deliberately **not** gated on roster length: hiding "Change profile" for a
1-entry roster would be a one-way door — that row is the only thing that re-fetches the roster, so a
Plex Home created later would be unreachable without signing out. Documented at the field.

Second honest limit, also documented at the field: `signed_in` describes the session **on disk**, not
the identity in use. An automated `/tmp/plxnative-token` boot streams on an injected token yet still
reports the stored account — deliberate, since the stored account is exactly what "Sign out" clears —
but it does mean a dev boot now shows "Sign out" where it used to show a no-op "Sign in".

## Still lying: the profile chip (deliberately not touched)

`ui/widgets.rs:117-186` (`profile_chip`) has the identical root cause and still labels itself from
`title.is_empty()`, so the chip and the popover it opens now disagree on one screen. I was asked to keep
edits outside `ui/account_menu.rs` purely additive because siblings are editing this crate, and that
file is not mine. Both doc comments say so, and the patch is one block inside the existing
generation-keyed cache:

```rust
// ui/widgets.rs, inside the `chip.as_ref().map(|c| c.0 != gen)` block
let cur = crate::plex::session::current();
let acc = crate::plex::session::peek().account(cur.as_ref());
let initial = acc.name.as_deref().and_then(|t| t.chars().next())
    .map(|c| c.to_uppercase().to_string()).unwrap_or_default();
let label = acc.name.clone()
    .unwrap_or_else(|| if acc.signed_in { "Account".into() } else { "Sign in".into() });
```

## Verification

- `make check` — **66 host tests pass** (+8: the state→(header, rows) table, the roster fallback, the
  index→action map, and one over the live `set_current` global under `testlock::serial()`).
- `make` — ARM cross-build clean (the same 5 pre-existing warnings, none in these files).
- Device: see the comment below.
- Reviewed by a second agent; six findings, all addressed except the chip (above), which is recorded in
  code instead.
