### PR TITLE
player: image subtitles scale from the canvas they were authored against

### DIFF
--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -2433,9 +2433,13 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                     crate::system::clear_opaque_region();
                     glClearColor(0.0, 0.0, 0.0, 0.0);
                     glClear(GL_COLOR_BUFFER_BIT);
-                    crate::ui::player_hud::draw_subtitle_bitmap(); // PGS/VobSub image subs
                     let hud_up = hud_shown(now, hud_until(), paused(), hud_dismissed) || crate::player::loading();
-                    crate::ui::player_hud::draw_subtitles(hud_up || matches!(route, Route::Player { overlay: Overlay::Menu }));
+                    // Both subtitle paths lift clear of the transport for the same reason and by
+                    // the same test — an open track menu counts, since that is exactly when the
+                    // user is reading the bottom of the screen.
+                    let subs_lift = hud_up || matches!(route, Route::Player { overlay: Overlay::Menu });
+                    crate::ui::player_hud::draw_subtitle_bitmap(subs_lift); // PGS/VobSub image subs
+                    crate::ui::player_hud::draw_subtitles(subs_lift);
                     if hud_up || !matches!(route, Route::Player { overlay: Overlay::None }) {
                         // hide the transport middle behind the Info card / Chapters strip
                         crate::ui::player_hud::draw_hud(ctrl, hud_nav.focus, hud_nav.btn, hud_nav.tab, now, !matches!(route, Route::Player { overlay: Overlay::Info | Overlay::Chapters }));

--- a/rust-modules/src/ff.rs
+++ b/rust-modules/src/ff.rs
@@ -250,6 +250,13 @@ extern "C" {
     ) -> c_int;
     fn avsubtitle_free(sub: *mut AVSubtitle);
     fn avcodec_free_context(ctx: *mut *mut AVCodecContext);
+    // Scratch AVCodecParameters for `sub_canvas` — library-allocated so its true size (136 on
+    // this build) is never our problem, and `from_context` starts by av_freep-ing par->extradata.
+    // Both PRESENT on the device's own libavcodec.so.57.89.100 (`tools/abi-probe.sh has
+    // libavcodec.so.57 avcodec_parameters_alloc avcodec_parameters_free`, 2026-07-29) — the stub
+    // .so links either way, so this is checked, not assumed.
+    fn avcodec_parameters_alloc() -> *mut AVCodecParameters;
+    fn avcodec_parameters_free(par: *mut *mut AVCodecParameters);
     fn avcodec_find_encoder_by_name(name: *const c_char) -> *const AVCodec;
     // MPEG1 encode (dev capture stream, venc section)
     fn avcodec_send_frame(ctx: *mut AVCodecContext, frame: *const c_void) -> c_int;
@@ -772,11 +779,98 @@ unsafe fn open_sub_decoder(cp: *const AVCodecParameters) -> *mut AVCodecContext 
     ctx
 }
 
+/// The subtitle stream's AUTHORING CANVAS (the coordinate space the decoded rects' x/y/w/h are
+/// expressed in), or (0,0) if this decoder never declared one. 1920×1080 for Blu-ray PGS,
+/// 720×480/576 for a DVD VobSub rip, 3840×2160 for some 4K PGS — assuming 1080p unconditionally
+/// is what made VobSub land as a postage stamp in the corner.
+///
+/// Read WITHOUT a raw struct poke: `avcodec_parameters_from_context` copies the decoder's
+/// width/height into the AVCodecParameters this crate already models (and whose width/height at
+/// +48/+52 the video path has used on-device since the demuxer landed), so the whole read runs
+/// inside the library's own code and needs no new ABI offset.
+///
+/// ABI proof (device's own `libavcodec.so.57.89.100`, disassembled 2026-07-29 — the build ships
+/// stripped, so this is the primary evidence, not a header):
+/// `avcodec_parameters_from_context+0x88` is `cmp r3,#3 / beq +0x13c` (AVMEDIA_TYPE_SUBTITLE ==
+/// 3) and `+0x13c` is exactly `ldr r2,[r5,#124] / ldr r3,[r5,#128] / str r2,[r4,#48] /
+/// str r3,[r4,#52]` — so THIS build does carry the subtitle case, and it corroborates
+/// `OFF_CTX_WIDTH`/`OFF_CTX_HEIGHT` (124/128) and AVCodecParameters.width/height (48/52) at the
+/// same time. The prologue's `memset(par, 0, 136)` likewise confirms the modeled sizeof = 136.
+///
+/// Must be called AFTER a decode: PGS carries the canvas in the presentation composition segment,
+/// so pgssubdec only sets it while decoding (dvdsub sets it at open, from the .idx `size:` line).
+unsafe fn sub_canvas(dec: *mut AVCodecContext) -> (i32, i32) {
+    let par = avcodec_parameters_alloc();
+    if par.is_null() {
+        return (0, 0);
+    }
+    let wh = if avcodec_parameters_from_context(par, dec) >= 0 {
+        ((*par).width, (*par).height)
+    } else {
+        (0, 0)
+    };
+    let mut p = par;
+    avcodec_parameters_free(&mut p);
+    // A canvas we cannot make sense of is worse than none: report unknown and let the renderer
+    // fall back to 1:1 rather than scale the cue by a garbage ratio. The window spans every real
+    // authoring canvas with room to spare (the smallest in the wild is DVD's 720×480) and rejects
+    // a decoder that reports a rect size, a zero, or an uninitialised field.
+    const MIN: c_int = 160;
+    const MAX: c_int = 8192;
+    if wh.0 < MIN || wh.1 < MIN || wh.0 > MAX || wh.1 > MAX {
+        (0, 0)
+    } else {
+        wh
+    }
+}
+
+/// Convert one decoded PAL8 subtitle rect to a straight-alpha RGBA bitmap (palette entries are
+/// 0xAARRGGBB), or None if the decoder left it unusable. Coords are passed through in the
+/// stream's own authoring canvas — the renderer scales, not us.
+///
+/// Every field here is unvalidated data from a decoder fed by the network, and `usize` is 32
+/// bits on this target, so the size is bounded BEFORE it is multiplied: `w*h*4` for a rect the
+/// decoder claimed was 40000×40000 wraps to a small allocation, and the write loop would then
+/// run off the end of it (a panic on the demux thread, which is outside `ui::guard`).
+unsafe fn rect_to_rgba(r: *const AVSubtitleRect) -> Option<crate::player::SubRect> {
+    if r.is_null() {
+        return None;
+    }
+    let (x, y, w, h, stride) = ((*r).x, (*r).y, (*r).w, (*r).h, (*r).linesize[0]);
+    let idx = (*r).data[0];
+    let pal = (*r).data[1] as *const u32;
+    // no real subtitle bitmap approaches 8192 on a side — the largest authoring canvas in the
+    // wild is 4K, and a rect cannot usefully exceed its own canvas
+    const MAX_SIDE: c_int = 8192;
+    if idx.is_null() || pal.is_null() || w <= 0 || h <= 0 || stride < w || w > MAX_SIDE || h > MAX_SIDE {
+        return None;
+    }
+    let (wu, hu, su) = (w as usize, h as usize, stride as usize);
+    let bytes = match wu.checked_mul(hu).and_then(|n| n.checked_mul(4)) {
+        Some(n) => n,
+        None => return None,
+    };
+    let mut rgba = vec![0u8; bytes];
+    for row in 0..hu {
+        let src = idx.add(row * su);
+        for col in 0..wu {
+            let p = *pal.add(*src.add(col) as usize); // 0xAARRGGBB (native u32)
+            let o = (row * wu + col) * 4;
+            rgba[o] = (p >> 16) as u8; // R
+            rgba[o + 1] = (p >> 8) as u8; // G
+            rgba[o + 2] = p as u8; // B
+            rgba[o + 3] = (p >> 24) as u8; // A
+        }
+    }
+    Some(crate::player::SubRect { x, y, w, h, rgba })
+}
+
 /// Decode one image-subtitle packet for the SELECTED track and push it to the render store.
-/// A CLEAR (num_rects==0) closes the open cue; otherwise rect 0's PAL8 bitmap is converted to
-/// straight-alpha RGBA (palette entries are 0xAARRGGBB) and pushed with start = packet pts (the
-/// end is set later by the next CLEAR or superseding set). The PGS authoring canvas is 1920×1080
-/// (== our UI, confirmed on-device), so x/y/w/h are pixel coords used directly by the renderer.
+/// A CLEAR (num_rects==0) closes the open cue; otherwise EVERY rect of the display set is
+/// converted to straight-alpha RGBA and pushed as one cue with start = packet pts (the end is
+/// set later by the next CLEAR or superseding set). Two-line dialogue and sign-plus-dialogue are
+/// authored as separate rects of the SAME display set, so dropping all but rect 0 (what this did
+/// before) silently lost half the line. The set's canvas comes from `sub_canvas`.
 unsafe fn decode_bitmap_cue(dec: *mut AVCodecContext, pkt: *mut AVPacket, track: c_int, st: *mut AVStream) {
     let mut sub: AVSubtitle = std::mem::zeroed();
     let mut got: c_int = 0;
@@ -789,30 +883,36 @@ unsafe fn decode_bitmap_cue(dec: *mut AVCodecContext, pkt: *mut AVPacket, track:
         avsubtitle_free(&mut sub);
         return;
     }
-    let r0 = *sub.rects;
-    let (x, y, w, h, stride) = ((*r0).x, (*r0).y, (*r0).w, (*r0).h, (*r0).linesize[0]);
-    let idx = (*r0).data[0];
-    let pal = (*r0).data[1] as *const u32;
-    if !idx.is_null() && !pal.is_null() && w > 0 && h > 0 && stride >= w {
-        let (wu, hu, su) = (w as usize, h as usize, stride as usize);
-        let mut rgba = vec![0u8; wu * hu * 4];
-        for row in 0..hu {
-            let src = idx.add(row * su);
-            for col in 0..wu {
-                let p = *pal.add(*src.add(col) as usize); // 0xAARRGGBB (native u32)
-                let o = (row * wu + col) * 4;
-                rgba[o] = (p >> 16) as u8; // R
-                rgba[o + 1] = (p >> 8) as u8; // G
-                rgba[o + 2] = p as u8; // B
-                rgba[o + 3] = (p >> 24) as u8; // A
-            }
+    // A pathological display set cannot be allowed to bloat the 24 MB store or the renderer's
+    // texture set; DVB regions are the realistic source of many rects, PGS allows at most 2.
+    const MAX_RECTS: usize = 8;
+    let n = (sub.num_rects as usize).min(MAX_RECTS);
+    let mut rects = Vec::with_capacity(n);
+    for i in 0..n {
+        if let Some(r) = rect_to_rgba(*sub.rects.add(i)) {
+            rects.push(r);
         }
+    }
+    if !rects.is_empty() {
+        let (cw, ch) = sub_canvas(dec);
         if track == crate::player::desired_sub_idx() {
-            crate::player::log(&format!("image cue [{}ms] {w}x{h} at {x},{y}", pts / 1_000_000));
+            let r0 = &rects[0];
+            crate::player::log(&format!(
+                "image cue [{}ms] {}x{} at {},{} rects={} canvas={cw}x{ch}",
+                pts / 1_000_000,
+                r0.w,
+                r0.h,
+                r0.x,
+                r0.y,
+                rects.len()
+            ));
         }
-        crate::player::push_subtitle_bitmap(track, pts, x, y, w, h, rgba);
-        if sub.num_rects > 1 {
-            crate::player::log(&format!("ff: image-sub track#{track} {} rects (only #0 shown)", sub.num_rects));
+        crate::player::push_subtitle_bitmap(track, pts, cw, ch, rects);
+        if sub.num_rects as usize > MAX_RECTS {
+            crate::player::log(&format!(
+                "ff: image-sub track#{track} {} rects (capped at {MAX_RECTS})",
+                sub.num_rects
+            ));
         }
     }
     avsubtitle_free(&mut sub);

--- a/rust-modules/src/player/CLAUDE.md
+++ b/rust-modules/src/player/CLAUDE.md
@@ -68,8 +68,12 @@ the seam or the Engine, so its presence in a signature keeps meaning something.
   doubles it). See `[[audio-payload-codecs]]`.
 - **Subtitles are client-rendered here — the TV's HW subtitle engine is URI-mode only** and
   unreachable in buffer-feed. Both text (SRT/ASS) and image (PGS/VobSub) subs are decoded and drawn by
-  us (canvas authored at 1920×1080); don't expect the pipeline to burn or overlay them. See
-  `[[tv-subtitle-engine]]` and the `plex/` soft-subs note.
+  us; don't expect the pipeline to burn or overlay them. See `[[tv-subtitle-engine]]` and the `plex/`
+  soft-subs note. An image sub's rect coords are in **the subtitle stream's own authoring canvas** —
+  1920×1080 for Blu-ray PGS but 720×480/576 for a DVD VobSub rip — so `ff::sub_canvas` reads that
+  canvas off the decoder (via `avcodec_parameters_from_context`, no raw struct offset; the ABI proof
+  is in its doc comment) and `player_hud::sub_screen_rect` scales the whole display set into the
+  video rect. Assuming 1080p unconditionally is what made VobSub render as a corner postage stamp.
 - **A seek NEVER interrupts the demuxer.** The pump publishes the target in `seek_to_ns` and the
   demux thread — the only thread that touches the `AVFormatContext` — `av_seek_frame`s on it
   between two reads. Do not reintroduce an interrupt: the pump used to `shutdown(2)` the socket to

--- a/rust-modules/src/player/mod.rs
+++ b/rust-modules/src/player/mod.rs
@@ -19,6 +19,8 @@ pub(crate) mod threads;
 
 use crate::task::MainThread;
 use shared::{Shared, SubBitmap, SubCue, Transport};
+/// one rect of an image-subtitle display set — the demuxer builds them, the HUD draws them
+pub(crate) use shared::SubRect;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_long};
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -248,7 +250,14 @@ pub(crate) fn active_subtitle(now_ns: i64) -> Option<String> {
 /// bitmaps and pushes them here; the renderer (M) reads the active one for the playpos. A new
 /// display-set supersedes any still-open cue on the same track (PGS signals the end via a later
 /// CLEAR or a superseding set, both handled here). Bounded by time like the text store.
-pub(crate) fn push_subtitle_bitmap(track: i32, start_ns: i64, x: i32, y: i32, w: i32, h: i32, rgba: Vec<u8>) {
+///
+/// `cw`/`ch` are the stream's authoring canvas (0 = the decoder never declared one) and every
+/// rect's coords are relative to it — the renderer scales the whole set into the video rect, so
+/// a 720×480 VobSub and a 1920×1080 PGS land the same size on screen.
+pub(crate) fn push_subtitle_bitmap(track: i32, start_ns: i64, cw: i32, ch: i32, rects: Vec<SubRect>) {
+    if rects.is_empty() {
+        return;
+    }
     let mut v = SHARED.sub_bitmaps.lock().unwrap();
     for c in v.iter_mut() {
         if c.track == track && c.end_ns == i64::MAX {
@@ -257,16 +266,26 @@ pub(crate) fn push_subtitle_bitmap(track: i32, start_ns: i64, x: i32, y: i32, w:
     }
     let floor = SHARED.playpos_ns.load(Relaxed) - 2_000_000_000;
     v.retain(|c| c.end_ns >= floor);
-    v.push(SubBitmap { track, start_ns, end_ns: i64::MAX, x, y, w, h, rgba });
+    v.push(SubBitmap { track, start_ns, end_ns: i64::MAX, cw, ch, rects });
     // Hard RAM ceiling: decoding ALL image tracks means several are buffered at once, so bound
-    // the store by total RGBA bytes (not count) and evict the oldest first. The time-retain above
-    // already drops most cues behind the playhead; this is the safety valve for many-track 4K
-    // titles. ~24 MB is comfortable headroom on the direct-play path.
+    // the store by total RGBA bytes (not count). ~24 MB is comfortable headroom on the direct-play
+    // path. A multi-rect display set counts as the sum of its rects, which is why the budget is
+    // bytes and not cue count — and which is what made the eviction ORDER start to matter.
+    //
+    // `v` is in demux (increasing-pts) order and the time-retain above has already dropped
+    // everything more than 2s behind the playhead, so `v[0]` is the cue AT or just behind the
+    // playhead — the one about to be drawn — while the tail is the demuxer's 10-20s read-ahead.
+    // Evicting index 0 (what this did) therefore blanks the subtitle the viewer is reading and
+    // keeps cues they have not reached. So: drop a cue the playhead has already passed first,
+    // since it can never be shown again; only when none is left does the FAR END of the
+    // read-ahead go, because that cue is at least not on screen yet.
     const BUDGET: usize = 24 * 1024 * 1024;
-    let mut total: usize = v.iter().map(|c| c.rgba.len()).sum();
+    let mut total: usize = v.iter().map(|c| c.bytes()).sum();
+    let now = SHARED.playpos_ns.load(Relaxed);
     while total > BUDGET && v.len() > 1 {
-        total -= v[0].rgba.len();
-        v.remove(0);
+        let i = v.iter().position(|c| c.end_ns <= now).unwrap_or(v.len() - 1);
+        total -= v[i].bytes();
+        v.remove(i);
     }
 }
 /// A CLEAR display-set (num_rects==0): close the currently-open cue on this track at `end_ns`.
@@ -291,15 +310,16 @@ pub(crate) fn active_bitmap_key(now_ns: i64) -> Option<i64> {
         .find(|c| c.track == sel && now_ns >= c.start_ns && now_ns < c.end_ns)
         .map(|c| c.start_ns)
 }
-/// Fetch (x,y,w,h,rgba) for the selected track's cue with this `start_ns` key. Clones the
-/// bitmap once (only when the renderer sees a new key), so the per-frame path stays cheap.
-pub(crate) fn bitmap_by_key(key: i64) -> Option<(i32, i32, i32, i32, Vec<u8>)> {
+/// Fetch (canvas_w, canvas_h, rects) for the selected track's display set with this `start_ns`
+/// key. Clones the bitmaps once (only when the renderer sees a new key), so the per-frame path
+/// stays cheap.
+pub(crate) fn bitmap_by_key(key: i64) -> Option<(i32, i32, Vec<SubRect>)> {
     let sel = SHARED.desired_sub_idx.load(Relaxed);
     let v = SHARED.sub_bitmaps.lock().unwrap();
     v.iter()
         .rev()
         .find(|c| c.track == sel && c.start_ns == key)
-        .map(|c| (c.x, c.y, c.w, c.h, c.rgba.clone()))
+        .map(|c| (c.cw, c.ch, c.rects.clone()))
 }
 /// extract displayable text from a subtitle block (SRT = raw UTF-8; ASS = the field
 /// after the 8th comma), stripping tags/override codes and normalizing line breaks.
@@ -404,4 +424,66 @@ pub extern "C" fn acb_on_event(ev: c_long, reply: *const c_char) {
         };
         log(&format!("acb_cb ev={ev} reply={r}"));
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: i32, y: i32, w: i32, h: i32) -> SubRect {
+        SubRect { x, y, w, h, rgba: vec![0u8; (w * h * 4) as usize] }
+    }
+
+    /// The image-subtitle store, exercised as a display SET rather than a single bitmap. Three
+    /// invariants moved when multi-rect landed and none of them is observable on the host except
+    /// here: every rect of a set survives the round trip under ONE key (so a two-line PGS cue is
+    /// not silently halved); a later set still closes the one still showing; and the RAM ceiling
+    /// counts a set's rects together, so a multi-rect cue cannot smuggle bytes past the budget.
+    ///
+    /// Takes the crate-wide `testlock` — `SHARED` is a process-global the whole player shares.
+    #[test]
+    fn an_image_display_set_round_trips_whole_and_is_superseded_as_a_unit() {
+        let _g = crate::testlock::serial();
+        SHARED.sub_bitmaps.lock().unwrap().clear();
+        SHARED.playpos_ns.store(0, Relaxed);
+        SHARED.desired_sub_idx.store(0, Relaxed);
+
+        // a two-rect set (dialogue plus a sign), authored on a DVD canvas
+        push_subtitle_bitmap(0, 1_000, 720, 480, vec![rect(60, 400, 600, 60), rect(100, 20, 200, 40)]);
+        let key = active_bitmap_key(1_500).expect("the set should be active at its start");
+        let (cw, ch, rects) = bitmap_by_key(key).expect("the active key must resolve");
+        assert_eq!((cw, ch), (720, 480), "the authoring canvas travels with the set");
+        assert_eq!(rects.len(), 2, "BOTH rects must survive — rect 0 only was the bug");
+        assert_eq!((rects[1].x, rects[1].y), (100, 20));
+
+        // the next set closes the open one AT ITS OWN START — a display set stays up until the
+        // one that replaces it begins, so the handover is seamless and never double-shows
+        push_subtitle_bitmap(0, 5_000, 720, 480, vec![rect(60, 400, 600, 60)]);
+        assert_eq!(active_bitmap_key(4_999), Some(1_000), "the first set holds right up to the handover");
+        assert_eq!(active_bitmap_key(5_000), Some(5_000), "and the second takes over on that exact ns");
+
+        // an empty set is not a cue: it must not land and must not close what is showing
+        push_subtitle_bitmap(0, 6_000, 720, 480, Vec::new());
+        assert_eq!(active_bitmap_key(5_500), Some(5_000));
+
+        // The byte budget charges a set for ALL its rects (2 x 4 MB here), and — the part that
+        // only matters once a set can be big — it must not evict the cue the viewer is READING.
+        // The playhead sits inside the 5_000 cue, so that one has to survive four 8 MB sets
+        // arriving from the demuxer's read-ahead; what goes is the far end of that read-ahead.
+        SHARED.playpos_ns.store(5_500, Relaxed);
+        for i in 0..4 {
+            push_subtitle_bitmap(0, 10_000 + i, 720, 480, vec![rect(0, 0, 1024, 1024), rect(0, 0, 1024, 1024)]);
+        }
+        let v = SHARED.sub_bitmaps.lock().unwrap();
+        let total: usize = v.iter().map(|c| c.bytes()).sum();
+        assert!(total <= 24 * 1024 * 1024, "the store stayed inside its ceiling ({total} bytes)");
+        assert!(v.iter().any(|c| c.start_ns == 5_000), "the cue under the playhead was not evicted");
+        drop(v);
+        assert_eq!(active_bitmap_key(5_500), Some(5_000), "and it is still the one on screen");
+
+        // leave the globals as they were found — `desired_sub_idx` deliberately survives a reset
+        // (shared.rs), so a test that leaves it selected changes what the NEXT one sees
+        SHARED.sub_bitmaps.lock().unwrap().clear();
+        SHARED.desired_sub_idx.store(-1, Relaxed);
+    }
 }

--- a/rust-modules/src/player/shared.rs
+++ b/rust-modules/src/player/shared.rs
@@ -19,20 +19,39 @@ pub(crate) struct SubCue {
     pub text: String,
 }
 
-/// one decoded image-subtitle cue (PGS/VobSub/DVB). `rgba` is a straight-alpha bitmap of
-/// `w`×`h` at position (`x`,`y`) in the PGS 1920×1080 authoring canvas — 1:1 with our UI, so
-/// it draws at those pixel coords directly. `end_ns` is i64::MAX until a CLEAR display-set
-/// (or a superseding set) truncates it. Unlike text cues we push ONLY the selected track
-/// (bitmaps are heavier than text on this RAM-tight TV), keyed by `start_ns` for the renderer.
-pub(crate) struct SubBitmap {
-    pub track: i32,
-    pub start_ns: i64,
-    pub end_ns: i64,
+/// one rect of a decoded image-subtitle display set. `rgba` is a straight-alpha bitmap of
+/// `w`×`h` at position (`x`,`y`) **in the subtitle stream's own authoring canvas** (see
+/// [`SubBitmap::cw`]) — NOT in screen pixels; the renderer scales it into the video rect.
+#[derive(Clone)]
+pub(crate) struct SubRect {
     pub x: i32,
     pub y: i32,
     pub w: i32,
     pub h: i32,
     pub rgba: Vec<u8>,
+}
+
+/// one decoded image-subtitle display set (PGS/VobSub/DVB) — every rect of it, not just the
+/// first: a two-line dialogue or a sign-plus-dialogue set is authored as several rects and they
+/// belong to the same on-screen moment. `end_ns` is i64::MAX until a CLEAR display-set (or a
+/// superseding set) truncates it. Unlike text cues we push ONLY the selected track (bitmaps are
+/// heavier than text on this RAM-tight TV), keyed by `start_ns` for the renderer.
+pub(crate) struct SubBitmap {
+    pub track: i32,
+    pub start_ns: i64,
+    pub end_ns: i64,
+    /// authoring-canvas width/height the rects' coords are expressed in — 1920×1080 for
+    /// Blu-ray PGS, 720×480/576 for a DVD VobSub rip, 3840×2160 for some 4K PGS. `0` = the
+    /// decoder never declared one, in which case the renderer falls back to 1:1.
+    pub cw: i32,
+    pub ch: i32,
+    pub rects: Vec<SubRect>,
+}
+impl SubBitmap {
+    /// total RGBA bytes held by this display set (what the store's byte budget counts)
+    pub fn bytes(&self) -> usize {
+        self.rects.iter().map(|r| r.rgba.len()).sum()
+    }
 }
 
 /// What playback is actually doing, as one value the UI can render from.

--- a/rust-modules/src/ui/player_hud.rs
+++ b/rust-modules/src/ui/player_hud.rs
@@ -84,7 +84,7 @@ pub(crate) fn draw_subtitles(hud_up: bool) {
     let n = lines.len() as f32;
     let cx = SCR_W * 0.5;
     // sit near the bottom normally; lift above the scrubber/tabs while the HUD is up
-    let baseline = if hud_up { SCR_H - 300.0 } else { SCR_H - 100.0 };
+    let baseline = if hud_up { SUB_CEIL_Y } else { SUB_BASE_Y };
     let block_top = baseline - n * lh;
     let white = [1.0f32, 1.0, 1.0, 1.0]; // subtitles stay pure white for legibility (carve-out)
     let outline = theme::scrim_black(0.85);
@@ -101,38 +101,118 @@ pub(crate) fn draw_subtitles(hud_up: bool) {
     }
 }
 
-/// Client-rendered IMAGE subtitles (PGS/VobSub): composite the active decoded bitmap over the
-/// video at its 1920×1080 canvas coords (== our UI, so used directly). Caches the GL texture and
-/// re-uploads only when the active cue changes (every few seconds). Main-thread only (GL). This
-/// is the image counterpart to draw_subtitles — a selected track is either text or image, so at
-/// most one of the two draws a cue at a time.
-pub(crate) fn draw_subtitle_bitmap() {
-    static mut TEX: c_uint = 0;
+/// Subtitle baseline: where the caption block sits with the transport DOWN, and the ceiling it
+/// lifts to with the transport UP (clear of the scrubber, buttons and tabs). Both paths share
+/// them: text lifts by moving its baseline, images lift by however much they overhang the
+/// ceiling — otherwise a bottom-positioned PGS cue sits behind the scrim while the user seeks.
+const SUB_BASE_Y: f32 = SCR_H - 100.0;
+const SUB_CEIL_Y: f32 = SCR_H - 300.0;
+
+/// Map a decoded image-subtitle rect from the stream's `cw`×`ch` authoring canvas onto the video
+/// rect — which is always the full panel here (the video track is authored 1920×1080; see the
+/// root CLAUDE.md). A subtitle canvas is the picture's own storage grid, so this is exactly the
+/// stretch the TV applies to the video itself: identity for 1080p PGS, 2.67×/2.25 for a 720×480
+/// NTSC VobSub, 0.5× for a 4K PGS track. `cw`/`ch` of 0 means the decoder never declared a canvas
+/// — then the rect is used 1:1, which is what this path did unconditionally before.
+///
+/// Deliberately NOT snapped to whole pixels: this is scaled content, and the crispness contract
+/// (root CLAUDE.md) snaps 1:1-texel content only.
+fn sub_screen_rect(r: (i32, i32, i32, i32), cw: i32, ch: i32) -> Rect {
+    let sx = if cw > 0 { SCR_W / cw as f32 } else { 1.0 };
+    let sy = if ch > 0 { SCR_H / ch as f32 } else { 1.0 };
+    Rect::new(r.0 as f32 * sx, r.1 as f32 * sy, r.2 as f32 * sx, r.3 as f32 * sy)
+}
+
+/// How far UP to shift the rects of a display set that overhang the transport, so they clear it.
+/// Nothing moves while the HUD is down, and the shift never exceeds the overhanging group's own
+/// top, so a set too tall to lift is clamped rather than pushed off the top of the screen.
+///
+/// The lift is measured over the OVERHANGING rects only, and (per [`overhangs`]) applies only to
+/// them. Measuring the whole set breaks the case multi-rect adds: a set carrying a sign at
+/// y≈100 and dialogue at y≈950 would clamp the lift to 100 — sliding the sign for no reason
+/// while leaving the dialogue still behind the scrim. Measuring the group and moving it as ONE
+/// unit is also why this is not a per-rect lift: two-line dialogue is two rects with different
+/// overhangs, and lifting each by its own would collapse them onto each other.
+fn hud_lift<I: Iterator<Item = Rect>>(rects: I, hud_up: bool) -> f32 {
+    if !hud_up {
+        return 0.0;
+    }
+    let (mut top, mut bottom) = (f32::MAX, f32::MIN);
+    for r in rects.filter(|r| overhangs(*r)) {
+        top = top.min(r.y);
+        bottom = bottom.max(r.y + r.h);
+    }
+    if top > bottom {
+        return 0.0; // nothing overhangs
+    }
+    (bottom - SUB_CEIL_Y).max(0.0).min(top.max(0.0))
+}
+
+/// Does this rect reach below the transport ceiling? Only such rects take the lift.
+fn overhangs(r: Rect) -> bool {
+    r.y + r.h > SUB_CEIL_Y
+}
+
+/// Client-rendered IMAGE subtitles (PGS/VobSub): composite the active decoded display set over
+/// the video, scaled from the subtitle stream's own authoring canvas into the video rect
+/// (`sub_screen_rect`) and lifted clear of the transport when `hud_up` (`hud_lift`). EVERY rect
+/// of the set is drawn — two-line dialogue and sign-plus-dialogue are authored as separate rects.
+/// Caches one GL texture per rect and re-uploads only when the active cue changes (every few
+/// seconds); the cached rects are the unlifted screen rects, so the lift can follow the HUD
+/// frame by frame without re-uploading. Main-thread only (GL). This is the image counterpart to
+/// draw_subtitles — a selected track is either text or image, so at most one of the two draws a
+/// cue at a time.
+pub(crate) fn draw_subtitle_bitmap(hud_up: bool) {
+    use std::ptr::addr_of_mut;
+    static mut SET: Vec<(c_uint, Rect)> = Vec::new();
     static mut KEY: i64 = i64::MIN;
-    static mut RECT: (f32, f32, f32, f32) = (0.0, 0.0, 0.0, 0.0);
+    // The cache key is (track, start_ns), not start_ns alone: two image tracks of the same file
+    // routinely start a display set on the SAME pts, so keying on the timestamp alone leaves the
+    // outgoing track's bitmap on screen after a switch between two image tracks.
+    static mut SEL: i32 = i32::MIN;
     unsafe {
-        if crate::player::desired_sub_idx() < 0 {
-            if TEX != 0 {
-                delete_tex(TEX);
-                TEX = 0;
+        let set = &mut *addr_of_mut!(SET);
+        let sel = crate::player::desired_sub_idx();
+        if sel < 0 {
+            for (t, _) in set.drain(..) {
+                delete_tex(t);
             }
             KEY = i64::MIN;
+            SEL = i32::MIN; // reset BOTH halves of the key — neither should prop the other up
             return;
         }
         match crate::player::active_bitmap_key(crate::player::playpos_ns()) {
             None => KEY = i64::MIN, // gap between cues — draw nothing this frame
             Some(k) => {
-                if k != KEY {
-                    if let Some((x, y, w, h, rgba)) = crate::player::bitmap_by_key(k) {
-                        TEX = upload_rgba(TEX, w, h, rgba.as_ptr());
-                        RECT = (x as f32, y as f32, w as f32, h as f32);
-                        KEY = k;
-                    } else {
-                        return; // cue evicted between key lookup and fetch
+                if k != KEY || sel != SEL {
+                    let (cw, ch, rects) = match crate::player::bitmap_by_key(k) {
+                        Some(v) => v,
+                        None => return, // cue evicted between key lookup and fetch
+                    };
+                    // retire the surplus first, then re-spec the ids we keep: upload_rgba reuses
+                    // a non-zero id, so a steady 1-rect stream never allocates a texture twice.
+                    for (t, _) in set.drain(rects.len().min(set.len())..) {
+                        delete_tex(t);
                     }
+                    for (i, r) in rects.iter().enumerate() {
+                        let dst = sub_screen_rect((r.x, r.y, r.w, r.h), cw, ch);
+                        let prev = set.get(i).map_or(0, |(t, _)| *t);
+                        let tex = upload_rgba(prev, r.w, r.h, r.rgba.as_ptr());
+                        match set.get_mut(i) {
+                            Some(slot) => *slot = (tex, dst),
+                            None => set.push((tex, dst)),
+                        }
+                    }
+                    KEY = k;
+                    SEL = sel;
                 }
+                let lift = hud_lift(set.iter().map(|(_, r)| *r), hud_up);
                 let white = [1.0f32, 1.0, 1.0, 1.0];
-                Painter::root().tex(TEX, Rect::new(RECT.0, RECT.1, RECT.2, RECT.3), 0.0, white);
+                let p = Painter::root();
+                for (tex, r) in set.iter() {
+                    let dy = if overhangs(*r) { lift } else { 0.0 };
+                    p.tex(*tex, Rect::new(r.x, r.y - dy, r.w, r.h), 0.0, white);
+                }
             }
         }
     }
@@ -544,5 +624,95 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(intro, SkipAction::Seek(2_000 * 1_000_000));
+    }
+
+    fn close(a: f32, b: f32) -> bool {
+        (a - b).abs() < 0.01
+    }
+    fn assert_rect(r: Rect, x: f32, y: f32, w: f32, h: f32) {
+        assert!(
+            close(r.x, x) && close(r.y, y) && close(r.w, w) && close(r.h, h),
+            "got ({}, {}, {}, {}), want ({x}, {y}, {w}, {h})",
+            r.x,
+            r.y,
+            r.w,
+            r.h
+        );
+    }
+
+    /// A 1080p-authored PGS rect must land EXACTLY where it always did — the scale is identity,
+    /// not merely close to it, or every Blu-ray subtitle in the library moves a pixel.
+    #[test]
+    fn image_sub_1080p_canvas_is_identity() {
+        assert_rect(sub_screen_rect((300, 900, 1320, 96), 1920, 1080), 300.0, 900.0, 1320.0, 96.0);
+    }
+
+    /// The bug this unit exists for: a DVD VobSub rip is authored on a 720×480 canvas, so drawn
+    /// 1:1 it is a postage stamp covering the top-left third of the panel. Scaled from its own
+    /// canvas it spans the picture and sits at the bottom, exactly like the PGS case above.
+    #[test]
+    fn image_sub_dvd_canvas_fills_the_panel() {
+        // a full-width, near-bottom VobSub line
+        assert_rect(sub_screen_rect((0, 400, 720, 60), 720, 480), 0.0, 900.0, 1920.0, 135.0);
+        // and an inset one keeps its position within the picture
+        let r = sub_screen_rect((180, 240, 360, 48), 720, 480);
+        assert_rect(r, 480.0, 540.0, 960.0, 108.0);
+        assert!(close(r.x + r.w * 0.5, SCR_W * 0.5), "a canvas-centred rect stays centred");
+    }
+
+    /// PAL (720×576) and 4K PGS (3840×2160) are the other two canvases in the wild; the 4K one
+    /// scales DOWN, which the old 1:1 path drew at double size and half off-screen.
+    #[test]
+    fn image_sub_pal_and_4k_canvases() {
+        assert_rect(sub_screen_rect((0, 480, 720, 72), 720, 576), 0.0, 900.0, 1920.0, 135.0);
+        assert_rect(sub_screen_rect((600, 1800, 2640, 192), 3840, 2160), 300.0, 900.0, 1320.0, 96.0);
+    }
+
+    /// A decoder that never declares a canvas (0) must fall back to 1:1 — the behaviour of the
+    /// whole path before this change — rather than divide by zero or blank the cue.
+    #[test]
+    fn image_sub_unknown_canvas_stays_1to1() {
+        assert_rect(sub_screen_rect((300, 900, 1320, 96), 0, 0), 300.0, 900.0, 1320.0, 96.0);
+        assert_rect(sub_screen_rect((300, 900, 1320, 96), -1, 1080), 300.0, 900.0, 1320.0, 96.0);
+    }
+
+    /// The HUD lift: image cues rise just enough to clear the transport, and only then.
+    #[test]
+    fn image_sub_lifts_only_over_the_transport() {
+        let dialogue = Rect::new(300.0, 900.0, 1320.0, 135.0); // bottom 1035, overhangs
+        // transport down: nothing moves, ever
+        assert_eq!(hud_lift([dialogue].into_iter(), false), 0.0);
+        // transport up: a bottom-anchored cue rises exactly its overhang, landing ON the ceiling
+        let lift = hud_lift([dialogue].into_iter(), true);
+        assert!(close(1035.0 - lift, SUB_CEIL_Y), "lifted bottom should sit at the ceiling");
+        // a sign at the top of frame already clears it and must stay put
+        let sign = Rect::new(100.0, 100.0, 200.0, 100.0);
+        assert_eq!(hud_lift([sign].into_iter(), true), 0.0);
+        assert!(!overhangs(sign) && overhangs(dialogue));
+        // a set too tall to lift is clamped instead of being pushed off the top of the screen
+        assert_eq!(hud_lift([Rect::new(0.0, 0.0, 1920.0, SCR_H)].into_iter(), true), 0.0);
+        assert_eq!(hud_lift([Rect::new(0.0, 50.0, 1920.0, SCR_H - 50.0)].into_iter(), true), 50.0);
+    }
+
+    /// The multi-rect case the lift has to get right, and the reason it is measured over the
+    /// OVERHANGING rects rather than the whole set: a sign plus dialogue must lift the dialogue
+    /// clear WITHOUT dragging the sign (whose top would otherwise clamp the whole shift), and
+    /// two-line dialogue must move as one unit or the two lines collapse onto each other.
+    #[test]
+    fn image_sub_lift_spans_only_the_rects_that_overhang() {
+        let sign = Rect::new(100.0, 100.0, 200.0, 100.0);
+        let dialogue = Rect::new(300.0, 900.0, 1320.0, 135.0);
+        let lift = hud_lift([sign, dialogue].into_iter(), true);
+        assert!(close(lift, 1035.0 - SUB_CEIL_Y), "the sign's top must not clamp the lift");
+        assert!(close(dialogue.y + dialogue.h - lift, SUB_CEIL_Y), "dialogue clears the transport");
+        assert!(!overhangs(sign), "and the sign is not shifted at all");
+
+        // two-line dialogue: different overhangs, ONE shift, so the gap between them survives
+        let l1 = Rect::new(300.0, 900.0, 1320.0, 50.0); // bottom 950
+        let l2 = Rect::new(300.0, 960.0, 1320.0, 50.0); // bottom 1010
+        let two = hud_lift([l1, l2].into_iter(), true);
+        assert!(close(two, 1010.0 - SUB_CEIL_Y), "measured over the group, not per rect");
+        assert!(overhangs(l1) && overhangs(l2), "both take the same shift");
+        assert!(close((l2.y - two) - (l1.y + l1.h - two), 10.0), "their 10px gap is preserved");
     }
 }

--- a/stub/avcodec_stub.c
+++ b/stub/avcodec_stub.c
@@ -21,6 +21,10 @@ int avcodec_open2(void *ctx, const void *codec, void **opts) { (void)ctx; (void)
 int avcodec_decode_subtitle2(void *ctx, void *sub, int *got, void *pkt) { (void)ctx; (void)sub; (void)got; (void)pkt; return 0; }
 void avsubtitle_free(void *sub) { (void)sub; }
 void avcodec_free_context(void **ctx) { (void)ctx; }
+/* Scratch AVCodecParameters for ff.rs::sub_canvas (the subtitle authoring canvas, read
+ * through avcodec_parameters_from_context so no raw struct offset is involved). */
+void *avcodec_parameters_alloc(void) { return 0; }
+void avcodec_parameters_free(void **par) { (void)par; }
 
 /* Dev-only probe (capture stream): does the TV's libavcodec build keep encoders? */
 void *avcodec_find_encoder_by_name(const char *name) { (void)name; return 0; }

--- a/tests/README.md
+++ b/tests/README.md
@@ -149,7 +149,7 @@ Operation cases (each also re-checks not-stuck / no-error afterward):
 | `morning_show_audio_native` | 1804 | native audio switch (eac3→eac3) — `audio switch (native)`, codec **stays 174** |
 | `home_alone_audio_transcode` | 3 | English (DTS) audio → transcode — `re-transcode` + `reload_transcode`, codec 174 (HEVC target; the video is re-encoded H264→HEVC — an audio-only/video-copy transcode is a future improvement) |
 | `substance_subtitle_srt` | 4 | embedded subtitle soft-render on the **default `ff.rs` demuxer** — `sub cue [..] "text"` lines |
-| `toy_story2_subtitle_pgs` | 1919 | **PGS image subtitle** client-render on HEVC 4K direct-play — `ff.rs` software-decodes the bitmap and logs `image cue [..] WxH at X,Y` (op flagged `"image": true`) |
+| `toy_story2_subtitle_pgs` | 1919 | **PGS image subtitle** client-render on HEVC 4K direct-play — `ff.rs` software-decodes the bitmap and logs `image cue [..] WxH at X,Y rects=N canvas=WxH` (op flagged `"image": true`) |
 
 ### Key log signals asserted (filter `smp_cb type=43 num=0 str=$` first)
 
@@ -164,8 +164,10 @@ Operation cases (each also re-checks not-stuck / no-error afterward):
   `reload_at: fresh Load at 140s`.
 - **audio switch:** `audio switch (native)` / `re-transcode:` + `reload_transcode:`.
 - **subtitles (text):** `sub cue [<a>..<b>ms] "<text>"`.
-- **subtitles (image PGS/VobSub):** `image cue [<t>ms] <W>x<H> at <x>,<y>` (a decoded bitmap
-  display-set pushed to the render store).
+- **subtitles (image PGS/VobSub):** `image cue [<t>ms] <W>x<H> at <x>,<y> rects=<N>
+  canvas=<W>x<H>` (a decoded display-set pushed to the render store — `rects` is how many bitmaps
+  it carries, `canvas` the stream's authoring canvas the renderer scales them from, `0x0` when the
+  decoder declares none). The assertion matches the prefix, so the tail can grow.
 
 ## Gotchas the harness handles for you
 


### PR DESCRIPTION
**Unit 14** — parity-gaps.md: *"Image-subtitle bitmaps are drawn at raw stream coordinates with no scaling from the subtitle canvas — VobSub/DVD subs land as a postage stamp"* (`major`/`small`), plus the `polish`/`small` follow-up *"PGS/VobSub image subtitles don't lift for the HUD, and only rect 0 of a multi-rect display set is drawn"*.

## What was wrong

A decoded PGS/VobSub rect's `x/y/w/h` are in the **subtitle stream's own authoring canvas**, not in screen pixels. We composited them 1:1 into our 1920x1080 UI and asserted in a comment that this was correct. It is correct for Blu-ray PGS and wrong for everything else: a DVD VobSub rip is authored on 720x480 and landed as a postage stamp in the upper-left quadrant; a 4K-authored PGS track drew at double size with half of it off the panel. The track menu offers those tracks and badges them `VOBSUB`, so the failure was reachable from the UI.

## What changed

- `ff::sub_canvas` reads the canvas off the decoder after each decode; it travels with the cue through the store to the renderer.
- `player_hud::sub_screen_rect` stretches the display set into the video rect — the same stretch the TV applies to the picture, since a subtitle canvas is the video's own storage grid. **A 1920x1080 canvas is exactly identity** (`1920.0/1920.0 == 1.0`, `x * 1.0 == x`), so every PGS track in the library renders as it did before. An undeclared canvas (`0`) falls back to 1:1 — today's unconditional behaviour.
- **Every rect** of a display set is decoded and drawn, not just rect 0. Two-line dialogue and sign-plus-dialogue are authored as separate rects of one set; the old code dropped half the line and logged that it had. The store now holds a set of rects per cue, which also makes the supersede rule correct by construction. Capped at 8 rects; the 24 MB ceiling counts a set's rects together.
- **Image cues lift clear of the transport** like text cues do, by their overhang. The shift is measured over — and applied to — only the rects that overhang, so a top-of-frame sign neither moves nor clamps the dialogue's lift. It is deliberately not per-rect: two-line dialogue has two different overhangs and lifting each by its own collapses the lines onto each other. Both paths now take the same `subs_lift` expression from `app.rs`.

Scaled content is **not** `gfx::snap`ped, per the crispness contract.

## Did I prove the ABI against the device's own binaries? YES — and no new offset was added

**No new struct-field offset is introduced by this change.** The canvas is read through the library's own `avcodec_parameters_from_context`, which copies the decoder's dimensions into the `AVCodecParameters` this crate already models (`width`/`height` at +48/+52 — the same fields the video path has read on-device since the demuxer landed). The read therefore runs inside libavcodec's own code, which is the `bind-tv-lib-abi` skill's preferred route ("prefer the library's own name-based API — no offset, no risk").

Two things were proven against the device, not inferred:

1. **Symbol presence.** `tools/abi-probe.sh has libavcodec.so.57 avcodec_parameters_alloc avcodec_parameters_free avcodec_parameters_from_context` → all `PRESENT` on the device's own `libavcodec.so.57.89.100`. Recorded in the extern block, because the stub `.so` links either way.
2. **That this build's `avcodec_parameters_from_context` actually handles subtitles.** The device build is stripped, so a header claim would be worthless. I pulled the library and disassembled the function with the NDK's `objdump`:

```
690a04 <+0x98>:  cmp r3, #3        ; AVMEDIA_TYPE_SUBTITLE
        beq 690aa8 <+0x13c>
690aa8 <+0x13c>: ldr r2, [r5, #124]   ; avctx->width
        ldr r3, [r5, #128]            ; avctx->height
        str r2, [r4, #48]             ; par->width
        str r3, [r4, #52]             ; par->height
```

The subtitle case is present in this build, and this incidentally **corroborates three offsets already in `ff.rs`** from an independent direction: `OFF_CTX_WIDTH`/`OFF_CTX_HEIGHT` (124/128) and `AVCodecParameters.width`/`height` (48/52). The prologue's `memset(par, 0, 136)` likewise confirms the modeled `sizeof == 136`. The whole derivation is in `sub_canvas`'s doc comment so it is not lost.

A canvas outside `160..8192` is reported as unknown rather than used — scaling by a garbage ratio is worse than not scaling.

## Device verification: deferred to coordinator

**I did not run anything on the TV.** I queued for the shared lock, never acquired it, and killed the job on the coordinator's instruction. The TV was never touched by me — no deploy, no launch, no stale binary. (I did *pull* `libavcodec.so.57` off the device read-only for the disassembly above.)

**Case to run**

```
./tests/run.py --filter toy_story2_subtitle_pgs --no-early
```

Toy Story 2 (`rk=1919`, HEVC 4K direct-play). The harness seeds `viewOffset` to **600000 ms (10:00)** and selects the PGS track from the track menu (tab 1, row 1) once playing, so a cue should appear within seconds of the switch. `--no-early` runs the full 90 s so there is a comfortable capture window; the existing assertions (`directplay`, `codec_id=174`, `min_video_width=3000`, timeline climb, no `Playing error`, video bound) are the regression gate.

**What to look for in `/tmp/plxnative-events.log`** — the new evidence is the `canvas=` field:

```
image cue [<t>ms] <W>x<H> at <x>,<y> rects=<N> canvas=<CW>x<CH>
```

- `canvas=1920x1080` → the canvas read works and the render is **byte-identical to before** (scale is exact identity). This is the expected result for a 1080p-authored PGS track and is a clean pass.
- `canvas=3840x2160` → this track is 4K-authored, and the fix is **visible**: the old build drew it at 2x with half off the panel; it should now sit correctly.
- `canvas=0x0` → the decoder declared nothing, so the 1:1 fallback is in play. Not a crash and not a regression, but it means the canvas read did not fire for PGS and the VobSub case would still be unfixed — worth reporting back.

`rects=` should normally be 1; a 2 is the multi-rect path working.

**Capture — service capture only**

```
tools/capture-screen.sh /tmp/unit-14.png DISPLAY
```

taken while a cue is up. **The in-app capture stream (`/tmp/plxnative-capture`, TCP :8910) cannot see this at all** — `capture.rs` grabs the app's own GLES frames, i.e. the UI plane only, and the subtitle composites over the hardware VIDEO overlay plane. `DISPLAY` is the composited panel output and is the only evidence. (`VIDEO` alone would show the picture without the subtitle; `GRAPHIC` alone shows the subtitle without the picture — that pair is a useful split if something looks wrong.)

**What the frame should look like if the scaling is right**

A PGS dialogue line on a 1920x1080 canvas is a wide, short strip: roughly **60-85% of the frame width** (~1150-1650 px), **6-10% of its height** (~70-110 px), horizontally centred, sitting in the **bottom sixth of the frame** (top edge around y≈900-1000 of 1080). Failure signatures:

- a small bitmap in the **upper-left third** of the frame → the canvas is larger than we scaled for (the original bug shape);
- a bitmap **overflowing the right/bottom edge**, roughly double the expected size → a 4K canvas whose scale was not applied.

**One more check, free while you are there:** with a cue on screen, press any key to raise the transport. The bitmap should rise so its bottom edge sits at **y = 780** (`SCR_H - 300`), clear of the scrubber — matching where text subtitles lift to. It should not move if it was already above that line.

**No VobSub item exists to test against.** I scanned all 477 movie + episode items on the PMS via `/library/metadata/{rk}`: every image-subtitle track in the library is `pgs`. There is no `vobsub`/`dvd_subtitle` anywhere, so the 720x480 path **cannot** be exercised on this server and is covered by host tests only. That is the one gap in this verification, and it is a library limitation, not a skipped step.

## Tests

`make check` — **65 passed** (58 baseline + 7 new), `make` (ARM cross-build) clean, no new warnings.

Per the stated boundary, the new tests exercise the **arithmetic, not the FFI** (`ff.rs`'s `#[link]` directives are `cfg_attr(not(test))`-gated, so a test that calls FFmpeg cannot link):

- `image_sub_1080p_canvas_is_identity` — the 1920x1080 regression guard, asserted exact
- `image_sub_dvd_canvas_fills_the_panel` — 720x480, the bug this unit exists for
- `image_sub_pal_and_4k_canvases` — 720x576 and 3840x2160 (the latter scales *down*)
- `image_sub_unknown_canvas_stays_1to1` — the 0 / negative fallback
- `image_sub_lifts_only_over_the_transport` and `image_sub_lift_spans_only_the_rects_that_overhang` — the lift, including sign-plus-dialogue and two-line dialogue
- `an_image_display_set_round_trips_whole_and_is_superseded_as_a_unit` (`player/mod.rs`, takes the crate-wide `testlock`) — the multi-rect store, the supersede handover, and the eviction order below

## Review pass

An independent reviewer went over the diff for memory safety, GL texture lifetime, arithmetic and cross-thread invariants. Everything it found is fixed in this commit:

| Finding | Fix |
|---|---|
| **The store's byte ceiling evicted the cue at the playhead.** `v[0]` is the cue being drawn once the time-retain has run, and the tail is the demuxer's 10-20 s read-ahead — so the budget blanked the subtitle being read and kept ones nobody had reached. A set costing up to 8 rects instead of 1 is what made it reachable | Drop a cue the playhead has already passed first; only fall back to the far end of the read-ahead when there is none. The test was checked to **fail** against the old policy |
| `hud_lift` measured the whole set, so a sign at y=100 clamped the lift and left the dialogue behind the scrim | Measured over and applied to only the overhanging rects |
| `rect_to_rgba` did not null-check the rect pointer — the loop now walks up to 8, not just `[0]` | Added |
| `w*h*4` can wrap: `usize` is **32-bit** on this target, and w/h are unvalidated decoder output. A wrapped product sizes the buffer below what the write loop and `glTexImage2D` then read | Bounded w/h to 8192 and `checked_mul` |
| The renderer's cache key was `start_ns` alone, but two image tracks of one file routinely start a set on the same pts — a switch left the outgoing track on screen | Key is now `(track, start_ns)`; both halves reset together |
| Symbol presence for the two new externs was proven but not written down | Recorded in the extern block |
| `tests/README.md` documented the old `image cue` format | Updated |

The reviewer confirmed no texture leak, double-delete, draw-after-delete or stale draw across every early-return and both the grow and shrink directions, and that the 1080p path is bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
