### PR TITLE
player: chapters follow the played leaf, and the rail shows them

### DIFF
--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -89,11 +89,29 @@ pub(crate) struct Related {
     pub(crate) thumb: String,
 }
 
+/// Clone because the playing-item store keeps the played leaf's OWN chapters (see [`PlayingItem`]) —
+/// on the detail-page play path they are cloned from the already-loaded `Detail` rather than refetched.
+#[derive(Clone)]
 pub(crate) struct Chapter {
     pub(crate) index: i64,    // 1-based chapter number
     pub(crate) start_ms: i64, // startTimeOffset — the seek target + timestamp label
     pub(crate) title: String, // Chapter.tag; empty → UI shows "Chapter {index}"
     pub(crate) thumb: String, // server image path → resolve_tex (empty if no chapter thumbs)
+}
+
+/// Parse an item's `Chapter[]` into the app's model — the ONE `plex::Chapter` → [`Chapter`] mapping,
+/// shared by the detail parse and the playing-item store (which must agree: the Chapters strip seeks
+/// with these offsets, so two mappings is two chances to disagree about which item they describe).
+fn convert_chapters(chapters: &[crate::plex::Chapter]) -> Vec<Chapter> {
+    chapters
+        .iter()
+        .map(|c| Chapter {
+            index: c.index,
+            start_ms: c.start_time_offset,
+            title: c.tag.clone(),
+            thumb: c.thumb.clone(),
+        })
+        .collect()
 }
 
 /// Which timeline segment a [`Marker`] describes. Only the two the player acts on are modelled —
@@ -351,16 +369,7 @@ fn fetch_detail(rk: &str) -> Option<Detail> {
         episodes: Vec::new(),
         cur_season: 0,
         related: Vec::new(),
-        chapters: it
-            .chapter
-            .iter()
-            .map(|c| Chapter {
-                index: c.index,
-                start_ms: c.start_time_offset,
-                title: c.tag.clone(),
-                thumb: c.thumb.clone(),
-            })
-            .collect(),
+        chapters: convert_chapters(&it.chapter),
         markers: convert_markers(&it.marker),
     };
     // audio/subtitle streams (movies carry Media/Part/Stream; a show does not — its
@@ -418,7 +427,10 @@ fn parse_streams(it: &crate::plex::Metadata, d: &mut Detail) {
 // played leaf's OWN data. The track menu and the route's audio pick read its streams; feeding a
 // menu built from episode 1's streams to a playback of episode 5 was a real track-identity bug.
 // `markers` is here for exactly that reason and not on `Detail`: skipping episode 1's intro
-// timing during episode 5 is the same bug wearing a different hat.
+// timing during episode 5 is the same bug wearing a different hat. `chapters` rides along for the
+// third instance of it: the Chapters tab and strip used to read `current()`, so an episode played
+// from a SHOW page found a show container (which carries no Chapter[]) and the tab silently
+// vanished — while a `current()` holding some OTHER leaf would have seeked with its offsets.
 
 #[derive(Clone)]
 pub(crate) struct PlayingItem {
@@ -427,6 +439,7 @@ pub(crate) struct PlayingItem {
     pub(crate) subs: Vec<Stream>,
     pub(crate) video_fps: f64, // the played leaf's video fps (0 = unknown) — feeds the Load esInfo
     pub(crate) markers: Vec<Marker>, // intro / credits segments — the in-player Skip prompt
+    pub(crate) chapters: Vec<Chapter>, // chapter boundaries — the Chapters tab/strip + rail ticks
 }
 static mut PLAYING: Option<PlayingItem> = None;
 
@@ -440,6 +453,14 @@ pub(crate) fn playing() -> Option<&'static PlayingItem> {
 /// reads, so no call site has to know the store can be absent mid-resolve.
 pub(crate) fn playing_markers() -> &'static [Marker] {
     playing().map(|p| p.markers.as_slice()).unwrap_or(&[])
+}
+
+/// The playing leaf's chapters, or an empty slice — the ONE accessor the Chapters strip and the
+/// scrubber's chapter ticks read. Deliberately NOT `current()`: during a show-page episode play
+/// `current()` is the SHOW (no `Chapter[]` at all), which is why the tab never appeared on that
+/// path, and a `current()` holding a different leaf would seek with another item's offsets.
+pub(crate) fn playing_chapters() -> &'static [Chapter] {
+    playing().map(|p| p.chapters.as_slice()).unwrap_or(&[])
 }
 
 /// Load the playing-item track store for `rk` at play time (route::build_stream). Reuses the
@@ -461,6 +482,7 @@ pub(crate) fn cached_playing(rk: &str) -> Option<PlayingItem> {
         subs: d.subs.clone(),
         video_fps: d.video_fps,
         markers: d.markers.clone(),
+        chapters: d.chapters.clone(),
     })
 }
 
@@ -469,14 +491,17 @@ pub(crate) fn fetch_playing_item(rk: &str) -> Option<PlayingItem> {
         return None;
     }
     let it = crate::plex::client_opt().and_then(|c| c.metadata(rk));
-    // Markers hang off the ITEM, streams off its first Part — so a part-less response still
-    // yields usable markers instead of discarding both.
+    // Markers and chapters hang off the ITEM, streams off its first Part — so a part-less response
+    // still yields both of those instead of discarding all three. `Client::metadata` already sends
+    // `includeChapters=1` (plex/library.rs), so the Chapter[] is on the wire either way: taking it
+    // here costs no request, and dropping it is what hid the Chapters tab on the episode path.
     let markers = it.as_ref().map(|it| convert_markers(&it.marker)).unwrap_or_default();
+    let chapters = it.as_ref().map(|it| convert_chapters(&it.chapter)).unwrap_or_default();
     let (audio, subs, video_fps) = it
         .as_ref()
         .and_then(|it| it.first_part().map(|p| convert_streams(&p.stream)))
         .unwrap_or_default();
-    Some(PlayingItem { rk: rk.to_string(), audio, subs, video_fps, markers })
+    Some(PlayingItem { rk: rk.to_string(), audio, subs, video_fps, markers, chapters })
 }
 
 /// Retire BOTH descriptions of the item that was playing, together.
@@ -490,6 +515,19 @@ pub(crate) fn fetch_playing_item(rk: &str) -> Option<PlayingItem> {
 /// makes it a contract instead.
 pub(crate) fn retire_playing() {
     set_now_playing(None);
+    retire_playing_item();
+}
+
+/// Retire ONLY the track/marker/chapter store, leaving the `NowPlaying` caption alone — what a NEW
+/// play REQUEST does at its start ([`crate::route::request_play`]), beside the same retirement of
+/// `UP_NEXT`.
+///
+/// The caption cannot be retired there because `detail::play_episode_at` sets it just BEFORE
+/// requesting the play. The store must be, though: it is the PREVIOUS leaf's for the whole resolve
+/// window (0.5-3 s, longer through a `/decision` handshake) and the HUD is up for all of it. With
+/// chapters in here that became user-reachable — the transport advertised a Chapters tab whose OK
+/// seeked the NEW episode to some other item's offset.
+pub(crate) fn retire_playing_item() {
     unsafe {
         *addr_of_mut!(PLAYING) = None;
         (*addr_of_mut!(SKIPPED)).clear();
@@ -501,8 +539,8 @@ pub(crate) fn install_playing(pt: Option<PlayingItem>) {
     unsafe { (*addr_of_mut!(SKIPPED)).clear() }; // a different leaf's markers, so a fresh slate
     if let Some(pt) = &pt {
         crate::player::log(&format!(
-            "playing item: rk={} audio={} subs={} markers={}",
-            pt.rk, pt.audio.len(), pt.subs.len(), pt.markers.len()));
+            "playing item: rk={} audio={} subs={} markers={} chapters={}",
+            pt.rk, pt.audio.len(), pt.subs.len(), pt.markers.len(), pt.chapters.len()));
     }
     unsafe { *addr_of_mut!(PLAYING) = pt };
 }

--- a/rust-modules/src/route.rs
+++ b/rust-modules/src/route.rs
@@ -750,6 +750,9 @@ pub(crate) fn request_play(rk: &str, part: &str, vcodec: &str, acodec: &str, tit
         // very episode from here, the one now on screen.
         *addr_of_mut!(UP_NEXT) = None;
     }
+    // …and the outgoing item's track/marker/chapter store, for exactly the reason above: it stays
+    // the PREVIOUS leaf's until this resolve lands. See `metadata::retire_playing_item`.
+    crate::metadata::retire_playing_item();
     crate::player::reset_audio_track();
     crate::player::reset_subtitle();
     // captured HERE, on the main thread, and moved into the worker — see ResolveEnv

--- a/rust-modules/src/ui/chapters_panel.rs
+++ b/rust-modules/src/ui/chapters_panel.rs
@@ -1,7 +1,12 @@
 //! In-player Chapters strip: a horizontal row of chapter cards (thumbnail + name + timestamp) over
 //! the transport, opened from the HUD's Chapters tab. LEFT/RIGHT pick a chapter, OK seeks to its
-//! start. Data from metadata::current().chapters (loaded with ?includeChapters=1). Card layout
-//! mirrors the detail-page episode picker; modal wiring mirrors info_panel.
+//! start. Card layout mirrors the detail-page episode picker; modal wiring mirrors info_panel.
+//!
+//! Data comes from the PLAYING leaf (`metadata::playing_chapters`, loaded with `?includeChapters=1`
+//! on the same fetch the track store already makes), never from `metadata::current()` — the same
+//! identity rule `ui/track_menu.rs` and `ui/skip_pill.rs` state. Reading `current()` is what made
+//! the Chapters tab vanish for every episode started from a show detail page: `current()` is then
+//! the SHOW, and a show container carries no `Chapter[]`.
 #![allow(dead_code)]
 use crate::metadata;
 use crate::ui::consts::{MARGIN_X, SCR_W, SDLK_LEFT, SDLK_RIGHT};
@@ -30,10 +35,16 @@ fn pop() -> &'static mut Popover {
 pub(crate) fn is_open() -> bool {
     unsafe { (*addr_of!(POP)).is_open() }
 }
-fn n() -> c_int {
-    metadata::current().map(|d| d.chapters.len()).unwrap_or(0) as c_int
+/// the playing leaf's chapters — the ONE read, so within a frame the count, the open, the seek and
+/// the draw cannot end up describing different items. ACROSS frames the store can still be replaced
+/// (a new play retires it, `route::request_play`), which is why `update` re-clamps the selection.
+fn chapters() -> &'static [metadata::Chapter] {
+    metadata::playing_chapters()
 }
-/// whether the current item has chapters — drives showing/hiding the Chapters tab
+fn n() -> c_int {
+    chapters().len() as c_int
+}
+/// whether the PLAYING item has chapters — drives showing/hiding the Chapters tab
 pub(crate) fn has_chapters() -> bool {
     n() > 0
 }
@@ -41,9 +52,7 @@ pub(crate) fn has_chapters() -> bool {
 pub(crate) fn open() {
     // focus the chapter that contains the current playhead
     let pos_ms = crate::player::playpos_ns() / 1_000_000;
-    let sel = metadata::current()
-        .map(|d| d.chapters.iter().rposition(|c| c.start_ms <= pos_ms).unwrap_or(0) as c_int)
-        .unwrap_or(0);
+    let sel = chapters().iter().rposition(|c| c.start_ms <= pos_ms).unwrap_or(0) as c_int;
     unsafe {
         addr_of_mut!(SEL).write(sel);
         addr_of_mut!(SCROLL).write(Spring::at(scroll_target(sel)));
@@ -88,10 +97,7 @@ pub(crate) fn move_focus(sym: c_int) {
 pub(crate) fn on_ok() -> i64 {
     let s = unsafe { addr_of!(SEL).read() };
     close();
-    metadata::current()
-        .and_then(|d| d.chapters.get(s.max(0) as usize))
-        .map(|c| c.start_ms * 1_000_000)
-        .unwrap_or(-1)
+    chapters().get(s.max(0) as usize).map(|c| c.start_ms * 1_000_000).unwrap_or(-1)
 }
 
 pub(crate) fn update(dt: f32) {
@@ -99,7 +105,12 @@ pub(crate) fn update(dt: f32) {
         return;
     }
     pop().update(dt);
-    let sel = unsafe { addr_of!(SEL).read() };
+    // The store this indexes belongs to the PLAYING item and a new play retires it, so re-clamp
+    // rather than spring the scroll toward a slot that no longer exists (which culls every card
+    // and leaves an empty panel). `on_ok`/`draw` are `.get()`-based, so this is about the strip
+    // staying coherent, not about safety.
+    let sel = unsafe { addr_of!(SEL).read() }.min((n() - 1).max(0));
+    unsafe { addr_of_mut!(SEL).write(sel) };
     let sctgt = scroll_target(sel);
     let sc = unsafe { &mut *addr_of_mut!(SCROLL) };
     sc.step(sctgt, 220.0, dt);
@@ -113,11 +124,8 @@ pub(crate) fn draw() {
     if !is_open() {
         return;
     }
-    let d = match metadata::current() {
-        Some(d) => d,
-        None => return,
-    };
-    if d.chapters.is_empty() {
+    let chs = chapters();
+    if chs.is_empty() {
         return;
     }
     let scroll = unsafe { addr_of!(SCROLL).read() }.pos;
@@ -129,7 +137,7 @@ pub(crate) fn draw() {
     // dim grey washed out even up close. SECONDARY matches the (readable) chapter-name grey; the
     // name still leads by size (LABEL vs CAPTION) + bold.
     let dimc = theme::TEXT_SECONDARY;
-    for (i, ch) in d.chapters.iter().enumerate() {
+    for (i, ch) in chs.iter().enumerate() {
         let x = MARGIN_X + i as f32 * (CH_W + CH_GAP);
         if !crate::ui::on_axis(x - scroll, CH_W, SCR_W, 0.0) {
             continue; // culled off-screen (the shared cull primitive)

--- a/rust-modules/src/ui/player_hud.rs
+++ b/rust-modules/src/ui/player_hud.rs
@@ -309,6 +309,92 @@ pub(crate) fn scrub_frac_x(mx: f32) -> f32 {
     ((mx - SB_X) / sb_w()).clamp(0.0, 1.0)
 }
 
+// ---- rail marks: chapter boundaries + intro/credits segments ---------------------------------
+// Both data sets already sit in memory during playback and both belong to the PLAYING leaf —
+// `metadata::playing_chapters()` and `metadata::playing_markers()` (which the Skip control reads
+// every frame). Neither costs a request: `?includeChapters=1&includeMarkers=1` ride the fetch the
+// track store already makes. So this is a draw, not a fetch.
+//
+// The device constraint shapes the geometry: this Mali is FILL-RATE bound and the HUD composites
+// over the transparent UI plane above the hardware video plane, so every mark here is a small
+// opaque quad — no glow, no gradient, no per-mark text. A 3x8px tick costs no measurable fill; what
+// `TICK_MIN_GAP` bounds is the DRAW CALL count (`sb_w() / TICK_MIN_GAP` = 145 worst case, against
+// 10-30 for a real item), which is the axis a per-quad painter actually spends on.
+
+/// chapter tick width, px
+const TICK_W: f32 = 3.0;
+/// Ticks nearer than this to the previous KEPT tick are dropped. Two jobs: a run of short chapters
+/// would otherwise smear into a solid bar, and `sb_w() / TICK_MIN_GAP` is the ceiling on how many
+/// extra quads the rail can add — which is what makes the cost provable instead of assumed.
+const TICK_MIN_GAP: f32 = 12.0;
+/// A tick this close to either end is dropped — it would sit under the rail's own rounded cap and
+/// read as a chipped edge rather than a boundary. (Chapter 1 usually starts at 0:00.)
+const TICK_EDGE: f32 = 8.0;
+/// Floor width for a marker band, so a very short segment on a long item is still a visible mark
+/// rather than a sub-pixel sliver. The rail's end wins over it: a segment starting in the last few
+/// px is drawn short rather than pushed off its own offset.
+const MARKER_MIN_W: f32 = 6.0;
+
+/// PURE: rail x for a position in ms, clamped to the rail. Total by construction — an unknown
+/// duration (the whole pre-roll, and any item the demuxer never reported one for) maps everything
+/// to the rail's start, and the callers below refuse to draw at all in that case.
+fn rail_x(ms: i64, dur_ms: i64, sx: f32, sw: f32) -> f32 {
+    if dur_ms <= 0 {
+        return sx;
+    }
+    sx + sw * (ms as f64 / dur_ms as f64).clamp(0.0, 1.0) as f32
+}
+
+/// PURE: the chapter ticks' CENTRE x on a rail spanning `[sx, sx + sw]`, in rail order.
+///
+/// Offsets at or past the item's end, and the 0:00 chapter every file opens with, are not
+/// boundaries on this rail — they are its ends. The rest are coalesced against the previously KEPT
+/// tick, which both stops a cluster from smearing and bounds the draw.
+///
+/// The coalesce is on DISTANCE, not on the difference: PMS emits chapters in ascending order and
+/// `Chapter[]` is not sorted or validated on the way in (`metadata::convert_chapters`), and PMS
+/// demonstrably does not sort such sibling arrays by offset — its `Marker[]` comes back credits-
+/// before-intro. A signed compare would read every backward step as "too close" and silently drop
+/// the whole rest of the list.
+fn chapter_tick_xs(chapters: &[crate::metadata::Chapter], dur_ms: i64, sx: f32, sw: f32) -> Vec<f32> {
+    let mut xs: Vec<f32> = Vec::new();
+    if dur_ms <= 0 || sw <= 0.0 {
+        return xs;
+    }
+    for c in chapters {
+        if c.start_ms <= 0 || c.start_ms >= dur_ms {
+            continue;
+        }
+        let x = rail_x(c.start_ms, dur_ms, sx, sw);
+        if x - sx < TICK_EDGE || (sx + sw) - x < TICK_EDGE {
+            continue;
+        }
+        if let Some(&prev) = xs.last() {
+            if (x - prev).abs() < TICK_MIN_GAP {
+                continue;
+            }
+        }
+        xs.push(x);
+    }
+    xs
+}
+
+/// PURE: a marker segment's `(left, right)` extent on the rail, or None when it cannot be drawn
+/// (unknown duration, or a segment that starts at/after the end of the item).
+///
+/// A `final` credits marker's stated `end_ms` is the CONTAINER duration and routinely overshoots
+/// the decoder's, so the right edge is clamped to the rail rather than allowed to overhang it —
+/// the same overshoot [`crate::metadata::marker_at`] absorbs by treating such a segment as
+/// open-ended.
+fn marker_band(m: crate::metadata::Marker, dur_ms: i64, sx: f32, sw: f32) -> Option<(f32, f32)> {
+    if dur_ms <= 0 || sw <= 0.0 || m.start_ms >= dur_ms || m.end_ms <= m.start_ms {
+        return None;
+    }
+    let l = rail_x(m.start_ms.max(0), dur_ms, sx, sw);
+    let r = rail_x(m.end_ms, dur_ms, sx, sw).max(l + MARKER_MIN_W).min(sx + sw);
+    (r > l).then_some((l, r))
+}
+
 /// draw a clock string centred on `cx` as ONE label box, clamped so it stays inside [lo, hi].
 /// (The old last-':'-anchor read visibly lopsided once the clock grew to H:MM:SS — "1:05" left of
 /// the knob vs "53" right.) The box width is measured on a same-shape template with every digit
@@ -410,11 +496,28 @@ pub(crate) fn draw_hud(slot: ControlSlot, focus: i32, btn: i32, tab: i32, now: u
     let dur = crate::player::duration_ns();
     let frac = if dur > 0 { (dispos as f64 / dur as f64).clamp(0.0, 1.0) } else { 0.0 };
     p.rect(Rect::new(sx, sy, sw, sh), sh * 0.5, track, track, 0.0);
+    let dur_ms = dur / 1_000_000;
+    // intro / credits segments, UNDER the fill: a segment already watched should read as watched,
+    // exactly like the rest of the rail. At most two per item (an intro and a credits).
+    for m in crate::metadata::playing_markers() {
+        if let Some((l, r)) = marker_band(*m, dur_ms, sx, sw) {
+            let rad = (sh * 0.5).min((r - l) * 0.5);
+            p.rrect(Rect::new(l, sy, r - l, sh), rad, rad, theme::RAIL_MARKER);
+        }
+    }
     let fw = (sw as f64 * frac) as f32;
     if fw > sh * 0.5 {
         p.rrect(Rect::new(sx, sy, fw, sh), sh * 0.5, 0.0, white);
     } else if fw > 0.0 {
         p.rrect(Rect::new(sx, sy, fw, sh), fw * 0.5, 0.0, white);
+    }
+    // chapter boundaries, OVER both bands, so a boundary reads on whichever side of the playhead it
+    // falls. Their x is snapped (unlike the fill and the knob, which move every frame and would
+    // stutter): a tick holds still for the whole item, so a fractional edge only buys it a soft
+    // 3px smear from the SDF's edge AA.
+    for tx in chapter_tick_xs(crate::metadata::playing_chapters(), dur_ms, sx, sw) {
+        let col = if tx < sx + fw { theme::RAIL_TICK_PLAYED } else { theme::RAIL_TICK };
+        p.rect(Rect::new(crate::gfx::snap(tx - TICK_W * 0.5), sy, TICK_W, sh), 0.0, col, col, 0.0);
     }
     // playhead: a focus-glowing knob when the scrubber is focused, a plain knob while scrubbing,
     // else a thin tick.
@@ -488,12 +591,25 @@ pub(crate) fn draw_hud(slot: ControlSlot, focus: i32, btn: i32, tab: i32, now: u
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metadata::{Marker, MarkerKind};
+    use crate::metadata::{Chapter, Marker, MarkerKind};
     use crate::ui::skip_pill::SkipAction;
 
     fn marker(kind: MarkerKind, final_seg: bool) -> Marker {
         Marker { kind, start_ms: 1_000, end_ms: 2_000, final_seg }
     }
+
+    fn seg(start_ms: i64, end_ms: i64, final_seg: bool) -> Marker {
+        Marker { kind: MarkerKind::Credits, start_ms, end_ms, final_seg }
+    }
+
+    fn chap(start_ms: i64) -> Chapter {
+        Chapter { index: 1, start_ms, title: String::new(), thumb: String::new() }
+    }
+
+    // A rail 1000px wide over a 1000ms item: 1px per ms, so an offset reads straight off the x.
+    const SX: f32 = 100.0;
+    const SW: f32 = 1000.0;
+    const DUR: i64 = 1_000;
 
     /// The control row's precedence, which used to live in the ORDER of five separate if-chains
     /// across `player_hud` and `app.rs` — the draw, the OK handler, the pointer handler, the
@@ -544,5 +660,60 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(intro, SkipAction::Seek(2_000 * 1_000_000));
+    }
+
+    /// The rail's chapter ticks: an offset maps to its own x, and the three cases that are NOT
+    /// boundaries — the 0:00 chapter every file opens with, anything at or past the end, and a
+    /// cluster too tight to draw apart — drop out instead of drawing a chipped cap or a grey smear.
+    #[test]
+    fn a_chapter_tick_lands_on_its_own_offset_and_nowhere_else() {
+        let chapters = [
+            chap(0),    // the item's start: the rail's left cap, not a boundary
+            chap(250),  // → 350
+            chap(256),  // 6px behind it — coalesced (TICK_MIN_GAP = 12)
+            chap(500),  // → 600
+            chap(995),  // inside TICK_EDGE of the right cap
+            chap(1_000), // exactly the end
+            chap(1_200), // past the end (a stale chapter list against a shorter part)
+        ];
+        assert_eq!(chapter_tick_xs(&chapters, DUR, SX, SW), vec![350.0, 600.0]);
+
+        // The coalesce measures from the KEPT tick, never from the dropped one — so however dense
+        // the input, no two DRAWN ticks are closer than the gap. (Measuring from the previous input
+        // instead would let a cluster of sub-gap steps smear across the rail.)
+        let creep = [chap(200), chap(208), chap(216), chap(224), chap(232)];
+        let xs = chapter_tick_xs(&creep, DUR, SX, SW);
+        assert_eq!(xs, vec![300.0, 316.0, 332.0], "8px steps against a 12px gap: every other tick");
+        assert!(xs.windows(2).all(|w| w[1] - w[0] >= TICK_MIN_GAP));
+
+        // An out-of-order list must not lose its tail. The coalesce is on distance, so a backward
+        // step reads as "far from the last kept tick" rather than as a negative gap — which a
+        // signed compare would have treated as too close, dropping everything after entry one.
+        assert_eq!(chapter_tick_xs(&[chap(500), chap(250), chap(750)], DUR, SX, SW), vec![600.0, 350.0, 850.0]);
+
+        // no duration yet (the whole pre-roll) → nothing to place ticks against
+        assert!(chapter_tick_xs(&[chap(250)], 0, SX, SW).is_empty());
+        assert!(chapter_tick_xs(&[], DUR, SX, SW).is_empty());
+    }
+
+    /// The intro/credits band covers its own segment, and a `final` credits marker — whose stated
+    /// end is the CONTAINER duration, which routinely overshoots the decoder's — stops at the rail's
+    /// end instead of overhanging it.
+    #[test]
+    fn a_marker_band_covers_its_segment_and_stops_at_the_rail() {
+        assert_eq!(marker_band(seg(100, 200, false), DUR, SX, SW), Some((200.0, 300.0)));
+
+        // a `final` credits segment running to (or past) the container duration
+        assert_eq!(marker_band(seg(900, 1_000, true), DUR, SX, SW), Some((1_000.0, 1_100.0)));
+        assert_eq!(marker_band(seg(900, 1_200, true), DUR, SX, SW), Some((1_000.0, 1_100.0)));
+
+        // a segment shorter than the floor is widened to it rather than drawn sub-pixel
+        let (l, r) = marker_band(seg(500, 501, false), DUR, SX, SW).expect("a 1ms segment still draws");
+        assert_eq!((l, r), (600.0, 600.0 + MARKER_MIN_W));
+
+        // nothing to draw: no duration, a segment that starts at/after the end, an inverted one
+        assert_eq!(marker_band(seg(100, 200, false), 0, SX, SW), None);
+        assert_eq!(marker_band(seg(1_000, 1_100, false), DUR, SX, SW), None);
+        assert_eq!(marker_band(seg(300, 300, false), DUR, SX, SW), None);
     }
 }

--- a/rust-modules/src/ui/theme.rs
+++ b/rust-modules/src/ui/theme.rs
@@ -159,6 +159,17 @@ pub const RAIL_TRACK: [f32; 4] = [1.0, 1.0, 1.0, 0.20];
 pub const RAIL_BUFFERED: [f32; 4] = [1.0, 1.0, 1.0, 0.28];
 /// Played/filled portion of a rail.
 pub const RAIL_FILL: [f32; 4] = [1.0, 1.0, 1.0, 0.95];
+/// An intro/credits SEGMENT on the player scrubber — a band lit a step above the track, drawn
+/// between the track and the fill so the played part of a segment reads as played. Stays inside the
+/// rail's monochrome language on purpose: a hue here would compete with the amber resume fill for
+/// "this bit is special", and the rail sits straight over moving video.
+pub const RAIL_MARKER: [f32; 4] = [1.0, 1.0, 1.0, 0.42];
+/// A chapter boundary tick on the UNPLAYED part of a rail — bright, because the track under it is
+/// nearly transparent over the video.
+pub const RAIL_TICK: [f32; 4] = [1.0, 1.0, 1.0, 0.72];
+/// The same tick on the PLAYED part: a notch cut out of the bright fill. One tick colour cannot
+/// serve both — white vanishes into the fill, dark vanishes into the track.
+pub const RAIL_TICK_PLAYED: [f32; 4] = scrim_black(0.55);
 /// Warm amber Continue-Watching progress fill (Plex-specific; no player equivalent). `#fab82e`.
 pub const RESUME_FILL: [f32; 4] = [0.98, 0.72, 0.18, 0.95];
 /// Unfilled track behind the Continue-Watching resume bar — the full-bleed card-bottom rail. A


### PR DESCRIPTION
Unit 12 of the movie/TV parity work (`docs/parity-gaps.md`, player/stats appendix): "Chapters are
unavailable for any episode started from a show detail page" and "No chapter or intro/credits
markers on the scrubber rail".

## 1. The Chapters tab on the episode path

`ui/chapters_panel.rs` read `metadata::current()` in all four accessors. During a show-page episode
play `current()` is the SHOW (`detail::play_episode_at` says so in a comment) and a show container
carries no `Chapter[]`, so `has_chapters()` was false and the HUD drew only the Info tab. The same
aliasing meant a `current()` holding a different leaf would seek with that item's offsets.

Chapters now ride `metadata::PlayingItem` beside `markers` — the store that exists for exactly this
identity problem — behind one new accessor, `metadata::playing_chapters()`.

**No extra PMS request, confirmed rather than assumed.** `Client::metadata` already sends
`includeChapters=1` (`plex/library.rs`), and both store-building paths already have the data:

* detail-page play → `cached_playing` clones the loaded `Detail`'s chapters (no GET, as before);
* show-page / straight-from-Home play → `fetch_playing_item` was already making that GET for markers
  and streams and **discarding the `Chapter[]` in the same response**.

Device proof, playing an episode from the show page: `playing item: rk=1886 audio=1 subs=38
markers=2 chapters=39` — one metadata GET, 39 chapters that used to be dropped.

### The staleness this exposed

Moving chapters into `PLAYING` made a latent bug user-reachable, so `request_play` now retires that
store beside `UP_NEXT`, for the reason already documented there: it stays the PREVIOUS leaf's for
the whole resolve window (0.5-3 s, longer through a `/decision` handshake), and the HUD is up for
all of it. Markers were shielded by `active_marker`'s `is_playing()` gate; a tab has no such gate,
and its OK would have seeked the new episode to another item's offset. The `NowPlaying` caption
can't move with it — `play_episode_at` sets it just *before* requesting the play — so the retirement
is `PLAYING`-only. `chapters_panel::update` also re-clamps its selection, since the list it indexes
can now be replaced under an open strip.

## 2. Chapter + intro/credits marks on the rail

Between the track and the knob:

* **intro/credits bands** from `metadata::playing_markers()` — under the fill, so a watched segment
  reads as watched. A `final` credits marker's stated end is the container duration (it overshoots
  the decoder's), so the band is clamped to the rail.
* **chapter ticks** over both, coloured by which side of the playhead they fall on — one colour
  can't serve both, since white vanishes into the fill and dark vanishes into the track.

Three new `theme.rs` tokens with doc lines; no inline colours, no text, no new font sizes.

Geometry is pure and host-tested (`chapter_tick_xs`, `marker_band`): the 0:00 chapter and anything
within 8px of a cap are dropped (they are the rail's ends, not boundaries on it), and ticks coalesce
on **distance** — PMS does not sort these sibling arrays by offset (its `Marker[]` comes back
credits-before-intro), and a signed compare would silently drop everything after the first backward
step.

## Verification

| Gate | Result |
|---|---|
| `make check` | 60 passed (58 baseline + 2 new geometry tests) |
| `make` (ARM cross-build) | clean, no new warnings |
| `./tests/run.py --fps-player` | **7/7 PASS** — `fps:track-menu` (its item draws 33 ticks) 54fps vs floor 45; `fps:info-panel` 53 vs 45 |
| `./tests/run.py --filter morning_show_skip_intro` | 2/2 PASS (`morning_show_skip_intro`, `..._press`) |
| Show-page episode boot, final binary | 60fps median with 35 ticks + both bands up; min 44 during pre-roll |

Ticks land within a pixel of what the pure function predicts (157/198/252/282/317 px), and each
marker band measures ~2.4x the plain track's ink — both measured off the `DISPLAY` capture rather
than eyeballed, since the rail is semi-transparent over live video.

A correctness review was run over the diff; its one real finding (the stale-store window above) is
fixed here, along with three doc-accuracy notes and the non-monotone coalesce. Its out-of-scope
find, left alone: `app.rs:1409-1410` has two identical `else if vis && hud_nav.focus == 1` arms, the
first empty, so **OK on a focused Subtitles/Audio disc is a no-op by remote** — pre-existing, from
`c1691d1`, and already recorded in `docs/parity-gaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
