### PR TITLE
player: OK on a focused Subtitles/Audio disc reaches the track menu again

### DIFF
--- a/.claude/skills/setup-environment/SKILL.md
+++ b/.claude/skills/setup-environment/SKILL.md
@@ -44,6 +44,7 @@ Then make sure the Rust side is ready (safe to re-run — no-ops if already done
 ```bash
 rustup toolchain install nightly
 rustup component add rust-src --toolchain nightly
+rustup component add clippy   --toolchain nightly   # `make check` runs `make lint` first
 brew install sshpass      # deploy/run only; skip if you won't touch the TV
 ```
 
@@ -149,6 +150,7 @@ create=1`, and rising FPS with no `SIGILL` / `undefined symbol`. See the main
 | Paths inside the SDK point at `/Users/runner/...` | You skipped/failed `relocate-sdk.sh`. Re-run it from the SDK root. |
 | `cannot find -lSDL2 / -lplayerAPIs / -lpf-1.0` | Wrong/incomplete sysroot (partial download, or `WEBOS_SDK` points somewhere stale). Re-extract; verify `find $SYSROOT -name 'libplayerAPIs.so*'`. |
 | `error: "-Z build-std" ... rust-src` or `cargo +nightly` fails | Missing nightly or rust-src: `rustup toolchain install nightly && rustup component add rust-src --toolchain nightly`. |
+| `make check` dies at `make lint` with `no such command: clippy` | The nightly was installed with `--profile minimal`, which omits clippy (the default profile ships it): `rustup component add clippy --toolchain nightly`. `make check` runs `lint` first; the cross-build itself never needs clippy. |
 | Binary is `Tag_CPU_arch: v6`, or SIGILLs on the TV at first atomic | `RUSTFLAGS_TV` got dropped, or std wasn't rebuilt. Ensure `-C target-cpu=cortex-a9` and `-Z build-std` are intact; `rm` the stale `libplxnative_modules.a` and rebuild. |
 | `relocation R_ARM_MOVW_ABS_NC ... recompile with -fPIC` when building a stub | A stub needs PIC. Stubs already use `-fPIC` in `STUBFLAGS`; if you added a bespoke stub rule, add `-fPIC`. |
 | Deploy/run steps fail with `sshpass: command not found` | `brew install sshpass`. The TV must be on and reachable (`make TV=<ip> ...`). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,16 @@ full one-time setup + troubleshooting.
 - `make deploy` — scp the binary + `appinfo.json` (+ fonts if missing) to the TV app dir.
 - `make run` — close any running instance, wipe `/tmp/plxnative-events.log`, launch, keep alive
   `RUN_SECS` (default 18s), then `cat` the on-device event log back to your terminal.
-- `make check` — the **host** unit suite (`cargo test --lib`, ~0.3s, no TV). Not a
-  prerequisite of `all` — the cross-build must never depend on a host toolchain run. See the
-  testing section for what it does and does not cover.
+- `make check` — the **host** unit suite (`cargo test --lib`, ~0.3s, no TV), preceded by `make
+  lint`. Not a prerequisite of `all` — the cross-build must never depend on a host toolchain run.
+  See the testing section for what it does and does not cover.
+- `make lint` — three **named** clippy lints (`ifs_same_cond`, `same_functions_in_if_condition`,
+  `if_same_then_else`) over the whole crate, `-A clippy::all` first so nothing else can *fail* the
+  gate (rustc's own warnings still print). It exists for one bug class the unit suite cannot reach:
+  a **shadowed branch**. A duplicated `else if` with an empty body once hid the arm that opens the
+  player's track menu — rustc does not warn on a repeated condition, and the dispatch is inside the
+  SDL event loop where no host test can see it. Needs the **clippy component on nightly** (rustup's
+  default profile ships it; a `--profile minimal` nightly does not).
 - `make test` — `deploy` then `run` (the normal iteration command).
 - `make kill` — close the app on the TV.
 - `make ipk` — repackage the installable `pkg/com.beb.plxnative_0.1.0_arm.ipk`.
@@ -209,13 +216,14 @@ There **is** a host unit suite, and it is not the real gate — both halves matt
 them is how this section used to be wrong in three files at once.
 
 **Tier 1 — `make check` (host, sub-second).** `cd rust-modules && cargo test --lib` runs the whole
-host suite in **~0.3s** on the dev Mac, no TV involved (48 tests as of 2026-07-29 — re-derive with
+host suite in **~0.3s** on the dev Mac, no TV involved (59 tests as of 2026-07-29 — re-derive with
 `cargo test --lib -- --list | grep -c ': test'` rather than trusting this or the per-module counts
 below; the first version of this section was stale within one commit because two agents added tests
-to the same batch that documented it). `make check` is that command; it is deliberately **not**
-a prerequisite of `all`, so an ordinary `make` still cross-compiles without ever invoking a host
-toolchain run. Run it before `make test` — it is free by comparison, and it is the only signal you
-get without waking a television. What it covers today, by module:
+to the same batch that documented it). `make check` is that command **plus `make lint`** (three
+named clippy lints, see the build section — the shadowed-branch gate, ~1s warm); it is deliberately
+**not** a prerequisite of `all`, so an ordinary `make` still cross-compiles without ever invoking a
+host toolchain run. Run it before `make test` — it is free by comparison, and it is the only signal
+you get without waking a television. What it covers today, by module:
 
   - `stream.rs` (10) — **socket semantics against real loopback sockets, plus response-header
     parsing**: `connect(2)` giving up on its deadline (RFC 5737 TEST-NET black hole), a refused

--- a/Makefile
+++ b/Makefile
@@ -200,9 +200,9 @@ clean:
 
 test: deploy run
 
-# `make check` — the HOST unit suite (~0.3s), the only correctness signal available
-# without a television. Deliberately NOT a prerequisite of `all`: the normal build is a cross
-# compile for the TV and must not be made to depend on a host toolchain run succeeding (a host
+# `make check` — the HOST unit suite (~0.3s) plus `lint` below, the only correctness signal
+# available without a television. Deliberately NOT a prerequisite of `all`: the normal build is a
+# cross compile for the TV and must not be made to depend on a host toolchain run succeeding (a host
 # cargo failure has nothing to do with whether the ARM staticlib is buildable, and `make deploy`
 # on a machine mid-toolchain-churn should not be blocked by it). Run it before `make test`.
 #
@@ -214,8 +214,29 @@ test: deploy run
 # that actually calls into FFmpeg or GL fails to link by design. --lib keeps it to the crate's own
 # `#[cfg(test)] mod tests` blocks (there are no integration tests in tests/ — that directory is the
 # on-device Python harness, a different thing entirely).
-check:
+check: lint
 	cd rust-modules && PATH="$$HOME/.cargo/bin:$$PATH" cargo test --lib
+
+# `make lint` — the three clippy lints that catch a SHADOWED branch, the one bug class the unit
+# suite structurally cannot reach. `app.rs` shipped a duplicated `else if` whose empty body hid the
+# real arm, so OK on the Subtitles/Audio discs did nothing at all — no menu, no log line — and rustc
+# does not warn on a repeated condition. That dispatch lives inside the SDL event loop, so there is
+# no host test for it; the lint is the whole gate. Explicitly NAMED lints, not a group: `-A
+# clippy::all` first because this crate is not clippy-clean and making it so is not this gate's job,
+# and naming them means a nightly bump cannot silently widen what `make check` fails on. All three
+# are clean as of 2026-07-29 (so is `clippy::correctness` as a group, except ff.rs:1330's deliberate
+# `loop { … break; }`). `--all-targets` so the `#[cfg(test)]` blocks are linted too, not just the
+# lib. ~12s cold, <1s warm — clippy needs the nightly clippy component, which rustup's DEFAULT
+# profile ships (a `--profile minimal` nightly does not).
+#
+# `if_same_then_else` is the one with a legitimate false positive here: two deliberately-identical
+# arms, e.g. `if back { exit_player() } else if stop { exit_player() }` — which app.rs's key chain
+# is full of. The escape hatch is this repo's own habit: clippy suppresses it when each arm carries
+# its own comment. Comment the arms, do not reach for an `#[allow]`.
+lint:
+	cd rust-modules && PATH="$$HOME/.cargo/bin:$$PATH" cargo +nightly clippy --all-targets -- \
+	  -A clippy::all \
+	  -D clippy::ifs_same_cond -D clippy::same_functions_in_if_condition -D clippy::if_same_then_else
 
 # ipk assembly: deb-style ar archive; the NDK ar emits GNU format (macOS ar is BSD)
 ipk: pkg/plxnative
@@ -241,4 +262,4 @@ threadprobe: tools/threadprobe.c
 sockprobe: tools/sockprobe.c
 	$(CC) $(CFLAGS) -o pkg/sockprobe tools/sockprobe.c -lpthread
 
-.PHONY: all setup-env deploy run run-stream kill check test ipk clean threadprobe sockprobe
+.PHONY: all setup-env deploy run run-stream kill check lint test ipk clean threadprobe sockprobe

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -537,6 +537,10 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
         // The last SEGMENT the control row offered. Sticky: it is never cleared back to None, so
         // each segment raises the HUD exactly once per playback however often the row flickers.
         let mut last_offer: Option<(crate::metadata::MarkerKind, i64)> = None;
+        // Did a stand-in own the control row last frame? The reset below is the EDGE of a stand-in
+        // vanishing under the focus ring — see `player_hud::standin_left_the_ring`, which is where
+        // that rule is written down and tested.
+        let mut ctrl_was_standin = false;
         let mut marker_tried = false; // dev: the /tmp/plxnative-marker jump has been resolved
         // UP-from-the-top explicitly dismisses the HUD even while paused; any other player input
         // clears it. Without this, paused() would force the HUD permanently visible.
@@ -1407,7 +1411,8 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                                     held_sym = 0; // async route flip: don't repeat a held key into the next screen
                                 }
                             } else if vis && hud_nav.focus == 1 {
-                            } else if vis && hud_nav.focus == 1 {
+                                // …so the discs are what row 1 holds — the complement of the arm
+                                // above, and the row's only other occupant.
                                 // OK on a control button opens its panel (Subtitles / Audio)
                                 crate::ui::track_menu::open_tab(if hud_nav.btn == 0 { 1 } else { 0 });
                                 route = Route::Player { overlay: Overlay::Menu };
@@ -2227,13 +2232,16 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                         hud_nav.focus = 1;
                         hud_nav.btn = 0;
                     }
-                } else if ctrl.is_discs() && hud_nav.focus == 1 {
+                } else if crate::ui::player_hud::standin_left_the_ring(ctrl_was_standin, ctrl, hud_nav.focus == 1) {
                     // The stand-in went away under the focus ring. Without this the row swaps back
                     // to the discs with focus still on it and `btn` still 0, so the next OK opened
                     // the SUBTITLES menu instead of toggling pause — exactly the bug class HudNav's
-                    // own doc says it exists to kill.
+                    // own doc says it exists to kill. Strictly the EDGE: as a steady state it also
+                    // fired on a user who walked UP to the discs on purpose, yanking the ring back
+                    // the same frame and making OK on a disc unreachable by remote.
                     hud_nav = HudNav::HOME;
                 }
+                ctrl_was_standin = !ctrl.is_discs();
                 // While the countdown runs, hold the HUD up — a timer nobody can see is a cut to
                 // the next episode out of nowhere. And if focus has moved off the row, the user is
                 // driving the transport: cancel rather than yank them into the next episode.

--- a/rust-modules/src/ui/player_hud.rs
+++ b/rust-modules/src/ui/player_hud.rs
@@ -271,6 +271,24 @@ pub(crate) fn slot() -> ControlSlot {
     slot_for(crate::metadata::active_marker(), crate::route::up_next().is_some())
 }
 
+/// PURE edge: has a stand-in just vanished OUT FROM UNDER the focus ring, so the ring has to go
+/// back to the scrubber? `focused` is whether the control row currently holds focus. `was_standin`
+/// is the occupant on the last OVERLAY-FREE frame, not simply the last frame — the caller only
+/// samples it while the transport is bare, so an edge that happens behind an open track menu / Info
+/// card is held and fires on the frame the overlay closes, rather than being lost.
+///
+/// It exists because the row swapping from a Skip pill back to the discs leaves focus on the row
+/// with `btn` still 0, so the next OK opens the SUBTITLES menu instead of toggling pause.
+///
+/// **It is an EDGE, not a steady state**, and that is the whole reason it is a named function with
+/// a test. Written inline as `is_discs() && focused` it is also true on every frame of a user who
+/// deliberately walked UP to the Subtitles/Audio discs — the ring is then yanked back to the
+/// scrubber the same frame it arrives, so focus can never rest on a disc and OK on one is
+/// unreachable by remote. The pointer path never saw it, which is why the on-device suite did not.
+pub(crate) fn standin_left_the_ring(was_standin: bool, now: ControlSlot, focused: bool) -> bool {
+    was_standin && now.is_discs() && focused
+}
+
 /// x of control button `idx` (0 = Subtitles on the left, 1 = Audio on the right)
 fn btn_x(idx: i32) -> f32 {
     let audio_x = CTRL_RIGHT - BTN_S;
@@ -544,5 +562,26 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(intro, SkipAction::Seek(2_000 * 1_000_000));
+    }
+
+    /// The ring only goes back to the scrubber on the EDGE where a stand-in vanished under it.
+    /// As a steady state (`is_discs() && focused`, which is how it shipped) it fired on every
+    /// frame the user had walked UP to the Subtitles/Audio discs, so focus could not rest there
+    /// and OK on a disc never reached the track menu — invisible to the pointer path, and so to
+    /// the on-device suite.
+    #[test]
+    fn only_a_vanishing_standin_takes_the_focus_ring_back() {
+        let discs = slot_for(None, false);
+        let skip = slot_for(Some(marker(MarkerKind::Intro, false)), false);
+
+        // the edge it exists for: the pill was there last frame, the discs are back, ring on the row
+        assert!(standin_left_the_ring(true, discs, true));
+
+        // the steady state it must NOT fire on: the discs were already there, so nothing vanished
+        assert!(!standin_left_the_ring(false, discs, true), "walking UP to the discs is not a lost stand-in");
+
+        // nothing to take back if the ring is elsewhere, or if a stand-in still owns the row
+        assert!(!standin_left_the_ring(true, discs, false));
+        assert!(!standin_left_the_ring(true, skip, true));
     }
 }


### PR DESCRIPTION
Unit 1 of the parity-gap work — `docs/parity-gaps.md` §0, the one live regression rather than a
parity gap. **It turned out to be two regressions, both from c1691d1, and each on its own is fatal
to the same control**: deleting the dead `else if` alone does not restore the feature.

## 1. The shadowed arm (`app.rs`, the one the audit found)

```rust
} else if vis && hud_nav.focus == 1 {          // EMPTY body — wins
} else if vis && hud_nav.focus == 1 {          // byte-identical — unreachable
    crate::ui::track_menu::open_tab(...);
```

OK on a focused Subtitles/Audio disc did nothing at all — no menu, no pause, no log line. Deleted
the empty arm. Rust does not warn on a repeated condition, which is why it survived review.

## 2. The focus reset was a steady state, not an edge (found while preparing device verification)

`app.rs`'s per-frame block ran `} else if ctrl.is_discs() && hud_nav.focus == 1 { hud_nav =
HudNav::HOME; }` on **every** iteration of `while running`, not on a transition. Its own comment
describes an edge: a Skip / Up-Next stand-in vanishing out from under the focus ring, which would
otherwise leave the ring on the row with `btn` still 0, so the next OK opened Subtitles instead of
toggling pause.

As a steady state it also fired on a user who walked UP to the discs deliberately. The ordering
inside one iteration is `while SDL_PollEvent` (UP sets `focus = 1`) → this block (sets it straight
back to 0) → the draw, so `draw_hud` never once received `focus == 1` with `Discs`. The ring could
not render on a disc, let alone rest there long enough to press OK. Confirmed by an independent
review of the diff.

The rule now lives in `player_hud::standin_left_the_ring(was_standin, now, focused)`, a pure
predicate beside `slot_for` — the one place it is written down and the one place it is tested — with
`ctrl_was_standin` tracked in the frame loop.

## Why nothing caught either one

The pointer path reaches `open_tab` through `icon_hit` in a *different* arm and never consults
either bug, and the on-device suite opens the track menu through `/tmp/plxnative-menupick`, which
calls `open_tab` / `focus_row` / `on_ok` directly — bypassing the key dispatch *and* the focus
lifetime. Every existing signal for this feature routed around both bugs.

## Can a host test lock this in?

**Bug 2: yes, and there is one.** `only_a_vanishing_standin_takes_the_focus_ring_back` asserts both
halves — the edge fires, the steady state does not.

**Bug 1: no, and I did not contort the code to fake one.** The dispatch is an if-chain inside the
SDL event loop over four local mutables; extracting it would mean restructuring ~28 lines of the
file four sibling agents are editing concurrently. A shadowed branch is also a bug *class* no unit
test can see, so the proportionate lock-in is a lint, not a test:

`make check` now runs `make lint` first — three **named** clippy lints (`ifs_same_cond`,
`same_functions_in_if_condition`, `if_same_then_else`). Re-introducing the deleted line makes it
exit 101 pointing at both arms (verified both ways). `-A clippy::all` comes first because this crate
is not clippy-clean and making it so is not this gate's job; the lints are named rather than a group
so a nightly bump cannot silently widen what `make check` fails on. ~12s cold, <1s warm.
`clippy::correctness` as a group is clean too, except `ff.rs:1330`'s deliberate `loop { … break; }`
— which is why the group was not adopted.

## Verification done

- `make check` — **59 passed** (58 baseline + 1), lint green.
- `make` — ARM cross-build green.
- Independent code review over the whole diff: both fixes confirmed correct, `btn` proven always in
  {0,1}, key and pointer proven to open the same tab, `ctrl_was_standin` proven to have no
  wrong-firing and no missed-edge path across overlays / route changes / a fresh session, and the
  three skip-intro / Up-Next on-device cases proven unaffected. Its findings on doc wording, an
  `if_same_then_else` false-positive shape, and the new nightly-clippy prerequisite are all folded
  in.

## Device verification: deferred to coordinator

Not run here — I released the TV queue per the policy change. **The playback suite is not needed**
(no playback, pipeline or drawing code changed; this is control flow). What *is* needed is the one
thing no automated case can reach: OK on a focused disc, **by remote**.

```sh
# 0. build this branch, then boot straight into playback of a MOVIE. rk=4 (The Substance) matters:
#    a movie has no intro/credits segment under the playhead, so ControlSlot::Discs owns the
#    control row rather than a Skip / Up-Next stand-in.
make
tools/tv-session.sh up --screen player=4

# 1. frames really presenting?  expect lines.
tools/tv-session.sh log 'FPS=.*route=player.*pos='

# 2. is the row actually the DISCS?  expect NOTHING. A hit here means a stand-in owns the row and
#    the run proves nothing — re-run step 0 (rk=1926 or rk=3 are also movies).
tools/tv-session.sh log 'marker offer:'

# 3. walk to the control row BY REMOTE. `tv-session.sh key` sends each token as its own ssh round
#    trip, so they land in SEPARATE frames — which is exactly what bug 2 was about; a single-frame
#    burst would pass even against the broken build. down,down,down normalises from ANY HUD state
#    (hidden / scrubber / control row / tabs) onto the tabs row; up,up then walks
#    tabs -> scrubber -> control row.
tools/tv-session.sh key down down down up up

# 4. OK on the focused disc
tools/tv-session.sh key ok

# 5. THE ASSERTION
tools/tv-session.sh log 'route=player overlay=menu'

# optional picture — the HUD is held up for as long as an overlay is open, so there is no rush
tools/tv-session.sh shot /tmp/track-menu.png
tools/tv-session.sh down
```

**PASS** = at least one `FPS=… route=player overlay=menu` line at step 5. That single line proves
*both* fixes at once:

- `overlay=menu` can only be set by the arm that was shadowed — `tv-session.sh` arms neither
  `/tmp/plxnative-menu` nor `/tmp/plxnative-menupick`, and no pointer click was sent; and
- that arm requires `hud_nav.focus == 1` at the instant OK arrives, so focus must have *survived
  across frames* on the discs, which the old per-frame reset made impossible.

**FAIL** = `overlay=none` throughout. Then OK on the disc still does nothing.

One flake to know: the HUD linger is 4500 ms and every key press refreshes it, so step 3 is safe as
long as consecutive ssh round trips are under ~4.5 s apart. If the link is slow the HUD can
auto-hide mid-walk and focus parks back on the scrubber — just re-run step 3, it is idempotent.

If you want belt-and-braces on the half of the control row I *did* touch (the stand-in edge), the
one case that exercises it through the same FIFO is:

```sh
./tests/run.py --filter morning_show_skip_intro_press
```

It waits for `marker offer:` and writes `ok` to the FIFO — focus claimed on a Skip pill, OK
activating it. My edge guard is false in that state (a stand-in still owns the row), so it must
still pass; reviewed as unaffected, but it is the cheapest live confirmation. **Skip the FPS
suite**: nothing here changes what is drawn or how often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
