### PR TITLE
detail: crew credits — Directed by line + crew in the Cast & Crew shelf

### DIFF
--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -35,9 +35,12 @@ pub(crate) fn friendly_codec(codec: &str) -> String {
     }
 }
 
+/// One credit on the Cast & Crew shelf. PMS ships crew (`Director[]`/`Writer[]`) in the SAME shape
+/// as the actors (`Role[]`) minus the `role` attribute, so a crew credit is this same struct with
+/// its JOB in `role` — see [`crew_credits`].
 pub(crate) struct Cast {
-    pub(crate) tag: String,   // actor name
-    pub(crate) role: String,  // character
+    pub(crate) tag: String,   // person's name
+    pub(crate) role: String,  // character (an actor) — or the job, "Director"/"Writer" (crew)
     pub(crate) thumb: String, // headshot (often an external metadata-static.plex.tv URL)
 }
 
@@ -222,6 +225,12 @@ pub(crate) struct Detail {
     pub(crate) genres: Vec<String>,
     pub(crate) countries: Vec<String>,
     pub(crate) cast: Vec<Cast>,
+    /// Director[] tags, in server order — the hero's "Directed by …" line.
+    pub(crate) directors: Vec<String>,
+    /// Director[] + Writer[] as credits (each carrying its JOB in `role`), drawn on the Cast &
+    /// Crew shelf AFTER the actors. Kept apart from `cast` so "who acted" stays answerable; the
+    /// shelf addresses both through [`Detail::credit`].
+    pub(crate) crew: Vec<Cast>,
     pub(crate) audio: Vec<Stream>,
     pub(crate) subs: Vec<Stream>,
     pub(crate) seasons: Vec<Season>,   // shows only
@@ -232,6 +241,22 @@ pub(crate) struct Detail {
     pub(crate) markers: Vec<Marker>, // intro / credits segments (leaf items only)
 }
 
+impl Detail {
+    /// How many tiles the Cast & Crew shelf holds: every actor, then every crew credit.
+    pub(crate) fn credits_len(&self) -> usize {
+        self.cast.len() + self.crew.len()
+    }
+    /// The `i`th shelf credit in that one flat index space, so the screen's focus/geometry can
+    /// address a tile by position without re-deriving which vec it fell in.
+    pub(crate) fn credit(&self, i: usize) -> Option<&Cast> {
+        if i < self.cast.len() {
+            self.cast.get(i)
+        } else {
+            self.crew.get(i - self.cast.len())
+        }
+    }
+}
+
 // The one loaded detail item (the detail page shows a single item at a time).
 static mut CURRENT: Option<Detail> = None;
 
@@ -239,6 +264,15 @@ static mut CURRENT: Option<Detail> = None;
 pub(crate) fn current() -> Option<&'static Detail> {
     unsafe { (*addr_of!(CURRENT)).as_ref() }
 }
+/// TEST-ONLY installer for the loaded item. The UI's layout tests need a `Detail` on screen with
+/// no PMS behind them; every other writer of `CURRENT` goes through the landing mailbox, which is
+/// exactly the invariant those tests must not have to fake. Crate-global, so callers hold
+/// [`crate::testlock::serial`].
+#[cfg(test)]
+pub(crate) fn install_for_test(d: Option<Detail>) {
+    unsafe { *addr_of_mut!(CURRENT) = d }
+}
+
 /// drop the loaded detail (on leaving the detail page). Also supersedes any in-flight async
 /// fetch — otherwise a load requested on the way in lands after the page closed and silently
 /// repopulates CURRENT (and NOW, via `sync_now_playing`) behind whatever screen is now mounted.
@@ -345,6 +379,10 @@ fn fetch_detail(rk: &str) -> Option<Detail> {
             .iter()
             .map(|r| Cast { tag: r.tag.clone(), role: r.role.clone(), thumb: r.thumb.clone() })
             .collect(),
+        // deduped like the shelf below it: a repeated Director[] row would otherwise read
+        // "Directed by Jane Doe, Jane Doe"
+        directors: dedup_tags(&it.director),
+        crew: crew_credits(&it),
         audio: Vec::new(),
         subs: Vec::new(),
         seasons: Vec::new(),
@@ -367,6 +405,47 @@ fn fetch_detail(rk: &str) -> Option<Detail> {
     // episodes do, so load_detail backfills a show's streams from its first episode).
     parse_streams(&it, &mut d);
     Some(d)
+}
+
+/// The crew jobs we surface, in the order they appear on the shelf. PMS names the job by the
+/// ARRAY the person arrived in (`Director[]`/`Writer[]`) — the rows themselves carry no job
+/// attribute, and (verified live) no `role` either, so this is where the sub-caption comes from.
+const CREW_JOBS: [&str; 2] = ["Director", "Writer"];
+
+/// The named tags of one crew array, in server order, without the blanks or the repeats.
+fn dedup_tags(tags: &[crate::plex::Tag]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for t in tags.iter().filter(|t| !t.tag.is_empty()) {
+        if !out.iter().any(|s| s == &t.tag) {
+            out.push(t.tag.clone());
+        }
+    }
+    out
+}
+
+/// Fold `Director[]` + `Writer[]` into the credits the Cast & Crew shelf draws after the actors.
+///
+/// One person credited twice collapses into ONE tile: two identical headshots side by side read as
+/// a duplication bug, not as two credits. Across the arrays that means the writer-director's tile
+/// reads "Director, Writer"; WITHIN one array (PMS does emit a repeated tag row after an agent
+/// merge) the job is already there and is not repeated — "Director, Director" is nobody's credit.
+/// Nameless rows are dropped: a tile with no name and (often) no headshot is a blank circle the
+/// focus can still land on.
+fn crew_credits(it: &crate::plex::Metadata) -> Vec<Cast> {
+    let mut out: Vec<Cast> = Vec::new();
+    for (job, list) in CREW_JOBS.iter().zip([&it.director, &it.writer]) {
+        for t in list.iter().filter(|t| !t.tag.is_empty()) {
+            match out.iter_mut().find(|c| c.tag == t.tag) {
+                Some(c) if !c.role.ends_with(job) => {
+                    c.role.push_str(", ");
+                    c.role.push_str(job);
+                }
+                Some(_) => {}
+                None => out.push(Cast { tag: t.tag.clone(), role: job.to_string(), thumb: t.thumb.clone() }),
+            }
+        }
+    }
+    out
 }
 
 /// Convert a part's Stream[] into (audio, subs, video_fps) — the ONE plex::Stream → Stream
@@ -651,8 +730,8 @@ fn fetch_full(rk: &str) -> Option<Detail> {
     }
     d.related = fetch_related(rk);
     crate::player::log(&format!(
-        "detail: rk={} '{}' show={} genres={} cast={} seasons={} eps={} related={} audio={} subs={} ms={}",
-        d.rk, d.title, d.is_show, d.genres.len(), d.cast.len(), d.seasons.len(), d.episodes.len(),
+        "detail: rk={} '{}' show={} genres={} cast={} crew={} seasons={} eps={} related={} audio={} subs={} ms={}",
+        d.rk, d.title, d.is_show, d.genres.len(), d.cast.len(), d.crew.len(), d.seasons.len(), d.episodes.len(),
         d.related.len(), d.audio.len(), d.subs.len(), t0.elapsed().as_millis()
     ));
     Some(d)
@@ -1179,5 +1258,69 @@ mod tests {
         assert!(!season_loading(), "but it still settles the spinner");
 
         clear();
+    }
+
+    // ---- credits (Cast & Crew) ----------------------------------------------------------------
+
+    /// The crew fold, parsed from the shape PMS actually sends (verified live 2026-07-29): the
+    /// `Director[]`/`Writer[]` rows are `Role[]` rows MINUS the `role` attribute, so the job — the
+    /// only thing left to caption a crew tile with — exists nowhere but the array name.
+    ///
+    /// Deliberately driven through serde rather than a hand-built `Metadata`, because the parse is
+    /// half the claim: if the DTO ever stops carrying `Director[]`, the tiles vanish silently.
+    #[test]
+    fn crew_credits_fold_both_job_arrays_into_one_deduplicated_shelf_list() {
+        let body = br#"{
+            "Director": [
+                { "id": 161, "filter": "director=161", "tag": "Jane Doe",
+                  "tagKey": "5d77682a", "count": 3,
+                  "thumb": "https://metadata-static.plex.tv/c/people/c.jpg" },
+                { "id": 162, "filter": "director=162", "tag": "" }
+            ],
+            "Writer": [
+                { "id": 163, "filter": "writer=163", "tag": "Jane Doe",
+                  "tagKey": "5d77682a", "count": 3,
+                  "thumb": "https://metadata-static.plex.tv/c/people/c.jpg" },
+                { "id": 164, "filter": "writer=164", "tag": "Sam Scribe" }
+            ]
+        }"#;
+        let it: crate::plex::Metadata = serde_json::from_slice(body).expect("the live crew shape parses");
+        assert_eq!(it.director.len(), 2, "Director[] is on the DTO");
+        assert_eq!(it.writer.len(), 2, "and so is Writer[]");
+        assert!(it.director[0].role.is_empty(), "crew rows carry no role — the JOB is the caption");
+
+        let crew = crew_credits(&it);
+        let got: Vec<(&str, &str)> = crew.iter().map(|c| (c.tag.as_str(), c.role.as_str())).collect();
+        assert_eq!(
+            got,
+            [("Jane Doe", "Director, Writer"), ("Sam Scribe", "Writer")],
+            "directors first, and the writer-director is ONE tile listing both jobs — not two \
+             identical headshots side by side"
+        );
+        assert_eq!(crew[0].thumb, "https://metadata-static.plex.tv/c/people/c.jpg", "the headshot rides along");
+        assert!(crew[1].thumb.is_empty(), "a crew member with no headshot is still a credit");
+    }
+
+    /// The shelf's flat index space: the screen addresses one row of tiles, so `credit(i)` must run
+    /// the actors out first and then the crew, and refuse an index past the end rather than panic —
+    /// the focus column outlives the item it was set on (a Related jump reloads underneath it).
+    #[test]
+    fn the_credit_index_space_runs_every_actor_then_every_crew_member() {
+        let person = |t: &str, r: &str| Cast { tag: t.to_string(), role: r.to_string(), thumb: String::new() };
+        let d = Detail {
+            cast: vec![person("Actor A", "Hero"), person("Actor B", "Villain")],
+            crew: vec![person("Jane Doe", "Director")],
+            ..Default::default()
+        };
+        assert_eq!(d.credits_len(), 3, "the shelf is as long as the two lists together");
+        let seen: Vec<(&str, &str)> =
+            (0..d.credits_len()).filter_map(|i| d.credit(i)).map(|c| (c.tag.as_str(), c.role.as_str())).collect();
+        assert_eq!(seen, [("Actor A", "Hero"), ("Actor B", "Villain"), ("Jane Doe", "Director")]);
+        assert!(d.credit(3).is_none(), "one past the end is None, not a panic");
+        assert!(d.credit(usize::MAX).is_none(), "and so is a wildly stale focus column");
+
+        let crew_only = Detail { crew: vec![person("Jane Doe", "Director")], ..Default::default() };
+        assert_eq!(crew_only.credits_len(), 1, "a crew-only item still fills the shelf");
+        assert_eq!(crew_only.credit(0).map(|c| c.tag.as_str()), Some("Jane Doe"), "and its first tile is the crew");
     }
 }

--- a/rust-modules/src/plex/models.rs
+++ b/rust-modules/src/plex/models.rs
@@ -275,7 +275,7 @@ pub struct Tag {
     #[serde(default)]
     pub role: String, // Role[] only (character name)
     #[serde(default)]
-    pub thumb: String, // Role[] headshot
+    pub thumb: String, // headshot — on the crew arrays (Director[]/Writer[]) as well as Role[]
 }
 
 /// Plex `Chapter[]` on a leaf item (movies/episodes with chapter data). Sibling of `Media[]`,

--- a/rust-modules/src/ui/card_row.rs
+++ b/rust-modules/src/ui/card_row.rs
@@ -105,6 +105,13 @@ impl RowStyle {
 #[derive(Clone, Copy)]
 pub(crate) struct CardRow {
     scale: [Spring; MAX_ROW_ITEMS],
+    /// The ONE spring every cell PAST the array shares — see [`CardRow::scale`]. A cast row is
+    /// routinely 60 names long, so "the tiles past the 24th simply don't animate" is not a corner
+    /// case; it is most of the Cast & Crew shelf, and the crew now lives at its far end.
+    overflow: Spring,
+    /// Which cell holds focus (`-1` none), so an overflow cell can claim `overflow` while its
+    /// neighbours — which read the same spring — stay at rest.
+    focus: i32,
     scroll_x: Spring,
     lift: Spring,
     pub base_y: f32,
@@ -113,6 +120,8 @@ impl CardRow {
     pub(crate) const fn new() -> Self {
         CardRow {
             scale: [Spring::at(1.0); MAX_ROW_ITEMS],
+            overflow: Spring::at(1.0),
+            focus: -1,
             scroll_x: Spring::at(0.0),
             lift: Spring::at(0.0),
             base_y: 0.0,
@@ -126,10 +135,14 @@ impl CardRow {
     /// `focused == None` freezes the scroll (a non-focused row holds its position — exactly the
     /// home shelf's behavior).
     pub(crate) fn update(&mut self, n: usize, focused: Option<usize>, sty: &RowStyle, dt: f32) {
+        self.focus = focused.map(|f| f as i32).unwrap_or(-1);
         for (i, sp) in self.scale.iter_mut().enumerate() {
             let target = if focused == Some(i) { sty.focus_scale } else { 1.0 };
             sp.step(target, sty.k_scale, dt);
         }
+        // the shared overflow spring pops only while focus is actually out past the array
+        let ot = if focused.is_some_and(|f| f >= MAX_ROW_ITEMS) { sty.focus_scale } else { 1.0 };
+        self.overflow.step(ot, sty.k_scale, dt);
         if let Some(fc) = focused {
             if n > 0 {
                 let want = scroll_into_view(self.scroll_x.pos, fc, n, sty.w, sty.gap, SCR_W - 2.0 * sty.margin_x);
@@ -138,9 +151,21 @@ impl CardRow {
         }
         self.lift.step(heading_clearance(focused, sty, self.scroll_x.pos), sty.k_scale, dt);
     }
+    /// Cell `i`'s live focus-pop scale. Cells inside the spring array own a spring each; every cell
+    /// PAST it shares `overflow`, and only the focused one reads it — otherwise the whole tail of a
+    /// long row would pop together. The cost of sharing is that stepping between two overflow cells
+    /// swaps the pop instantly instead of crossfading; the alternative (this used to clamp the index,
+    /// so an overflow cell read cell 23's spring) was a focused tile with NO pop, NO lifted shadow
+    /// and NO ring — the entire focus treatment is derived from this number.
     #[inline]
     pub(crate) fn scale(&self, i: usize) -> f32 {
-        self.scale[i.min(MAX_ROW_ITEMS - 1)].pos
+        if i < MAX_ROW_ITEMS {
+            self.scale[i].pos
+        } else if self.focus == i as i32 {
+            self.overflow.pos
+        } else {
+            1.0
+        }
     }
     #[inline]
     pub(crate) fn scroll_x(&self) -> f32 {
@@ -404,5 +429,35 @@ mod tests {
         assert!(at(2) > 0.5 && at(2) < at(1), "slot 2 is on the taper ({} vs {})", at(2), at(1));
         assert_eq!(at(4), 0.0, "a tile far from the heading must not move it");
         assert_eq!(heading_clearance(None, &sty, 0.0), 0.0);
+    }
+
+    /// A row LONGER than the spring array. Every focus treatment a tile gets — the pop, the lifted
+    /// shadow, the ring — is derived from `scale(i)`, and the index used to be clamped into the
+    /// array, so focusing tile 30 of a 60-name cast row popped nothing at all (it read cell 23's
+    /// resting spring). The shared overflow spring must pop for the focused tile, and for it alone:
+    /// its neighbours read the same spring.
+    #[test]
+    fn a_focused_tile_past_the_spring_array_still_pops_and_its_neighbours_do_not() {
+        let sty = RowStyle::CAST;
+        let mut row = CardRow::new();
+        let far = MAX_ROW_ITEMS + 6; // a crew credit at the end of a long cast list
+        for _ in 0..180 {
+            row.update(far + 2, Some(far), &sty, DT);
+        }
+        assert!(
+            (row.scale(far) - sty.focus_scale).abs() < 0.01,
+            "the focused overflow tile must reach the focus scale (got {})",
+            row.scale(far)
+        );
+        assert_eq!(row.scale(far + 1), 1.0, "the tile after it shares the spring, not the focus");
+        assert_eq!(row.scale(far - 1), 1.0, "nor the one before it");
+        assert!((row.scale(MAX_ROW_ITEMS - 1) - 1.0).abs() < 0.01, "and the last in-array cell rests");
+
+        // focus coming back inside the array releases the overflow pop
+        for _ in 0..180 {
+            row.update(far + 2, Some(0), &sty, DT);
+        }
+        assert_eq!(row.scale(far), 1.0, "focus left the tail, so no overflow tile reads the spring");
+        assert!((row.scale(0) - sty.focus_scale).abs() < 0.01, "and the in-array cell pops as ever");
     }
 }

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -89,6 +89,10 @@ const NBTN: c_int = 2; // Play + watched toggle (an info disc would be a no-op o
 const PW: f32 = 168.0; // Play pill width
 const CGAP: f32 = 20.0;
 const CD: f32 = 60.0; // circle button diameter
+/// The hero text column's width — the synopsis wrap AND every fine-print line under it (the
+/// date/runtime pair, the "Directed by" credit) share it, so nothing in the block can grow past
+/// the right-aligned "Starring" line.
+const HERO_TEXT_W: f32 = 900.0;
 
 // Below-the-hero content is ONE vertical scroll of stacked blocks, driven by the shared retui
 // `ScrollColumn` (`impl Column for DetailView`): its `child_top` COMPUTES each block's pre-scroll top
@@ -176,7 +180,7 @@ fn sections() -> ([c_int; 6], usize) {
         // Cast & Crew (credits) before Related — the flow order is the push order here (block_h /
         // draw_child / move_focus all key off the section id, not its position, so this is the one
         // place ordering lives).
-        if !d.cast.is_empty() {
+        if d.credits_len() > 0 {
             v[n] = 4;
             n += 1;
         }
@@ -195,7 +199,7 @@ fn n_items(section: c_int) -> c_int {
         1 => metadata::current().map(|d| d.seasons.len()).unwrap_or(0) as c_int,
         2 => metadata::current().map(|d| d.episodes.len()).unwrap_or(0) as c_int,
         3 => metadata::current().map(|d| d.related.len()).unwrap_or(0) as c_int,
-        4 => metadata::current().map(|d| d.cast.len()).unwrap_or(0) as c_int,
+        4 => metadata::current().map(|d| d.credits_len()).unwrap_or(0) as c_int, // actors + crew
         5 => 4, // About: card + Information + Languages + Accessibility (selection moves between them)
         _ => 0,
     }
@@ -499,21 +503,46 @@ fn hero_synopsis(summary: &str) -> TextView<'_> {
     TextView::new(summary, theme::size::MICRO, theme::TEXT_SECONDARY).leading(29.0).max_lines(4)
 }
 
+/// The loaded item's director credits, or None when the server sent no `Director[]` — the ONE
+/// rule for whether the hero carries a "Directed by …" line. The flow (`hero_layout`) reserves the
+/// line's band on it and the paint (`draw_hero`) formats it, so the two cannot disagree. Borrowed
+/// rather than formatted: `hero_layout` runs twice a frame and has no business allocating.
+fn directors() -> Option<&'static [String]> {
+    metadata::current().map(|d| d.directors.as_slice()).filter(|v| !v.is_empty())
+}
+
 /// The hero text column's y-chain — title bottom (566) → meta (+36) → synopsis (+46, MEASURED) →
-/// date (+20) → buttons (+46) — computed ONCE for both the painter (draw_hero) and the flow
-/// (update()'s column.top), so the pixels and the scroll math cannot desync. A 4-line synopsis
-/// used to push the Play pill to within 2px of the season tabs; the flow now keeps one
-/// standardized gap (`BTN_CONTENT_GAP`) under the buttons for every title.
-/// Returns (meta_y, syn_y, date_y, btn_y).
-fn hero_layout(m: Option<&PmsMovie>) -> (f32, f32, f32, f32) {
+/// date (+20) → "Directed by" (+`space::LG`, only when there is one) → buttons (+46) — computed
+/// ONCE for both the painter (draw_hero) and the flow (update()'s column.top), so the pixels and
+/// the scroll math cannot desync. A 4-line synopsis used to push the Play pill to within 2px of
+/// the season tabs; the flow now keeps one standardized gap (`BTN_CONTENT_GAP`) under the buttons
+/// for every title.
+/// Returns (meta_y, syn_y, date_y, btn_y, dir_y) — `dir_y` is APPENDED rather than slotted into
+/// flow order so the existing element indices keep their meaning (`update()` reads `.3` for the
+/// button row), and it is only meaningful when [`directors`] is Some.
+fn hero_layout(m: Option<&PmsMovie>) -> (f32, f32, f32, f32, f32) {
     let d = metadata::current();
     let owned = if d.is_none() { m.map(|m| m.summary.clone()).unwrap_or_default() } else { String::new() };
     let summary: &str = d.map(|d| d.summary.as_str()).unwrap_or(&owned);
-    let syn_h = if summary.is_empty() { 0.0 } else { hero_synopsis(summary).measure_h(900.0) };
+    let syn_h = if summary.is_empty() { 0.0 } else { hero_synopsis(summary).measure_h(HERO_TEXT_W) };
+    hero_chain(syn_h, directors().is_some())
+}
+
+/// The pure arithmetic half of [`hero_layout`] — everything except the synopsis measurement, which
+/// is the one part that needs a font. Split out so the flow-vs-paint contract this chain exists to
+/// hold (above all the CONDITIONAL "Directed by" band) is host-testable; measuring is not, since
+/// the host suite opens no SDL_ttf.
+fn hero_chain(syn_h: f32, has_director: bool) -> (f32, f32, f32, f32, f32) {
     let meta_y = 566.0 + 36.0;
     let syn_y = meta_y + 46.0;
     let date_y = syn_y + syn_h.max(34.0) + 20.0;
-    (meta_y, syn_y, date_y, date_y + 46.0)
+    // The credit line sits one air rung under the date/runtime line — a PITCH like its siblings
+    // above (these ys are line tops, so a `space::LG` step leaves ~10px of ink gap at CAPTION,
+    // which is the "two separate fine-print statements" reading, not a paragraph). It takes NO
+    // space at all on an item without directors — the button row keeps its old y there.
+    let dir_y = date_y + theme::space::LG;
+    let last_y = if has_director { dir_y } else { date_y };
+    (meta_y, syn_y, date_y, last_y + 46.0, dir_y)
 }
 
 pub(crate) fn update(dt: f32) {
@@ -778,7 +807,7 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
         }
     }
     // the whole y-chain below comes from the ONE shared layout (also feeds the scroll flow)
-    let (meta_y, syn_y, date_y, btn_y) = hero_layout(m);
+    let (meta_y, syn_y, date_y, btn_y, dir_y) = hero_layout(m);
     if let Ok(mc) = CString::new(parts.join("   \u{b7}   ")) {
         p.text(mc.as_ptr(), tx, meta_y, theme::size::BODY, d_a, 0, 0);
     }
@@ -788,7 +817,7 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
     let summary_owned = if d.is_none() { m.map(|m| m.summary.clone()).unwrap_or_default() } else { String::new() };
     let summary: &str = d.map(|d| d.summary.as_str()).unwrap_or(&summary_owned);
     if !summary.is_empty() {
-        hero_synopsis(summary).draw(p, Rect::new(tx, syn_y, 900.0, 0.0));
+        hero_synopsis(summary).draw(p, Rect::new(tx, syn_y, HERO_TEXT_W, 0.0));
     }
 
     // ---- date · runtime ----
@@ -802,6 +831,23 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
         }
         if let Ok(ic) = CString::new(info) {
             p.text(ic.as_ptr(), tx, date_y, theme::size::CAPTION, dim, 0, 0);
+        }
+    }
+
+    // ---- "Directed by …" — the crew credit the reference puts in the metadata block. A step
+    // brighter than the date/runtime fine print above it (these are names, not filing data), and
+    // elided to the hero text column so a five-director title can't run under the Starring line.
+    // Its band is reserved by hero_layout, so an item without directors moves nothing. ----
+    if let Some(names) = directors() {
+        let line = crate::text::elide(
+            &format!("Directed by {}", names.join(", ")),
+            HERO_TEXT_W,
+            theme::size::CAPTION,
+            0,
+            false,
+        );
+        if let Ok(dc) = CString::new(line) {
+            p.text(dc.as_ptr(), tx, dir_y, theme::size::CAPTION, d_a, 0, 0);
         }
     }
 
@@ -1082,12 +1128,18 @@ fn draw_related(p: Painter) {
 /// `RowStyle::CAST`): spring focus-magnification + animated scroll + glow ring, exactly like the
 /// poster/Related shelves. Cast shows every member's name/role (a poster row titles only the
 /// focused tile), so the labels ride the `extra` hook.
+///
+/// The row is the item's whole CREDIT list — actors first, then the crew the server sent
+/// (`metadata::Detail::credit`), which is what finally makes the heading true. The sub-caption is
+/// the character for an actor and the job ("Director", "Writer") for a crew member, because crew
+/// rows carry no `role` on the wire; both ride the same `cast_label`.
 fn draw_cast(p: Painter) {
     let d = match metadata::current() {
         Some(d) => d,
         None => return,
     };
-    if d.cast.is_empty() {
+    let n = d.credits_len();
+    if n == 0 {
         return;
     }
     let cast_y = 0.0; // local origin (ScrollColumn pre-translates to this section's top)
@@ -1098,21 +1150,30 @@ fn draw_cast(p: Painter) {
     draw_strip(
         p,
         &view().cast,
-        d.cast.len(),
+        n,
         focus_col,
         row_y,
         (CAST_D, CAST_D),
         CAST_SLOT,
         &RowStyle::CAST,
         SCR_W + CAST_D,
-        |i| Art::Thumb { key: &d.cast[i].thumb, res: (300, 300) },
+        // Art::Person, not Thumb: plenty of crew (and some actors) have no headshot on the
+        // server, and the person glyph says "no photo" where a bare placeholder disc said
+        // "broken image". The absolute metadata-static.plex.tv URL rides the SAME server-side
+        // /photo/:/transcode fetch the actor headshots already use.
+        |i| Art::Person { key: d.credit(i).map_or("", |c| c.thumb.as_str()), res: (300, 300) },
         |_| None,
-        |pc, i, x, focused| cast_label(pc, &d.cast[i].tag, &d.cast[i].role, x + CAST_D * 0.5, row_y, focused),
+        |pc, i, x, focused| {
+            if let Some(c) = d.credit(i) {
+                cast_label(pc, &c.tag, &c.role, x + CAST_D * 0.5, row_y, focused);
+            }
+        },
     );
 }
 
-/// A cast member's name + role, centred under the headshot and elided to the per-member slot (long
-/// names like "Benedict Cumberbatch" would otherwise run into the neighbour at couch-legible sizes).
+/// A credit's name + sub-caption (an actor's character, or a crew member's job), centred under the
+/// headshot and elided to the per-member slot (long names like "Benedict Cumberbatch" would
+/// otherwise run into the neighbour at couch-legible sizes).
 fn cast_label(p: Painter, name: &str, role: &str, cx: f32, row_y: f32, focused: bool) {
     let name_c = if focused { theme::TEXT_PRIMARY } else { theme::TEXT_SECONDARY };
     let budget = CAST_SLOT - 12.0;
@@ -1120,7 +1181,9 @@ fn cast_label(p: Painter, name: &str, role: &str, cx: f32, row_y: f32, focused: 
         p.text(nc.as_ptr(), cx, row_y + CAST_D + 26.0, theme::size::LABEL, name_c, 1, if focused { 1 } else { 0 });
     }
     if !role.is_empty() {
-        if let Ok(rc) = CString::new(crate::text::elide(role, budget, theme::size::CAPTION, 1, false)) {
+        // measured at the weight it is DRAWN (regular): measuring bold cut it a word early, which
+        // the longer crew captions ("Director, Writer") hit far more often than a character name
+        if let Ok(rc) = CString::new(crate::text::elide(role, budget, theme::size::CAPTION, 0, false)) {
             p.text(rc.as_ptr(), cx, row_y + CAST_D + 58.0, theme::size::CAPTION, theme::TEXT_TERTIARY, 1, 0);
         }
     }
@@ -1594,6 +1657,61 @@ fn draw_about(p: Painter) {
             let h = TextView::new(desc, theme::size::CAPTION, val).leading(30.0).max_lines(4).draw(p, Rect::new(ax, ay + 52.0, 500.0, 0.0));
             ay += 52.0 + h + 26.0;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(directors: &[&str]) -> metadata::Detail {
+        metadata::Detail {
+            rk: "rk-1".to_string(),
+            title: "An Item".to_string(),
+            directors: directors.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+    fn credit(name: &str, job: &str) -> metadata::Cast {
+        metadata::Cast { tag: name.to_string(), role: job.to_string(), thumb: String::new() }
+    }
+
+    /// `hero_chain` is the ONE y-chain the hero's paint and the below-hero scroll flow share
+    /// (`update()` reads `.3` for the button row). The "Directed by" line therefore has to reserve
+    /// its band in the chain itself: drawing it without doing so would put a credit line under the
+    /// Play pill, and reserving it unconditionally would leave a 40px hole on every item PMS sent
+    /// no `Director[]` for — which is most TV shows.
+    #[test]
+    fn the_directed_by_band_is_reserved_when_there_is_a_line_and_never_otherwise() {
+        // driven at both a short and a tall synopsis: the band must be the ONLY difference
+        for syn_h in [0.0f32, 116.0] {
+            let (_, _, date_y, btn_y, _) = hero_chain(syn_h, false);
+            assert_eq!(btn_y, date_y + 46.0, "no directors: the button row keeps the y it always had");
+
+            let (_, _, date2, btn2, dir_y) = hero_chain(syn_h, true);
+            assert_eq!(date2, date_y, "nothing ABOVE the credit line moves");
+            assert_eq!(dir_y, date_y + theme::space::LG, "the credit sits one air rung under the date line");
+            assert_eq!(btn2, dir_y + 46.0, "and the buttons clear the line that is now there");
+            assert!(btn2 > btn_y, "the reserved band is real space, not an overlap");
+        }
+    }
+
+    /// The shelf is the whole credit list, so an item with crew but no actors still gets one — the
+    /// section gate and the item count must agree on that or the page offers a focus stop it draws
+    /// nothing into.
+    #[test]
+    fn a_crew_only_item_still_gets_the_cast_and_crew_shelf() {
+        let _serial = crate::testlock::serial();
+        let mut d = item(&["Jane Doe"]);
+        d.crew = vec![credit("Jane Doe", "Director, Writer")];
+        metadata::install_for_test(Some(d));
+
+        let (secs, n) = sections();
+        assert!(secs[..n].contains(&4), "section 4 is present for a crew-only item");
+        assert_eq!(n_items(4), 1, "and it holds the one credit");
+
+        metadata::install_for_test(None);
+        assert!(!sections().0[..sections().1].contains(&4), "with nothing loaded there is no shelf");
     }
 }
 

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -22,11 +22,17 @@ pub(crate) fn resolve_tex(path: &str, w: c_int, h: c_int, png: c_int) -> u32 {
     crate::posters::poster_get(key.as_ptr() as *const c_char)
 }
 
-/// Source art for a [`card`]: a catalog poster (resolved 250×375, dark gradient skeleton) or any
-/// keyed thumbnail at an explicit resolution (flat placeholder skeleton).
+/// Source art for a [`card`]: a catalog poster (resolved 250×375, dark gradient skeleton), any
+/// keyed thumbnail at an explicit resolution (flat placeholder skeleton), or a person's headshot
+/// (the same thumbnail, but its EMPTY case draws a person glyph rather than a blank tile).
 pub(crate) enum Art<'a> {
     Poster(Option<&'a PmsMovie>),
     Thumb { key: &'a str, res: (c_int, c_int) },
+    /// A credit's headshot (the Cast & Crew shelf). Distinct from [`Art::Thumb`] because a
+    /// missing headshot is ROUTINE here — the server has one for most actors and for few crew —
+    /// and an empty circle beside named circles reads as a broken image rather than as a person
+    /// the metadata agent has no photo of.
+    Person { key: &'a str, res: (c_int, c_int) },
 }
 
 /// The one art-tile draw op. Resolves `art` to a texture (or a dark skeleton) and draws it at `frame`,
@@ -71,8 +77,38 @@ pub(crate) fn card(p: Painter, frame: Rect, art: Art, rad: f32, focused: bool, s
                 p.rrect_sheened(r, rad, theme::CARD_PLACEHOLDER);
             }
         }
+        Art::Person { key, res } => {
+            let t = resolve_tex(key, res.0, res.1, 0);
+            if t != 0 {
+                p.tex_carded(t, r, rad, theme::TINT_WHITE, f);
+            } else {
+                p.rrect_sheened(r, rad, theme::CARD_PLACEHOLDER);
+                // Only for a person the server has NO headshot of — an unresolved texture with a
+                // key behind it is merely still loading, and glyphing that would flash a "no
+                // photo" mark on every tile of every page for the length of its fetch.
+                if key.is_empty() {
+                    // quantize the glyph box to 4px so the focus-pop animation reuses a handful of
+                    // cached icon masks instead of rasterizing + uploading one per rounded pixel
+                    // (same discipline as the unwatched angle above)
+                    let d = ((r.w * PERSON_GLYPH_RATIO) / 4.0).round() * 4.0;
+                    crate::ui::icons::draw(
+                        p,
+                        crate::ui::icons::Icon::User,
+                        Rect::new(r.cx() - d * 0.5, r.cy() - d * 0.5, d, d),
+                        theme::TEXT_TERTIARY,
+                    );
+                }
+            }
+        }
     }
 }
+
+/// Person-glyph box as a fraction of a headshot tile — the [`Art::Person`] fallback's one ratio.
+/// Deliberately TIGHTER than [`DISC_ICON_RATIO`] (0.54, the ratio every disc *control* glyph uses,
+/// and what the profile chip's own fallback works out to): a headshot tile is 190px, and 0.54 of it
+/// is past `icons::tex_for`'s 96px rasterization clamp — the mask would be upscaled and soft. At
+/// 0.44 the box lands at 84-88px across the whole focus pop, inside the clamp and crisp.
+const PERSON_GLYPH_RATIO: f32 = 0.44;
 
 /// The scale a focused card pops to (shared by every animated card row).
 pub(crate) const CARD_FOCUS_SCALE: f32 = 1.07;


### PR DESCRIPTION
Unit 5 of the movie/TV parity batch (`docs/parity-gaps.md` §2 theme B, cheap win #7): PMS sends
`Director[]` and `Writer[]` on every movie and episode we already fetch, and we parsed them into
the DTO and threw them away — with the shelf that should hold them titled "Cast & Crew" and filled
with nothing but `Role[]` actors. **No new endpoint, no extra round trip.**

## What lands

**1. A "Directed by …" line in the hero metadata block**, under the date/runtime fine print
(`size::CAPTION`, `TEXT_SECONDARY` — a step brighter than the filing data above it, because these
are names). Its band is reserved *inside* the shared `hero_layout` y-chain, not drawn on top of it,
so the Play pill still clears the text and an item with **no** directors keeps the exact button y it
had. The arithmetic half of that chain is split out as `hero_chain(syn_h, has_director)` so the
flow-vs-paint contract is host-testable at all — measuring the synopsis needs SDL_ttf, which the
host suite does not open.

**2. Crew mixed into the Cast & Crew row**, so the heading stops lying: actors first, then crew,
addressed through one flat index space (`Detail::credits_len` / `Detail::credit`) so the screen's
focus, geometry and section gate never have to know which vec a tile fell in. Actors keep their
character as the sub-caption; **crew get their job**, because (verified live) crew rows are actor
rows *minus* `role` — `{id, filter, tag, tagKey, count, thumb}` — so the job exists nowhere but the
array the person arrived in. A person credited twice collapses into ONE tile reading
`Director, Writer`; two identical headshots side by side read as a duplication bug, not two credits.
Repeats *within* one array (agent merges do produce them) don't yield "Director, Director", and the
hero line dedupes the same way.

## Two shared-component fixes the crew forced out — both already wrong for long ACTOR lists

* **`Art::Person`** (`ui/widgets.rs`) — a headshot tile whose EMPTY case draws a person glyph over
  the placeholder instead of a blank disc. Missing headshots are routine for crew: **12 of this
  server's 26 movies** have at least one thumbless director/writer. Only *genuinely absent* art
  glyphs — a key that is merely still loading keeps the plain placeholder, or every tile on the page
  would flash "no photo" while its photo arrives. The absolute `metadata-static.plex.tv` URL rides
  the same server-side `/photo/:/transcode` fetch the actor circles already use (our raw socket can
  do neither DNS nor TLS; the server does both). Glyph box is quantized to 4px so the focus pop
  reuses two cached masks instead of rasterizing one per rounded pixel, and it stays inside
  `icons::tex_for`'s 96px clamp.
* **`CardRow` overflow spring** (`ui/card_row.rs`) — cells past the 24-spring array shared cell 23's
  spring by index clamp, and *every* focus treatment a tile gets (pop, lifted shadow, ring) is
  derived from that scale. So focusing the 30th tile of a 60-name cast row animated **nothing**.
  They now share one dedicated overflow spring that only the focused cell reads. Latent before this
  PR (most movies here have 20–120 actors); the crew lands at exactly that end of the row, which is
  what made it worth fixing rather than noting.

## Verification

* `make check` — **63 pass** (58 baseline **+5**): the crew fold driven through serde from the live
  JSON shape (so the DTO half is under test too), the flat credit index incl. out-of-range and
  crew-only items, the conditional hero band at both a short and a tall synopsis, the crew-only
  shelf gate, and the overflow-spring pop.
* `make` — ARM cross-build green.
* **Device: not run.** I acquired the TV lock and released it unused when the coordinator
  centralised device verification. Recipe below.

## Device verification: deferred to coordinator

Two things to see, and one movie shows all of them: **`ratingKey=2029` — "Obsession"**. Its entire
crew is *Jackson Treadway*, credited **Director *and* Writer**, with **no headshot on the server**,
and it has only 2 actors, so all three tiles fit on screen without scrolling the row. (Backups with
a *mixed* row: `2020` "My Fault: London" — 2 directors, one thumbless; `2012` "Wallace & Gromit:
Vengeance Most Fowl" — 3 thumbless writers.)

```sh
# 1) FPS regression (UI tier — this change draws on home/library/detail).
#    The detail-transition scene already sweeps the Cast & Crew row on rk 2012,
#    which has three thumbless crew members, so it exercises the glyph path.
./tests/run.py --fps          # expect 5/5; detail-transition floor 45

# 2) Boot straight onto the movie detail page and capture the HERO.
TOK=$(grep PMS_TOKEN src/config.local.h | sed -E 's/.*"([^"]*)".*/\1/')
SSH='sshpass -p alpine ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@192.168.0.114'
$SSH "find /tmp -maxdepth 1 -name 'plxnative-*' ! -name '*.log' -exec rm -f {} + ; \
      printf '%s' '$TOK' > /tmp/plxnative-token ; printf '2029' > /tmp/plxnative-detail"
make run RUN_SECS=70 &                       # leaves the app up for the two captures
sleep 25
tools/capture-screen.sh /tmp/unit-5-hero.png DISPLAY

# 3) One remote 'down' moves focus from the hero to the Cast & Crew shelf; capture it.
$SSH "printf 'down\n' > /tmp/plxnative-remote"
sleep 4
tools/capture-screen.sh /tmp/unit-5-cast.png DISPLAY
wait                                          # the run prints the event log

# 4) hand the TV back
make kill
$SSH "find /tmp -maxdepth 1 -name 'plxnative-*' ! -name '*.log' -exec rm -f {} +"
```

**What proves it works**

| Artifact | Look for |
|---|---|
| `/tmp/unit-5-hero.png` | a **`Directed by Jackson Treadway`** line in the hero text column, under the date/runtime line and above the Play pill — not overlapping either, and the Play pill still fully on screen |
| `/tmp/unit-5-cast.png` | the Cast & Crew row holding **3** circles: 2 actors with headshots + character names, then **Jackson Treadway** captioned **`Director, Writer`** — his circle is the empty-thumb case, so it must show a **person glyph on the placeholder disc**, not a blank circle, and it must **pop + ring when focused** |
| the event log (`make run` prints it) | `detail: rk=2029 … cast=2 crew=1 …` — the new `crew=` field is the parse proof |

If the hero line is missing, `directors()` came back empty → check the `detail:` log line's `crew=`
count first; if that is `1` but no line drew, the bug is in the hero, not the parse.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
