### PR TITLE
route: retain the play queue's rows as a lean projection

### DIFF
--- a/rust-modules/src/plex/mod.rs
+++ b/rust-modules/src/plex/mod.rs
@@ -37,5 +37,10 @@ pub use client::{client, client_opt, install, Client, StreamUrl};
 pub use models::*;
 #[allow(unused_imports)]
 pub use params::*;
+// The projected play-queue row + the identity rule that locates one: op-file items rather than
+// wire DTOs, so they are re-exported by name (route.rs names the row in `Plan`/`QueueInfo` — the
+// rest of `timeline` is reached through `Client`'s methods and needs none).
+#[allow(unused_imports)]
+pub use timeline::{queue_index_of, QueueRow};
 #[allow(unused_imports)]
 pub use transcoder::is_dp_audio;

--- a/rust-modules/src/plex/timeline.rs
+++ b/rust-modules/src/plex/timeline.rs
@@ -48,6 +48,10 @@ impl Client {
     /// `Media[0].Part[0].key` + codecs — everything `route::request_play` needs). The Up Next control
     /// screen is therefore free: it reads [`PlayQueueResult::next`] from the queue this playback
     /// already had to create, instead of asking the server what plays next.
+    ///
+    /// The WHOLE window is kept, as [`QueueRow`]s — the queue this round trip already paid for is
+    /// the queue a list can draw and jump around in, and throwing it away meant re-asking the
+    /// server for something it had already sent.
     pub fn create_play_queue(&self, machine_id: &str, rating_key: &str, session: &str) -> Option<PlayQueueResult> {
         let uri = format!("server://{machine_id}/com.plexapp.plugins.library/library/metadata/{rating_key}");
         let q = QueryBuilder::new("/playQueues")
@@ -58,50 +62,117 @@ impl Client {
             .int("repeat", 0)
             .str("X-Plex-Session-Identifier", session);
         let q = self.playback_identity(q);
-        let mut mc = self.post_json(&q.build())?;
-        // Remaining AFTER the item being played, from the whole-queue counters (the returned
-        // `Metadata[]` can be a window). Clamped: a server that omits either counter must read as
-        // "nothing after this", not as a negative count the UI would then format.
-        let remaining = (mc.play_queue_total_count - mc.play_queue_selected_item_offset - 1).max(0);
-        let selected = mc.play_queue_selected_item_id;
-        let next = next_after(&mut mc.metadata, selected, rating_key);
-        Some(PlayQueueResult { id: mc.play_queue_id, selected_item_id: selected, remaining, next })
+        Some(PlayQueueResult::of(self.post_json(&q.build())?, rating_key))
     }
 }
 
-/// The queue row that follows the selected one — pulled OUT of the item list rather than cloned,
-/// because a `Metadata` row carries the whole Media/Part/Stream/Role tree and this runs on the
-/// resolve worker on a 32-bit TV.
+/// One retained row of the play queue: everything a queue list draws, plus everything
+/// [`crate::route::request_play`] needs to START that row — and nothing else.
+///
+/// The projection is the whole point. A `Metadata` row carries the entire Media/Part/Stream/Role
+/// tree, this runs on the resolve worker of a 32-bit TV, and a `continuous=1` queue can be a whole
+/// show — so the rows are retained ONLY in this shape. Field names mirror `route::UpNext` (which
+/// is built from one of these) rather than the wire: `dur_ms` is `duration`, `resume_ms` is
+/// `viewOffset`, `part`/`vcodec`/`acodec` come from `Media[0]`/`Media[0].Part[0]` exactly as the
+/// single-successor projection always did.
+///
+/// NOT episode-gated: a queue row may be a movie, and the list must be able to show it. The
+/// "episodes only" rule belongs to the one-item Up Next control, not to the queue.
+#[derive(Clone, Default)]
+pub struct QueueRow {
+    /// `playQueueItemID` — identity WITHIN the queue. A ratingKey can repeat in a queue (the same
+    /// item queued twice), a playQueueItemID cannot, so every lookup keys off this. 0 = a server
+    /// that omitted the field.
+    pub item_id: i64,
+    pub rk: String,
+    /// `type` — movie | episode | clip …
+    pub kind: String,
+    /// the item's own title (the episode title for an episode)
+    pub title: String,
+    /// `grandparentTitle` — the show, empty for a movie
+    pub show_title: String,
+    /// `parentIndex` — season number (0 for a movie)
+    pub season: i64,
+    pub index: i64,
+    pub thumb: String,
+    pub dur_ms: i64,
+    /// `viewOffset` — the resume point, 0 = unwatched/from the start
+    pub resume_ms: i64,
+    /// `Media[0].Part[0].key` — the direct-play part
+    pub part: String,
+    pub vcodec: String,
+    pub acodec: String,
+}
+
+impl QueueRow {
+    /// Consume a queue `Metadata` row into its lean projection. BY VALUE: the strings are moved,
+    /// not cloned, and the rest of the row's tree is dropped as this returns.
+    fn of(m: super::models::Metadata) -> QueueRow {
+        // `Media[0]` / `Media[0].Part[0]`, the same pick `Metadata::first_part` makes — by value,
+        // so the other versions and their Stream lists die here.
+        let (vcodec, acodec, part) = match m.media.into_iter().next() {
+            Some(md) => (
+                md.video_codec,
+                md.audio_codec,
+                md.part.into_iter().next().map(|p| p.key).unwrap_or_default(),
+            ),
+            None => (String::new(), String::new(), String::new()),
+        };
+        QueueRow {
+            item_id: m.play_queue_item_id,
+            rk: m.rating_key,
+            kind: m.kind,
+            title: m.title,
+            show_title: m.grandparent_title,
+            season: m.parent_index,
+            index: m.index,
+            thumb: m.thumb,
+            dur_ms: m.duration,
+            resume_ms: m.view_offset,
+            part,
+            vcodec,
+            acodec,
+        }
+    }
+}
+
+/// Where a row sits in the queue — THE identity rule, in one place, because everything that
+/// points at a queue row needs the same answer (the successor lookup below, and whatever draws
+/// "you are here" in a queue list).
 ///
 /// Identity is `playQueueItemID`, not `ratingKey`: a queue may legitimately hold the same item
-/// twice, and matching on the rating key would then pick the wrong successor. The rating key is
-/// only the fallback for a server that omitted the per-row id — for a queue built FROM this item
-/// the two agree, and losing Up Next entirely is the worse failure.
-fn next_after(
-    items: &mut Vec<super::models::Metadata>,
-    selected_item_id: i64,
-    rating_key: &str,
-) -> Option<super::models::Metadata> {
-    let by_id = (selected_item_id != 0)
-        .then(|| items.iter().position(|m| m.play_queue_item_id == selected_item_id))
-        .flatten();
-    let at = by_id.or_else(|| items.iter().position(|m| m.rating_key == rating_key))?;
-    // `drain` on an empty trailing range is legal and yields None, which is the same answer a
-    // bounds check would produce — so there is no bounds check.
-    items.drain(at + 1..).next()
+/// twice, and matching on the rating key would then pick the wrong row. The rating key is only the
+/// fallback for a server that omitted the per-row id — for a queue built FROM this item the two
+/// agree, and losing the row entirely is the worse failure.
+pub fn queue_index_of(items: &[QueueRow], item_id: i64, rating_key: &str) -> Option<usize> {
+    let by_id = (item_id != 0).then(|| items.iter().position(|r| r.item_id == item_id)).flatten();
+    by_id.or_else(|| items.iter().position(|r| r.rk == rating_key))
+}
+
+/// The queue row that follows the selected one — None at the end of the queue, and None when the
+/// selection matches no row at all (handing back `items[1]` there would start something the user
+/// was never watching).
+fn next_after<'a>(items: &'a [QueueRow], selected_item_id: i64, rating_key: &str) -> Option<&'a QueueRow> {
+    items.get(queue_index_of(items, selected_item_id, rating_key)? + 1)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plex::models::Metadata;
+    use crate::plex::models::Envelope;
 
     /// one queue row: (playQueueItemID, ratingKey)
-    fn row(item_id: i64, rk: &str) -> Metadata {
-        Metadata { play_queue_item_id: item_id, rating_key: rk.to_string(), ..Default::default() }
+    fn row(item_id: i64, rk: &str) -> QueueRow {
+        QueueRow { item_id, rk: rk.to_string(), ..Default::default() }
     }
-    fn rks(items: &[Metadata]) -> Vec<&str> {
-        items.iter().map(|m| m.rating_key.as_str()).collect()
+    fn rks(items: &[QueueRow]) -> Vec<&str> {
+        items.iter().map(|r| r.rk.as_str()).collect()
+    }
+    /// A response body through the SHIPPED mapping — the same call `create_play_queue` makes once
+    /// its POST returns, so these tests cannot pass on a projection the app does not use.
+    fn result(body: &str, rating_key: &str) -> PlayQueueResult {
+        let mc = serde_json::from_str::<Envelope>(body).expect("a PMS body parses").media_container;
+        PlayQueueResult::of(mc, rating_key)
     }
 
     /// The whole up-next extraction. Every case here is one the live server actually produces:
@@ -110,44 +181,116 @@ mod tests {
     /// `continuous=1` queue is just itself.
     #[test]
     fn the_successor_is_the_row_after_the_selected_one() {
-        let mut q = vec![row(13083, "1804"), row(13084, "1805"), row(13085, "1806")];
-        let next = next_after(&mut q, 13083, "1804").expect("a mid-queue item has a successor");
-        assert_eq!(next.rating_key, "1805");
-        assert_eq!(rks(&q), ["1804"], "the rows after the successor are dropped with it");
+        let q = vec![row(13083, "1804"), row(13084, "1805"), row(13085, "1806")];
+        let next = next_after(&q, 13083, "1804").expect("a mid-queue item has a successor");
+        assert_eq!(next.rk, "1805");
 
         // a queue of one — the season finale / movie case
-        let mut solo = vec![row(13092, "774")];
-        assert!(next_after(&mut solo, 13092, "774").is_none());
+        let solo = vec![row(13092, "774")];
+        assert!(next_after(&solo, 13092, "774").is_none());
         // ...and the LAST row of a longer queue is the same thing
-        let mut q = vec![row(1, "a"), row(2, "b")];
-        assert!(next_after(&mut q, 2, "b").is_none());
+        let q = vec![row(1, "a"), row(2, "b")];
+        assert!(next_after(&q, 2, "b").is_none());
     }
 
     #[test]
     fn the_selected_row_is_found_by_queue_item_id_not_rating_key() {
         // A queue holding the same episode twice: matching on the ratingKey would pick the FIRST
         // occurrence and hand back its successor, which is the wrong episode.
-        let mut q = vec![row(1, "dup"), row(2, "mid"), row(3, "dup"), row(4, "after")];
-        let next = next_after(&mut q, 3, "dup").expect("the second occurrence has a successor");
-        assert_eq!(next.rating_key, "after");
+        let q = vec![row(1, "dup"), row(2, "mid"), row(3, "dup"), row(4, "after")];
+        let next = next_after(&q, 3, "dup").expect("the second occurrence has a successor");
+        assert_eq!(next.rk, "after");
     }
 
     #[test]
     fn a_missing_queue_item_id_falls_back_to_the_rating_key() {
         // Rows with no playQueueItemID (0) — the successor must still be found, or the feature
         // silently disappears on a server that trims the field.
-        let mut q = vec![row(0, "1804"), row(0, "1805")];
-        let next = next_after(&mut q, 0, "1804").expect("the rating key is the fallback identity");
-        assert_eq!(next.rating_key, "1805");
+        let q = vec![row(0, "1804"), row(0, "1805")];
+        let next = next_after(&q, 0, "1804").expect("the rating key is the fallback identity");
+        assert_eq!(next.rk, "1805");
     }
 
     #[test]
     fn an_unrecognised_selection_yields_nothing_rather_than_the_first_row() {
         // Neither identity matches: returning `items[0]`'s successor here would start an episode
         // the user was never watching.
-        let mut q = vec![row(1, "a"), row(2, "b")];
-        assert!(next_after(&mut q, 99, "zzz").is_none());
-        assert!(next_after(&mut Vec::new(), 1, "a").is_none(), "an empty queue is not a panic");
+        let q = vec![row(1, "a"), row(2, "b")];
+        assert!(next_after(&q, 99, "zzz").is_none());
+        assert!(next_after(&[], 1, "a").is_none(), "an empty queue is not a panic");
+    }
+
+    /// A real `continuous=1` response — three episodes, the first selected — through the shipped
+    /// mapping. Shapes that are here on purpose: PMS string-encodes some numbers (`duration`,
+    /// `viewOffset`) and not others, an episode can carry MULTIPLE `Media[]` versions (4K + 1080p
+    /// — the projection takes `[0]`, the same pick the single-successor code always made), and the
+    /// rows carry the Stream/Role tree that the lean row has nowhere to put.
+    #[test]
+    fn a_real_playqueue_body_keeps_every_row_as_a_lean_projection() {
+        let q = result(
+            r#"{"MediaContainer":{"size":3,"playQueueID":40213,"playQueueSelectedItemID":13083,
+              "playQueueSelectedItemOffset":0,"playQueueTotalCount":3,"Metadata":[
+              {"playQueueItemID":13083,"ratingKey":"1804","type":"episode","title":"Pilot",
+               "grandparentTitle":"The Morning Show","parentIndex":1,"index":1,
+               "thumb":"/library/metadata/1804/thumb/1781586780","duration":"3273248",
+               "viewOffset":"142000","Role":[{"tag":"Jennifer Aniston"}],
+               "Media":[{"videoCodec":"hevc","audioCodec":"eac3",
+                 "Part":[{"id":3130,"key":"/library/parts/3130/1781467224/file.mkv",
+                   "Stream":[{"id":1,"streamType":1},{"id":2,"streamType":2}]}]},
+                {"videoCodec":"h264","audioCodec":"aac",
+                 "Part":[{"id":3134,"key":"/library/parts/3134/1781468203/file.mkv"}]}]},
+              {"playQueueItemID":13084,"ratingKey":"1805","type":"episode","title":"A Seat at the Table",
+               "grandparentTitle":"The Morning Show","parentIndex":1,"index":2,"duration":3120000,
+               "Media":[{"videoCodec":"h264","audioCodec":"ac3",
+                 "Part":[{"key":"/library/parts/3140/1781467999/file.mkv"}]}]},
+              {"playQueueItemID":13085,"ratingKey":"1806","type":"episode","title":"Chaos Is the New Cocaine",
+               "grandparentTitle":"The Morning Show","parentIndex":1,"index":3,
+               "Media":[{"videoCodec":"h264","audioCodec":"ac3","Part":[{"key":"/p/3.mkv"}]}]}]}}"#,
+            "1804",
+        );
+        assert_eq!(rks(&q.items), ["1804", "1805", "1806"], "the WHOLE window is retained, not just the successor");
+        assert_eq!((q.id, q.selected_item_id, q.remaining), (40213, 13083, 2), "the ids and the count still land");
+
+        let first = &q.items[0];
+        assert_eq!(first.item_id, 13083);
+        assert_eq!(first.kind, "episode");
+        assert_eq!(first.title, "Pilot");
+        assert_eq!(first.show_title, "The Morning Show");
+        assert_eq!((first.season, first.index), (1, 1));
+        assert_eq!(first.thumb, "/library/metadata/1804/thumb/1781586780");
+        assert_eq!((first.dur_ms, first.resume_ms), (3273248, 142000), "string-encoded numbers still land");
+        assert_eq!(first.part, "/library/parts/3130/1781467224/file.mkv", "Media[0].Part[0].key");
+        assert_eq!((first.vcodec.as_str(), first.acodec.as_str()), ("hevc", "eac3"), "Media[0], not the 1080p version");
+
+        // the successor is exactly what it was when it was the only thing kept — and it is the
+        // retained row after the selected one, not a separately-derived answer
+        let next = q.next.as_ref().expect("the selected row has a successor");
+        assert_eq!((next.rk.as_str(), next.index), ("1805", 2));
+        assert_eq!(next.part, "/library/parts/3140/1781467999/file.mkv", "the successor is start-able");
+        assert_eq!(next.dur_ms, 3120000, "…and a plain JSON number lands too");
+        let at = queue_index_of(&q.items, q.selected_item_id, "1804").expect("the playing row is locatable");
+        assert_eq!((at, q.items[at + 1].rk.as_str()), (0, next.rk.as_str()), "next IS items[selected+1]");
+    }
+
+    /// Two rows the LIST must survive that the one-item Up Next control would have refused: a
+    /// movie (a `continuous=1` movie queue is just itself — the list still has to be able to draw
+    /// it) and a row with no `Media` at all, which must project to empty strings, not a panic.
+    #[test]
+    fn a_movie_row_and_a_media_less_row_both_project() {
+        let q = result(
+            r#"{"MediaContainer":{"playQueueSelectedItemID":900,"Metadata":[
+              {"playQueueItemID":900,"ratingKey":"774","type":"movie","title":"Sinners",
+               "Media":[{"videoCodec":"hevc","audioCodec":"truehd","Part":[{"key":"/p/774.mkv"}]}]},
+              {"playQueueItemID":901,"ratingKey":"775","type":"movie","title":"No Media Here"}]}}"#,
+            "774",
+        );
+        let items = &q.items;
+        assert_eq!(items[0].kind, "movie", "the projection is NOT episode-gated");
+        assert_eq!(items[0].show_title, "", "a movie has no grandparentTitle");
+        assert_eq!(items[0].part, "/p/774.mkv");
+        let bare = &items[1];
+        assert_eq!((bare.part.as_str(), bare.vcodec.as_str(), bare.acodec.as_str()), ("", "", ""));
+        assert_eq!(bare.rk, "775", "the rest of the row still projects");
     }
 }
 
@@ -159,7 +302,32 @@ pub struct PlayQueueResult {
     pub selected_item_id: i64,
     /// items queued AFTER the one now playing (0 = this is the last)
     pub remaining: i64,
+    /// The returned window of the queue, projected — the row now playing INCLUDED, in queue order,
+    /// so a list can show where playback sits. Its length may DIFFER from `remaining + 1` in both
+    /// directions: the window can be a slice of a long queue, and it also carries the rows BEFORE
+    /// the selected one when `playQueueSelectedItemOffset > 0`. `playQueueTotalCount` is the whole
+    /// queue; this is what the server actually sent.
+    pub items: Vec<QueueRow>,
     /// the item that plays next, or None at the end of the queue (and for a movie, whose
-    /// continuous queue is just itself — verified live: total count 1)
-    pub next: Option<super::models::Metadata>,
+    /// continuous queue is just itself — verified live: total count 1). A copy of the `items` row
+    /// after the selected one; one lean row is worth not making every caller redo the lookup.
+    pub next: Option<QueueRow>,
+}
+
+impl PlayQueueResult {
+    /// The WHOLE response→result mapping, kept out of `create_play_queue` so the host tests grade
+    /// the code that ships instead of a copy of it (only the request build is left up there).
+    fn of(mc: super::models::MediaContainer, rating_key: &str) -> PlayQueueResult {
+        // Remaining AFTER the item being played, from the whole-queue counters (the returned
+        // `Metadata[]` can be a window). Clamped: a server that omits either counter must read as
+        // "nothing after this", not as a negative count the UI would then format.
+        let remaining = (mc.play_queue_total_count - mc.play_queue_selected_item_offset - 1).max(0);
+        let selected = mc.play_queue_selected_item_id;
+        // Project BY VALUE: every `Metadata` row is consumed into a `QueueRow` and its
+        // Media/Part/Stream/Role tree dropped right here, on the worker. What the main thread then
+        // holds for the length of the playback is a dozen scalars and strings per row.
+        let items: Vec<QueueRow> = mc.metadata.into_iter().map(QueueRow::of).collect();
+        let next = next_after(&items, selected, rating_key).cloned();
+        PlayQueueResult { id: mc.play_queue_id, selected_item_id: selected, remaining, items, next }
+    }
 }

--- a/rust-modules/src/route.rs
+++ b/rust-modules/src/route.rs
@@ -384,11 +384,22 @@ struct QueueInfo {
     id: String,
     item_id: String,
     up_next: Option<UpNext>,
+    rows: Vec<crate::plex::QueueRow>,
 }
 
 /// The next episode of the item now playing, or None (a movie, the last episode, or a queue that
 /// failed). Installed by `apply_plan`; `request_play` retires it the moment a new item resolves.
 static mut UP_NEXT: Option<UpNext> = None;
+
+/// The whole queue behind the item now playing — the playing row included, in queue order,
+/// projected to `plex::QueueRow` ON THE RESOLVE WORKER (a `Metadata` row carries its entire
+/// Media/Part/Stream/Role tree; a show's queue is dozens of them, and this device is 32-bit).
+/// Same lifecycle as `UP_NEXT`: installed by `apply_plan`, retired by `request_play`.
+///
+/// Whatever the server sent is kept, uncapped — a projected row is ~300 bytes on this device, so
+/// even a whole show is tens of KB. The capping that matters is the DRAWING (a still per row is a
+/// GL texture); that belongs to the overlay, and `apply_plan` deliberately warms only `up_next`'s.
+static mut QUEUE: Vec<crate::plex::QueueRow> = Vec::new();
 
 /// The queued next episode. Main-thread only, and — like `metadata::playing()` — it hands out a
 /// `&'static` the Up Next control reads across a frame, so `apply_plan` (main thread) staying its
@@ -398,25 +409,42 @@ pub(crate) fn up_next() -> Option<&'static UpNext> {
     unsafe { (*addr_of!(UP_NEXT)).as_ref() }
 }
 
+/// The current playback's queue rows, in queue order, the row now playing among them — locate it
+/// with `plex::queue_index_of(rows, PQ_ITEM_ID.parse().unwrap_or(0), &cur_rk())`, which is the ONE
+/// implementation of the identity rule (item id, rating key as the fallback). Empty until a plan
+/// lands, and whenever the queue POST failed.
+///
+/// MAIN THREAD ONLY. Unlike [`up_next`] this lends the rows to a closure instead of handing out a
+/// `&'static`, and that is deliberate: `request_play` FREES this Vec as its first act, so a
+/// borrowed row used to start playback would be read after free — exactly the aliasing bug
+/// `request_play_up_next`'s by-value signature exists to make unrepresentable. A caller that wants
+/// to keep a row past the call clones it out (`with_queue(|q| q.get(i).cloned())`); the borrow
+/// checker cannot police a `&'static`, but it does police this.
+#[allow(dead_code)] // nothing reads the rows yet — the queue overlay that draws them is its own batch
+pub(crate) fn with_queue<R>(f: impl FnOnce(&[crate::plex::QueueRow]) -> R) -> R {
+    f(unsafe { &*addr_of!(QUEUE) })
+}
+
 /// Build the Up Next descriptor from a queue row. Episodes only: `continuous=1` on a movie
 /// returns just the movie itself (verified live — total count 1), and "up next" is a show idea.
-fn up_next_of(m: &crate::plex::Metadata) -> Option<UpNext> {
-    if m.kind != "episode" || m.rating_key.is_empty() {
+/// The gate belongs HERE, on the one-item control — the retained row list is deliberately not
+/// episode-gated, because a queue list has to be able to show whatever the queue holds.
+fn up_next_of(r: &crate::plex::QueueRow) -> Option<UpNext> {
+    if r.kind != "episode" || r.rk.is_empty() {
         return None;
     }
-    let media0 = m.media.first();
     Some(UpNext {
-        rk: m.rating_key.clone(),
-        part: m.first_part().map(|p| p.key.clone()).unwrap_or_default(),
-        vcodec: media0.map(|x| x.video_codec.clone()).unwrap_or_default(),
-        acodec: media0.map(|x| x.audio_codec.clone()).unwrap_or_default(),
-        show_title: m.grandparent_title.clone(),
-        ep_title: m.title.clone(),
-        season: m.parent_index,
-        index: m.index,
-        thumb: m.thumb.clone(),
-        dur_ms: m.duration,
-        resume_ms: m.view_offset,
+        rk: r.rk.clone(),
+        part: r.part.clone(),
+        vcodec: r.vcodec.clone(),
+        acodec: r.acodec.clone(),
+        show_title: r.show_title.clone(),
+        ep_title: r.title.clone(),
+        season: r.season,
+        index: r.index,
+        thumb: r.thumb.clone(),
+        dur_ms: r.dur_ms,
+        resume_ms: r.resume_ms,
     })
 }
 
@@ -440,8 +468,8 @@ fn resolve_playqueue(rk: &str, session: &str, cached: &str) -> QueueInfo {
         Some(q) => {
             let up_next = q.next.as_ref().and_then(up_next_of);
             crate::player::log(&format!(
-                "playqueue: id={} item={} remaining={} next={}",
-                q.id, q.selected_item_id, q.remaining,
+                "playqueue: id={} item={} remaining={} rows={} next={}",
+                q.id, q.selected_item_id, q.remaining, q.items.len(),
                 up_next.as_ref().map(|u| format!("S{}E{} {}", u.season, u.index, u.rk))
                     .unwrap_or_else(|| "-".into())
             ));
@@ -450,6 +478,7 @@ fn resolve_playqueue(rk: &str, session: &str, cached: &str) -> QueueInfo {
                 id: if q.id > 0 { q.id.to_string() } else { String::new() },
                 item_id: if q.selected_item_id > 0 { q.selected_item_id.to_string() } else { String::new() },
                 up_next,
+                rows: q.items,
             }
         }
         None => {
@@ -510,6 +539,8 @@ pub(crate) struct Plan {
     pub playing: Option<crate::metadata::PlayingItem>,
     /// the episode queued after this one, straight off the `continuous=1` PlayQueue
     pub up_next: Option<UpNext>,
+    /// that same PlayQueue's whole returned window, projected on the worker (see `QUEUE`)
+    pub queue: Vec<crate::plex::QueueRow>,
 }
 
 /// Pick the stream URL for an item: direct-play only what the pipeline decodes natively (H264/
@@ -542,6 +573,7 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
         plan.pq_id = q.id;
         plan.pq_item_id = q.item_id;
         plan.up_next = q.up_next;
+        plan.queue = q.rows;
     }
     // the playing item's OWN track lists (menu + audio pick + esInfo fps read them) — the
     // loaded detail can be a different item (show page / straight-from-Home play)
@@ -747,8 +779,10 @@ pub(crate) fn request_play(rk: &str, part: &str, vcodec: &str, acodec: &str, tit
         // Retire the OUTGOING item's queue before its successor resolves: this names the episode
         // after the one that WAS playing, and leaving it up would offer the Up Next control a
         // stale "next" for the whole resolve window — including, when the user just started that
-        // very episode from here, the one now on screen.
+        // very episode from here, the one now on screen. The retained rows go with it, for the
+        // same reason and because a fresh `Vec` also hands their strings back to the allocator.
         *addr_of_mut!(UP_NEXT) = None;
+        *addr_of_mut!(QUEUE) = Vec::new();
     }
     crate::player::reset_audio_track();
     crate::player::reset_subtitle();
@@ -827,8 +861,12 @@ pub(crate) fn pump_play() -> bool {
 /// ran it.
 fn apply_plan(plan: Plan, rk: &str) {
     crate::metadata::install_playing(plan.playing);
-    // main thread only — `up_next()` hands the Up Next control a `&'static` (see its doc)
-    unsafe { *addr_of_mut!(UP_NEXT) = plan.up_next };
+    // main thread only — `up_next()`/`queue()` hand out `&'static`s (see their docs). The rows
+    // arrive already projected: the worker never retained a `Metadata` tree to install here.
+    unsafe {
+        *addr_of_mut!(UP_NEXT) = plan.up_next;
+        *addr_of_mut!(QUEUE) = plan.queue;
+    }
     // Warm the next episode's still NOW rather than at first draw. The URL has been known since
     // this plan resolved — tens of minutes before the credits — and `resolve_tex` is async, so
     // touching it here costs nothing and spares the control a skeleton for one image-transcode


### PR DESCRIPTION
Parity unit 13 — theme **F. The play queue is created and discarded** (`docs/parity-gaps.md`), and the queue appendix entry *"The queue's item rows are received and then thrown away — nothing retains the list."*

## What changed

Every playback already POSTs `/playQueues?continuous=1` and gets the whole `Metadata[]` window back — every row a full item with thumb, S/E, duration, viewOffset, codecs and a Part key. `plex/timeline.rs` kept the immediate successor and dropped the rest, so the app had no queue list, no way to reach an arbitrary member, and an Up Next that could only ever be the next episode — while paying for the round trip that carried all of it.

The rows are retained now, as a **lean projection**, never as `Metadata`:

- **`plex::QueueRow`** — 13 fields (rk, `playQueueItemID`, kind, title, show title, season/index, thumb, `dur_ms`, `resume_ms`, part key, vcodec, acodec), ~300 bytes a row on this device.
- Projected **on the resolve worker**, **by value**: `create_play_queue` consumes each `Metadata` row (`into_iter`), moves its strings, and drops the Media/Part/Stream/Role tree right there. A retained queue now costs *less* than the one successor `Metadata` used to.
- Installed **on the main thread** through `Plan` → `apply_plan`, like every other resolved field — the worker stays read- and write-pure with respect to the route statics.
- Keyed by **`playQueueItemID`**, with the ratingKey only as the fallback for a server that trims the field. That rule now has exactly one implementation, `plex::queue_index_of`, used by the successor lookup and available to whatever later draws "you are here".
- The row list is deliberately **not episode-gated** (a queue row may be a movie); the "episodes only" rule stays on the one-item Up Next control, where it is correct.

Data layer only — no overlay UI, no new endpoint, no extra request.

## The one design call worth reviewing

`route::with_queue(|rows| …)` lends the rows to a closure rather than handing out a `&'static` the way `up_next()` does. `request_play` frees this `Vec` as its first act (retiring the outgoing item's queue before its successor resolves), so a borrowed row used to *start* playback would be read after free — the exact aliasing bug `request_play_up_next`'s by-value signature exists to make unrepresentable. A `&'static` can't be policed by the borrow checker; a closure argument can.

This came out of the code-review pass, which rated it the only Medium finding. Its other findings are also applied: the response→result mapping moved into `PlayQueueResult::of` so the host tests grade the shipped path instead of a copy, the `items`-length doc no longer claims a one-directional relationship to `remaining`, and two assertions that could not fail are gone.

## Verification

**Host — `make check`: 60/60 (58 baseline, +2 new).** ARM cross-build (`make`) clean, no new warnings.

The new tests parse real multi-row `/playQueues` bodies through `PlayQueueResult::of`:
- the whole window is retained (not just the successor), with every projected field asserted — including PMS's string-encoded `duration`/`viewOffset`, and `Media[0]` being taken over a second 1080p version exactly as before;
- `next` **is** `items[selected + 1]`, located by `playQueueItemID`;
- a movie row and a `Media`-less row both project (kind kept, empty strings, no panic).
The four pre-existing successor tests are unchanged in substance: item-id identity, the duplicate-ratingKey queue, the missing-id fallback, and an unrecognised selection yielding nothing.

## Device verification: deferred to coordinator

Not run here — device verification was centralised with the coordinator while this was queued for the single TV. I held the lock briefly and released it without deploying, so nothing was left half-deployed. The build that would be deployed is committed and cross-compiles clean.

**The one case to run:**

```
./tests/run.py --filter morning_show_up_next_autoadvance
```

It is the whole risk surface of this change in a single case (`rk=1804`, cap 110 s): `play` for the start path, then `op: marker` with `marker: credits` → `expect_up_next: "1805"` for the finish → Up Next → auto-advance chain. The harness emits `/tmp/plxnative-marker=credits` itself, which seeks to 5 s before the server's credits marker; there is no need to arm it by hand. Nothing else in the suite exercises the queue. **No FPS tier** — this change draws nothing, so frame rate cannot move.

**What a regression looks like in the event log.** The change is invisible by design, so grade it on these four lines:

1. **Queue retention (the new line).** The resolve log gained a field:
   `playqueue: id=<n> item=<n> remaining=<n> rows=<N> next=S2E3 1805`
   `rows=` is the retained count and is what this PR adds. Expect **`rows=` ≥ 2** for `rk=1804` and `rows=` ≥ `remaining+1`-ish (see the window note below). **`rows=0` with a non-zero `id=` is the regression** — the POST succeeded and the projection dropped everything.
2. **Up Next still resolves.** `next=S2E3 1805` on that same line, never `next=-`. This is the field the harness itself greps (`tests/run.py:877` requires `"playqueue:"` and `"next="` and *not* `"next=-"`), and it is the assertion most likely to catch a mistake in the projection, because `next` is now derived from the retained rows rather than pulled out of the raw `Metadata[]`.
3. **Playback start unchanged.** The usual `decision: part=… -> DIRECT PLAY`, codec id 174, video width ≥ 3000, ACB bind, and no `Playing error`. Nothing in the play path was touched, so any movement here is a real regression rather than a flake.
4. **Timeline unchanged.** The 10 s `/:/timeline` posts still carrying `playQueueID`/`playQueueItemID`, and the 1 Hz `FPS= … pos=` heartbeat climbing (the case's `min_timeline_climb_s: 5`). `PQ_ID`/`PQ_ITEM_ID` are written from the same `Plan` fields as before; if they came back empty, the plumbing change broke them.
5. **Auto-advance completes.** The second item (`1805`) starts — the case ends on a *different* ratingKey, so a log that never leaves 1804 means the Up Next chain broke.

**What to watch in retained memory.** This adds per-item allocations on a 32-bit heap, so:

- The retained cost is `rows=` × ~300 bytes (13 fields, 8 of them `String`; `size_of` is 136 B on armv7 plus ~160 B of string bodies). A whole-show queue of 200 rows is ≈ 60 KB — but **`rows=` in the log is the number to sanity-check**: an unexpectedly large value (hundreds for a single-season show) would mean PMS returned a bigger window than assumed and is worth reporting back.
- **Peak** memory is unchanged: `post_json` already parsed the entire `Vec<Metadata>` before any of this ran. The projection *reduces* what survives that parse — the `Metadata` tree is dropped on the worker, and the strings are moved rather than cloned, so a retained queue costs less than the single successor `Metadata` did.
- No new threads, no new sockets, no new textures: `apply_plan` still warms only Up Next's thumb, so the thread-count and RLIMIT_AS ceilings are untouched.
- One thing worth an eye across the auto-advance boundary: each new item's `request_play` frees the outgoing queue (`*QUEUE = Vec::new()`) before the successor's resolve lands, so the retained rows should not accumulate across a binge — memory after the advance to 1805 should look like memory during 1804, not double it.

## Notes for whoever builds the overlay

- `PlayQueueResult.items` can be a *window*: its length may differ from `remaining + 1` in both directions (a slice of a long queue, and it carries rows *before* the selected one when `playQueueSelectedItemOffset > 0`). `GET /playQueues/{id}` with `X-Plex-Container-Start/Size` is the paging fix, and is specified in `docs/plex-openapi.json`.
- The retained rows are uncapped on purpose. The capping that matters is *drawing* (a still per row is a GL texture); `apply_plan` still warms only Up Next's thumb.
- `docs/parity-gaps.md`'s queue entry is now half-stale (it quotes the old `drain` and the old log format). I left it alone deliberately — 16 other units are landing against that same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
