### PR TITLE
ui: the tab row scrolls, so every library is reachable

### DIFF
--- a/rust-modules/src/ui/home.rs
+++ b/rust-modules/src/ui/home.rs
@@ -216,10 +216,21 @@ pub(crate) fn hero_focus() -> c_int {
     unsafe { addr_of!(hero_fc).read() }
 }
 pub(crate) fn set_hero_focus(v: c_int) {
-    // cap at what the tab row can draw — focus must never land on a truncated pill
-    let npill = 1 + crate::browse::section_count().min(crate::ui::widgets::MAX_TABS - 1); // Home + sections
-    let lo = hero_focus_for_pill(npill - 1);
-    unsafe { addr_of_mut!(hero_fc).write(v.clamp(lo, HERO_NBTN as c_int - 1)) }
+    unsafe { addr_of_mut!(hero_fc).write(v.clamp(hero_focus_lo(), HERO_NBTN as c_int - 1)) }
+}
+
+/// The lowest (most negative) hero-focus value: the LAST tab pill. Every discovered library
+/// section has one — the row scrolls to reach the pills past the screen width, so the clamp is
+/// the section count, no longer a hard cap that hid a fifth library from the whole UI.
+/// ([`crate::ui::widgets::tab_count`] is the one source of that count; it is never 0, so the
+/// subtraction can't wrap.)
+fn hero_focus_lo() -> c_int {
+    hero_focus_lo_for(crate::ui::widgets::tab_count())
+}
+/// The pure half of [`hero_focus_lo`] — split out so the "focus reaches the LAST section however
+/// many there are" invariant is host-testable without a live section table.
+fn hero_focus_lo_for(npill: usize) -> c_int {
+    hero_focus_for_pill(npill.max(1) - 1)
 }
 
 /// Decode a top-band focus value to its tab-pill index (0 = Home, 1.. = sections), or None
@@ -810,6 +821,10 @@ pub(crate) fn home_update(dt: f32) {
         unsafe {
             (*addr_of_mut!(chip_expand)).step(if chip_focused() { 1.0 } else { 0.0 }, K_CHIP, dt)
         };
+        // the shared tab strip's horizontal scroll, same deal: a server with more libraries than
+        // fit the row reaches the rest by scrolling the focused pill into view. Home is always
+        // this screen's selected tab, so off the band the strip returns to the start.
+        crate::ui::widgets::tab_row_update(0, hero_pill_index(hero_focus()).map(|i| i as c_int).unwrap_or(-1), dt);
         let env = h.env(dt);
         h.grid.update(&env);
     });
@@ -822,11 +837,15 @@ pub(crate) fn home_draw() {
         let env = h.env(0.0);
         h.grid.layout(env.screen, &env); // &mut layout before the &self composite draw
         h.draw(&env, Painter::root());
-        draw_chip(Painter::root());
         // the centered library tab pills (shared with the Library screen): Home is the selected
         // tab here; a pill holds focus when the hero top band is on it.
         let pf = hero_pill_index(hero_focus()).map(|i| i as c_int).unwrap_or(-1);
         crate::ui::widgets::draw_tab_row(Painter::root(), 0, pf);
+        // the chip goes on TOP of the tab track, not under it. Its focused capsule unfurls the
+        // profile name to its right, and with enough libraries the (centered) track now reaches
+        // far enough left to meet it — under the track, the name was painted over by the track's
+        // own scrim. Both are the same dark material, so an overlap reads as one band.
+        draw_chip(Painter::root());
     });
 }
 
@@ -935,10 +954,11 @@ mod tests {
     /// Regression: the top band packed pill `i` as `-(i+1)`, so Home (pill 0) landed on -1 — the
     /// profile chip's value. `hero_pill_index` rejects anything above -2, so the Home pill was
     /// unreachable by D-pad and could never wear the focused (white) treatment on its own screen.
-    /// The packing now round-trips for EVERY pill the row can draw, Home included.
+    /// The packing now round-trips for EVERY pill the row can draw, Home included — and the row
+    /// is no longer capped at 5, so the sweep runs well past the old bound.
     #[test]
     fn every_tab_pill_round_trips_through_the_focus_packing() {
-        for i in 0..crate::ui::widgets::MAX_TABS {
+        for i in 0..32usize {
             let f = hero_focus_for_pill(i);
             assert_ne!(f, -1, "pill {i} must not alias the profile chip");
             assert_eq!(hero_pill_index(f), Some(i), "pill {i} must decode back to itself");
@@ -946,6 +966,55 @@ mod tests {
         assert_eq!(hero_pill_index(-1), None, "the profile chip is not a pill");
         assert_eq!(hero_pill_index(0), None, "the hero Play pill is not a tab pill");
         assert_eq!(hero_pill_index(c_int::MIN), None, "the grid-card sentinel is not a pill");
+    }
+
+    /// Regression (unit 10): the top band clamped focus at `MAX_TABS - 1` = 4 sections, so a
+    /// server with a fifth `movie`/`show` library had no way at all to reach it — `browse`
+    /// discovered it, the grid browsed it, and RIGHT simply stopped. Walking RIGHT from the Home
+    /// pill must now land on the LAST pill for any section count, and never past it.
+    #[test]
+    fn top_band_focus_walks_to_the_last_section_whatever_the_count() {
+        for npill in 1..=8usize {
+            let lo = hero_focus_lo_for(npill);
+            // RIGHT in the top band is `set_hero_focus(f - 1)` (more negative = further right)
+            let mut f = hero_focus_for_pill(0);
+            for _ in 0..npill + 4 {
+                f = (f - 1).clamp(lo, HERO_NBTN as c_int - 1);
+                assert!(
+                    hero_pill_index(f).map(|i| i < npill).unwrap_or(false),
+                    "walking RIGHT with {npill} pills left focus on {f}, which is not a drawable pill"
+                );
+            }
+            assert_eq!(
+                hero_pill_index(f),
+                Some(npill - 1),
+                "RIGHT must reach the last of {npill} pills"
+            );
+            // and LEFT walks back through every pill to Home, then off the pills onto the chip
+            for _ in 0..npill - 1 {
+                f = (f + 1).clamp(lo, HERO_NBTN as c_int - 1);
+            }
+            assert_eq!(hero_pill_index(f), Some(0), "LEFT must return to the Home pill");
+            f = (f + 1).clamp(lo, HERO_NBTN as c_int - 1);
+            assert_eq!(f, -1, "one more LEFT leaves the pills for the profile chip");
+        }
+    }
+
+    /// …and the clamp is actually WIRED to the pill count. The walk above drives the pure helper;
+    /// this drives the real setter, which is the line the cap used to live on. The host has no
+    /// section table (`browse::reset` — the only writer any test reaches — always leaves it
+    /// empty), so the row here is the Home pill alone and the band's last pill IS Home.
+    #[test]
+    fn set_hero_focus_clamps_onto_the_last_drawable_pill() {
+        let _g = FOCUS.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = hero_focus();
+        assert_eq!(crate::ui::widgets::tab_count(), 1, "no sections discovered on the host");
+        set_hero_focus(c_int::MIN / 2);
+        assert_eq!(hero_focus(), hero_focus_for_pill(0), "past the last pill clamps onto it");
+        assert_eq!(hero_pill_index(hero_focus()), Some(0));
+        set_hero_focus(999);
+        assert_eq!(hero_focus(), HERO_NBTN as c_int - 1, "past the action row clamps to its end");
+        set_hero_focus(saved);
     }
 
     #[test]

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -51,7 +51,7 @@ const SCRIM_KNEE_A: f32 = 0.40;
 const SCRIM_IN: f32 = 56.0;
 /// Row pitch: card + the focused under-label band (title + caption) before the next row.
 const PITCH: f32 = CARD_H + 96.0;
-use crate::ui::widgets::{MAX_TABS, TOP_BAR_Y}; // the shared top-bar chrome lives in widgets
+use crate::ui::widgets::TOP_BAR_Y; // the shared top-bar chrome lives in widgets
 
 // ---- screen state (main-thread statics, same discipline as home.rs) -------------------------
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -126,6 +126,16 @@ fn menu() -> Menu {
 fn area() -> Area {
     unsafe { addr_of!(AREA).read() }
 }
+/// The tab pill holding remote focus, or -1. ONE source for it: the draw pass and the strip's
+/// scroll step must agree on which pill to keep on screen, or the row chases a pill it isn't
+/// highlighting.
+fn tab_focus() -> c_int {
+    if area() == Area::Tabs && !menu_open() {
+        unsafe { addr_of!(TAB_F).read() as c_int }
+    } else {
+        -1
+    }
+}
 
 // ---- derived grid facts ---------------------------------------------------------------------
 fn total() -> usize {
@@ -183,6 +193,10 @@ pub(crate) fn enter(sec: usize) {
     crate::browse::set_cur(sec.min(n - 1));
     crate::browse::kick_letters();
     restore_view();
+    // with more libraries than fit the row, a section past the visible pills would open with its
+    // own tab off screen (the `/tmp/plxnative-library=N` boot, or a restored far-right section).
+    // Put it on screen once, here, rather than dragging the row every frame.
+    crate::ui::widgets::tab_row_reveal(crate::browse::cur() + 1);
     unsafe {
         AREA = Area::Grid;
         MENU = Menu::None;
@@ -308,6 +322,10 @@ pub(crate) fn update(dt: f32) {
         // remember the view for re-entry (state amnesia is the official app's #2 complaint)
         crate::browse::save_view(focus_idx(), (*addr_of!(SCROLL)).pos);
     }
+    // the shared tab strip's horizontal scroll — with more libraries than fit the row, this is
+    // what reaches the far pills. Drawn from `.pos`; the draw pass runs at dt=0. Off the tab row
+    // it tracks THIS section's pill, which `enter` already put on screen, so it holds still.
+    crate::ui::widgets::tab_row_update(crate::browse::cur() as c_int + 1, tab_focus(), dt);
     if menu_open() {
         pop().update(dt);
         let ph = panel_rect().h;
@@ -338,8 +356,9 @@ pub(crate) fn move_focus(sym: c_uint) {
     unsafe {
         match area() {
             Area::Tabs => {
-                // clamp to what the row can DRAW — focus must never walk onto a truncated pill
-                let n = (1 + crate::browse::section_count()).min(MAX_TABS);
+                // Home + every section: the row scrolls the far pills into view, so focus may
+                // walk to the last one (it used to stop at a hard cap of 4 sections)
+                let n = crate::ui::widgets::tab_count();
                 if sym == SDLK_LEFT && TAB_F > 0 {
                     TAB_F -= 1;
                 } else if sym == SDLK_RIGHT && TAB_F + 1 < n {
@@ -890,8 +909,7 @@ pub(crate) fn draw() {
     // never unfurls here — expand 0.
     let cd = crate::ui::widgets::CHIP_D;
     crate::ui::widgets::profile_chip(p, Rect::new(MARGIN_X, TOP_BAR_Y, cd, cd), 0.0);
-    let tab_focus = if area() == Area::Tabs && !menu_open() { (unsafe { addr_of!(TAB_F).read() }) as c_int } else { -1 };
-    crate::ui::widgets::draw_tab_row(p, crate::browse::cur() as c_int + 1, tab_focus);
+    crate::ui::widgets::draw_tab_row(p, crate::browse::cur() as c_int + 1, tab_focus());
 
     let tool_focus = |i: usize| area() == Area::Toolbar && !menu_open() && unsafe { addr_of!(TOOL_F).read() } == i;
     let unw = crate::browse::unwatched();

--- a/rust-modules/src/ui/mod.rs
+++ b/rust-modules/src/ui/mod.rs
@@ -133,6 +133,17 @@ impl Rect {
     pub fn inset(&self, d: f32) -> Rect {
         Rect::new(self.x + d, self.y + d, self.w - 2.0 * d, self.h - 2.0 * d)
     }
+    /// The overlap of two rects — the part of `self` that `o` lets through. A miss returns a
+    /// ZERO-SIZE rect (never a negative one), so `w > 0` is a clean "any of this is visible?"
+    /// test. This is how a scissor-clipped strip records what it actually drew: hit-testing the
+    /// clipped rect instead of the laid-out one is what stops an off-screen item staying
+    /// clickable at coordinates it no longer occupies.
+    #[inline]
+    pub fn intersect(&self, o: Rect) -> Rect {
+        let (x0, y0) = (self.x.max(o.x), self.y.max(o.y));
+        let (x1, y1) = ((self.x + self.w).min(o.x + o.w), (self.y + self.h).min(o.y + o.h));
+        Rect::new(x0, y0, (x1 - x0).max(0.0), (y1 - y0).max(0.0))
+    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -506,9 +506,15 @@ impl View for TabPill {
 // sections>) sit CENTERED — the tvOS tab-bar idiom. Drawn by BOTH the Home screen and the
 // Library screen so they read as one global tab bar; the pill rects live here so both
 // screens' pointer paths share [`tab_pill_at`]. ----
-/// Home + up to 4 sections. Focus walking and the rects clamp to this — a pill that can't be
-/// drawn must never be focusable.
-pub(crate) const MAX_TABS: usize = 5;
+/// Home + **every** discovered library section. Focus walking clamps to this — the invariant is
+/// still "a pill that can't be drawn must never be focusable", but it now holds by construction
+/// rather than by a cap: the strip scrolls horizontally inside its track (see
+/// [`tab_scroll_target`]), so every pill can be brought into view and every pill is focusable.
+/// This used to be a hard `MAX_TABS = 5`, which left a fifth `movie`/`show` section unreachable
+/// from the UI even though `browse` discovers it and the grid browses it fine.
+pub(crate) fn tab_count() -> usize {
+    1 + crate::browse::section_count()
+}
 /// The top chrome band's y — the chip and the pills sit on it (Home and Library alike).
 pub(crate) const TOP_BAR_Y: f32 = 44.0;
 /// SAME element, SAME geometry as the detail season tabs (user directive): one control height
@@ -522,28 +528,59 @@ const TAB_PILL_PAD: f32 = 18.0;
 /// selected Home pill. The focused [`profile_chip`] wraps itself in the same inset, which is what
 /// makes its capsule and this track one band.
 pub(crate) const TAB_TRACK_PAD: f32 = 8.0;
-static mut PILL_RECTS: [Rect; MAX_TABS] = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_TABS];
-static mut N_PILLS: usize = 0;
+/// Inter-pill air ≈ the season tabs' rhythm (their `TAB_ADVANCE` 52 minus the 2×18 pad the pills
+/// here already carry — pill edge to pill edge reads the same). Doubles as the scroll-into-view
+/// context margin, exactly as the season tabs use their advance.
+const TAB_GAP: f32 = 16.0;
+/// How wide the pill strip may grow before it starts scrolling. The row stays CENTERED, but it
+/// must never reach the profile chip (a focus stop of its own at `MARGIN_X`), so the viewport is
+/// the screen less a symmetric chip-clearing margin, less the track's own inset on both ends.
+const TAB_SIDE_CLEAR: f32 = crate::ui::consts::MARGIN_X + CHIP_D + theme::space::MD;
+const TAB_VIEW_MAX: f32 = crate::ui::consts::SCR_W - 2.0 * (TAB_SIDE_CLEAR + TAB_TRACK_PAD);
+/// The strip's scroll stiffness. The detail page's season-tab row springs at the same 240 — same
+/// control, same overflow problem, so the two rows must move alike (the user directive that keeps
+/// the tab pills and the season tabs in step covers their motion, not just their geometry).
+const K_TAB_SCROLL: f32 = 240.0;
+/// The VISIBLE part of each pill as drawn this frame (scroll folded in, then intersected with the
+/// strip's viewport), one entry per pill — never a fixed array's worth, or the hit test would stop
+/// where the old cap did. Storing the *clipped* rect is what keeps the hit test and the scissor
+/// telling the same story: a pill scrolled out of the track has zero width here, so it is neither
+/// drawn nor clickable, and a half-visible one is clickable exactly across the half you can see.
+static mut PILL_RECTS: Vec<Rect> = Vec::new();
+/// Horizontal scroll of the strip inside its track; 0 whenever the whole row fits.
+static mut TAB_SCROLL: crate::ui::Spring = crate::ui::Spring::at(0.0);
 // label + width cache keyed on browse::sections_gen(): rebuilding the CStrings and
 // re-measuring every frame — on Home's hot path too — was a review-confirmed waste
 static mut TAB_CACHE: Option<(u32, Vec<std::ffi::CString>, Vec<f32>)> = None;
 
-/// The tab pill under the pointer (0 = Home, 1.. = sections), or None.
+/// The tab pill under the pointer (0 = Home, 1.. = sections), or None. Matches against the
+/// CLIPPED rects, so only the pill area you can actually see is clickable.
+///
+/// One consequence worth knowing: these rects are the last DRAWN frame's, so a click that lands
+/// while the strip is mid-reveal is graded against where the pills were when the user last saw
+/// them — which is the right frame to grade against, but does mean a click aimed at a pill the
+/// spring is still carrying can land on its neighbour. The strip only moves in response to the
+/// user's own focus move, so the two gestures do not overlap in practice.
 pub(crate) fn tab_pill_at(mx: f32, my: f32) -> Option<usize> {
-    let n = unsafe { std::ptr::addr_of!(N_PILLS).read() };
-    let rects = unsafe { std::ptr::addr_of!(PILL_RECTS).read() };
-    rects[..n].iter().position(|r| r.contains(mx, my))
+    let rects = unsafe { &*std::ptr::addr_of!(PILL_RECTS) };
+    rects.iter().position(|r| r.w > 0.5 && r.contains(mx, my))
 }
 
-/// Draw the centered pill row. `selected` = the tab whose screen is showing (0 = Home);
-/// `focused` = the pill holding remote focus, or -1. Records the rects for [`tab_pill_at`].
-pub(crate) fn draw_tab_row(p: Painter, selected: std::os::raw::c_int, focused: std::os::raw::c_int) {
+/// Run `f` with the tab row's labels + pill widths, rebuilding them only when
+/// `browse::sections_gen()` moves. Shared by the per-frame scroll step and the draw, so the two
+/// can't measure the strip differently.
+///
+/// Deliberately a closure and not a `&'static` getter: the borrow points into `TAB_CACHE`, and a
+/// nested rebuild would free the `CString`s a caller is still handing to `TabPill` as a raw
+/// `*const c_char`. Scoping it here makes that impossible to write by accident — so do NOT call
+/// this again from inside `f`.
+fn with_tab_metrics<R>(f: impl FnOnce(&[std::ffi::CString], &[f32]) -> R) -> R {
     use std::ffi::CString;
     use std::ptr::addr_of_mut;
     let gen = crate::browse::sections_gen();
     let cache = unsafe { &mut *addr_of_mut!(TAB_CACHE) };
     if cache.as_ref().map(|c| c.0 != gen).unwrap_or(true) {
-        let nsec = crate::browse::section_count().min(MAX_TABS - 1);
+        let nsec = crate::browse::section_count();
         let mut labels: Vec<CString> = Vec::with_capacity(1 + nsec);
         labels.push(CString::new("Home").unwrap_or_default());
         for i in 0..nsec {
@@ -558,37 +595,132 @@ pub(crate) fn draw_tab_row(p: Painter, selected: std::os::raw::c_int, focused: s
         *cache = Some((gen, labels, widths));
     }
     let (_, labels, widths) = cache.as_ref().unwrap();
-    let n = labels.len();
-    // inter-pill air ≈ the season tabs' rhythm (their TAB_ADVANCE 52 minus the 2×18 pad the
-    // pills here already carry — pill edge to pill edge reads the same)
-    let gap = 16.0f32;
-    let total_w: f32 = widths.iter().sum::<f32>() + gap * (n as f32 - 1.0);
-    let x0 = (crate::ui::consts::SCR_W - total_w) * 0.5;
-    // ONE translucent dark capsule contains the whole row — the tvOS tab-bar track. It (not the
-    // segments) owns legibility over bright hero art: inside it the segments keep their clean
-    // season-tab looks (plain = bare dim text). Sheened for the 1px glass rim. The uniform inset
-    // (and so the concentric radii) is [`TAB_TRACK_PAD`], shared with the focused profile chip.
-    let track = Rect::new(
-        x0 - TAB_TRACK_PAD,
-        TOP_BAR_Y - TAB_TRACK_PAD,
-        total_w + 2.0 * TAB_TRACK_PAD,
-        TAB_PILL_H + 2.0 * TAB_TRACK_PAD,
-    );
-    // dark-material weight: light enough to keep a hint of the art, dark enough that the
-    // TEXT_TERTIARY plain segments hold contrast even over pure-white art (Toy Story 2)
-    p.rect_sheened(track, track.h * 0.5, theme::scrim_black(0.72), theme::scrim_black(0.82));
-    let mut x = x0;
-    let env = Env::inert();
-    unsafe { N_PILLS = n };
-    for i in 0..n {
-        let r = Rect::new(x, TOP_BAR_Y, widths[i], TAB_PILL_H);
-        unsafe { (*std::ptr::addr_of_mut!(PILL_RECTS))[i] = r };
-        TabPill::new(labels[i].as_ptr(), theme::size::BODY, r)
-            .segment(i as c_int == selected)
-            .focused(i as c_int == focused)
-            .draw(&env, p);
-        x += widths[i] + gap;
+    f(labels, widths)
+}
+
+/// Content width of the whole pill strip: the pills plus the air between them.
+fn tab_content_w(widths: &[f32]) -> f32 {
+    widths.iter().sum::<f32>() + TAB_GAP * (widths.len() as f32 - 1.0).max(0.0)
+}
+/// The VISIBLE pill area: the strip's own width until it outgrows [`TAB_VIEW_MAX`], then that.
+fn tab_view_w(widths: &[f32]) -> f32 {
+    tab_content_w(widths).min(TAB_VIEW_MAX).max(0.0)
+}
+/// Content-space x of pill `i`'s left edge (0 = the strip's start).
+fn tab_pill_x(widths: &[f32], i: usize) -> f32 {
+    let i = i.min(widths.len());
+    widths[..i].iter().sum::<f32>() + TAB_GAP * i as f32
+}
+/// Scroll offset that brings pill `idx` into the strip's viewport: the minimal scroll-into-view
+/// rule the season tabs and every shelf share ([`card_row::reveal`]) — move only when the pill
+/// (± one gap of context) would clip, and never past the content ends. Pure, so the "every pill
+/// is reachable" invariant is host-testable without a font.
+fn tab_scroll_target(widths: &[f32], idx: usize, cur: f32) -> f32 {
+    let view_w = tab_view_w(widths);
+    let max = (tab_content_w(widths) - view_w).max(0.0);
+    if idx >= widths.len() {
+        return cur.clamp(0.0, max);
     }
+    let x = tab_pill_x(widths, idx);
+    let lo = x + widths[idx] + TAB_GAP - view_w; // right edge (+ context) on screen
+    let hi = x - TAB_GAP; // left edge (− context) on screen
+    crate::ui::card_row::reveal(cur, lo, hi, max)
+}
+
+/// Step the strip's horizontal scroll — called once per frame from BOTH screens' update (the draw
+/// runs at dt=0, like the profile chip's unfurl). `focused` = the pill holding remote focus or -1,
+/// `selected` = the tab whose screen is showing.
+///
+/// Off the row it tracks the SELECTED pill, and on Home that means the strip returns to the start
+/// when focus leaves the band. That is deliberate, and it is where this differs from the season
+/// tabs (which HOLD): the way back INTO the band is the profile chip and then the Home pill — its
+/// left end — so a strip parked far to the right would be showing pills that the next keypress
+/// cannot reach without scrolling back anyway, under a row with no selected tab visible. Reveal
+/// is minimal-scroll, so this is a no-op whenever the selected pill is already on screen, which is
+/// the whole of the Library screen's life after [`tab_row_reveal`] placed it.
+pub(crate) fn tab_row_update(selected: c_int, focused: c_int, dt: f32) {
+    use std::ptr::{addr_of, addr_of_mut};
+    let idx = if focused >= 0 { focused } else { selected.max(0) } as usize;
+    let cur = unsafe { addr_of!(TAB_SCROLL).read() };
+    let t = with_tab_metrics(|_, w| tab_scroll_target(w, idx, cur.pos));
+    unsafe { (*addr_of_mut!(TAB_SCROLL)).step(t, K_TAB_SCROLL, dt) };
+    let s = unsafe { addr_of!(TAB_SCROLL).read() };
+    crate::ui::anim::probe("tabrow.scroll", s.pos, s.vel, t, dt);
+}
+
+/// Put pill `idx` on screen at once (no glide). For screen ENTRY — the Library screen opened
+/// straight into a far-right section (the `/tmp/plxnative-library=N` boot, or a section restored
+/// from the saved view) must show its own tab, and a long slide on arrival would be motion the
+/// user never asked for. Mirrors `detail.rs`'s `tab_hscroll.jump` on a fresh detail page.
+pub(crate) fn tab_row_reveal(idx: usize) {
+    use std::ptr::{addr_of, addr_of_mut};
+    let cur = unsafe { addr_of!(TAB_SCROLL).read() };
+    let t = with_tab_metrics(|_, w| tab_scroll_target(w, idx, cur.pos));
+    unsafe { (*addr_of_mut!(TAB_SCROLL)).jump(t) };
+}
+
+/// Draw the centered pill row. `selected` = the tab whose screen is showing (0 = Home);
+/// `focused` = the pill holding remote focus, or -1. Records the rects for [`tab_pill_at`].
+pub(crate) fn draw_tab_row(p: Painter, selected: std::os::raw::c_int, focused: std::os::raw::c_int) {
+    use std::ptr::{addr_of, addr_of_mut};
+    let rects = unsafe { &mut *addr_of_mut!(PILL_RECTS) };
+    rects.clear(); // nothing drawn = nothing hittable, including on the early return below
+    with_tab_metrics(|labels, widths| {
+        let n = labels.len();
+        if n == 0 {
+            return;
+        }
+        let content_w = tab_content_w(widths);
+        let view_w = tab_view_w(widths);
+        // ONE translucent dark capsule contains the whole row — the tvOS tab-bar track. It (not the
+        // segments) owns legibility over bright hero art: inside it the segments keep their clean
+        // season-tab looks (plain = bare dim text). Sheened for the 1px glass rim. The uniform inset
+        // (and so the concentric radii) is [`TAB_TRACK_PAD`], shared with the focused profile chip.
+        // The track is the strip's width until the strip outgrows the screen, then it caps and the
+        // pills scroll inside it — the track itself never moves.
+        let x0 = (crate::ui::consts::SCR_W - view_w) * 0.5;
+        let track = Rect::new(
+            x0 - TAB_TRACK_PAD,
+            TOP_BAR_Y - TAB_TRACK_PAD,
+            view_w + 2.0 * TAB_TRACK_PAD,
+            TAB_PILL_H + 2.0 * TAB_TRACK_PAD,
+        );
+        // dark-material weight: light enough to keep a hint of the art, dark enough that the
+        // TEXT_TERTIARY plain segments hold contrast even over pure-white art (Toy Story 2)
+        p.rect_sheened(track, track.h * 0.5, theme::scrim_black(0.72), theme::scrim_black(0.82));
+        // A strip wider than its track is a bounded panel, not a scrolling document, so this is the
+        // scissor case (see the ui/CLAUDE.md clipping rule): a pill leaving the row is cut at the
+        // pill area's edge — which is also the "there is more over there" affordance. Paired below.
+        // A non-zero scroll clips too even when the strip now fits: the section table can shrink
+        // (sign-out, server switch) and the spring takes a few frames to unwind, and those frames
+        // must not paint pills outside the track.
+        let view = Rect::new(x0, TOP_BAR_Y, view_w, TAB_PILL_H);
+        let sx = unsafe { addr_of!(TAB_SCROLL).read() }.pos;
+        let scrolls = content_w > view_w + 0.5 || sx.abs() > 0.5;
+        if scrolls {
+            p.clip(view);
+        }
+        let env = Env::inert();
+        rects.reserve(n);
+        for i in 0..n {
+            let r = Rect::new(x0 + tab_pill_x(widths, i) - sx, TOP_BAR_Y, widths[i], TAB_PILL_H);
+            // ONE rule for "is this pill on screen": its rect clipped to the viewport. The clipped
+            // rect is what gets recorded for the hit test AND what decides whether to draw at all
+            // (a 12-library server would otherwise lay out three rows' worth of text the scissor
+            // throws away), so the two can never disagree about a sliver at the edge.
+            let vis = r.intersect(view);
+            rects.push(vis);
+            if vis.w > 0.5 {
+                TabPill::new(labels[i].as_ptr(), theme::size::BODY, r)
+                    .segment(i as c_int == selected)
+                    .focused(i as c_int == focused)
+                    .draw(&env, p);
+            }
+        }
+        if scrolls {
+            p.clip_clear();
+        }
+    })
 }
 
 /// Which colour treatment a control (Button / CircleButton) wears. One control widget, three looks —
@@ -747,4 +879,82 @@ pub(crate) fn badge(p: Painter, x: f32, cy: f32, text: &str, style: BadgeStyle) 
     let ty = crate::text::text_vcenter_y(sz, 1, cy);
     p.text(lc.as_ptr(), x + w * 0.5, ty, sz, ink, 1, 1);
     w
+}
+
+// ---------------------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A spread of pill widths. Deliberately wider than the device's (a real "TV" pill measures
+    /// ≈67px at `size::BODY`, "Kids & Family Movies" ≈350) so a modest pill count crosses
+    /// [`TAB_VIEW_MAX`] and the overflow arithmetic is exercised without inventing 30 libraries —
+    /// the thresholds below are therefore about the geometry, not about a particular server.
+    fn widths_for(n: usize) -> Vec<f32> {
+        (0..n).map(|i| 140.0 + (i % 5) as f32 * 60.0).collect()
+    }
+
+    /// The unit-10 invariant, stated the way the [`tab_count`] doc states it: EVERY pill can be
+    /// drawn, because the strip scrolls to it. For any section count, and from any starting
+    /// scroll, the target for pill `i` puts that whole pill inside the visible strip — so no
+    /// focusable index can lack a drawn rect, which is what the old `MAX_TABS` cap used to buy
+    /// by refusing to focus the pills it could not reach.
+    #[test]
+    fn every_pill_scrolls_fully_into_the_strips_viewport() {
+        for n in 1..=16usize {
+            let w = widths_for(n);
+            let view_w = tab_view_w(&w);
+            let max = (tab_content_w(&w) - view_w).max(0.0);
+            for &start in &[0.0f32, 400.0, -900.0, 9000.0] {
+                for i in 0..n {
+                    let t = tab_scroll_target(&w, i, start);
+                    assert!(t >= -0.01 && t <= max + 0.01, "n={n} i={i}: scroll {t} outside 0..={max}");
+                    let x = tab_pill_x(&w, i) - t; // the pill's left edge in viewport space
+                    assert!(
+                        x >= -0.01 && x + w[i] <= view_w + 0.01,
+                        "n={n} i={i} (start {start}): pill spans {x}..{} of a {view_w}-wide strip",
+                        x + w[i]
+                    );
+                }
+            }
+        }
+    }
+
+    /// A row that fits must keep its centered, unscrolled tvOS look — the track IS the content and
+    /// there is nowhere to scroll to. Past that the scroll is minimal, not eager: asking for a
+    /// pill that is already on screen must leave the strip exactly where it is, wherever that is.
+    #[test]
+    fn the_strip_scrolls_only_once_it_outgrows_the_row_and_only_as_far_as_it_must() {
+        let fits = widths_for(4);
+        assert!(tab_content_w(&fits) <= TAB_VIEW_MAX, "4 pills of this size must still fit");
+        assert_eq!(tab_view_w(&fits), tab_content_w(&fits), "the track is the content");
+        assert_eq!(tab_content_w(&fits) - tab_view_w(&fits), 0.0, "…so there is no scroll range");
+
+        let over = widths_for(12);
+        assert!(tab_content_w(&over) > TAB_VIEW_MAX, "12 pills of this size must overflow");
+        assert_eq!(tab_view_w(&over), TAB_VIEW_MAX, "the track caps at the viewport");
+        assert!(tab_scroll_target(&over, 11, 0.0) > 0.0, "the last pill must be scrolled to");
+        assert_eq!(tab_scroll_target(&over, 0, 0.0), 0.0, "the first pill is already at the start");
+        assert_eq!(tab_scroll_target(&over, 1, 0.0), 0.0, "a pill in view does not move the strip");
+        // and the same rule part-way along: pill 5 sits inside the viewport at scroll 800, so the
+        // strip HOLDS there rather than re-centering on it
+        assert_eq!(tab_scroll_target(&over, 5, 800.0), 800.0, "a mid-strip pill in view holds");
+    }
+
+    /// A focus index left over from a bigger section table (the table is refetched on sign-in or
+    /// a server switch) must clamp, not index out of bounds — the strip is drawn from these same
+    /// widths every frame, so a panic here would be a panic in the frame loop. Graded on an
+    /// OVERFLOWING row so the clamp has a non-zero range to be wrong about.
+    #[test]
+    fn a_stale_pill_index_clamps_instead_of_panicking() {
+        let w = widths_for(12);
+        let max = tab_content_w(&w) - tab_view_w(&w);
+        assert!(max > 0.0, "the fixture must actually have somewhere to scroll");
+        assert_eq!(tab_scroll_target(&w, 99, 500.0), 500.0, "an in-range scroll is left alone");
+        assert_eq!(tab_scroll_target(&w, 99, 9e3), max, "an over-scroll is pulled back to the end");
+        assert_eq!(tab_scroll_target(&w, 99, -5.0), 0.0, "a negative scroll is pulled to the start");
+        assert_eq!(tab_pill_x(&w, 99), tab_pill_x(&w, 12), "past the end reads as the strip's end");
+        assert_eq!(tab_content_w(&[]), 0.0, "an empty strip has no width and no gaps");
+        assert_eq!(tab_scroll_target(&[], 0, 12.0), 0.0);
+    }
 }


### PR DESCRIPTION
## Unit 10 — libraries past the fourth are unreachable

`docs/parity-gaps.md` §2 theme C. `MAX_TABS = 5` ("Home + up to 4 sections") hard-capped the only
navigation we have into a library. Everything under it was already fine and provably so:
`browse::ensure_sections` discovers every `movie`/`show` section, `browse::set_cur` accepts any
index below the count, and `/tmp/plxnative-library=N` browses section 4 and beyond correctly. Only
the pill row could not address them — so a user with Movies / TV / Kids Movies / Kids TV / 4K Movies
had a fifth library the app knew about, could load, and could not open.

### What changed

The cap is gone rather than raised — a bigger constant only moves the unreachable library further
out. The invariant in the old doc comment ("a pill that can't be drawn must never be focusable") is
kept, and now holds by construction instead: **the pill strip scrolls horizontally**, so every pill
can be brought into view, so every pill is focusable.

The treatment is ours, not the reference client's sidebar-with-an-overflow: the detail page's season
tabs already solve exactly this for a many-season show, and the tab pills are the same element by
explicit user directive. So the strip reuses that pattern — `card_row::reveal` minimal
scroll-into-view on a critically-damped spring at the season row's own stiffness (240). The track
stays centred and caps at a width that clears the profile chip on both sides; past that the pills
slide inside it, scissor-clipped at the pill area's edge (the bounded-panel clip case from
`ui/CLAUDE.md`, which doubles as the "there is more over there" affordance). **A row that fits is
untouched**: no clip, no scroll, the same centred tvOS bar as before — so on a server with four or
fewer video libraries this change is invisible.

- `widgets.rs` — `MAX_TABS` → `tab_count()` (the one source of the focusable pill count); pure
  geometry (`tab_content_w` / `tab_view_w` / `tab_pill_x` / `tab_scroll_target`), `tab_row_update`
  (the per-frame spring step both screens call) and `tab_row_reveal` (a jump, for screen entry).
  `PILL_RECTS` is a `Vec` of the pills **clipped to the viewport**, and that same clipped width
  decides whether to draw — one rule, so the scissor and the pointer can't disagree about a sliver
  at the strip's edge.
- `home.rs` — the top-band clamp goes through `tab_count()`; `home_update` steps the strip; the
  profile chip now draws **after** the track (its unfurled name capsule and a wide track can now
  meet, and under the track the name was painted over).
- `library.rs` — the Tabs-area walk goes through `tab_count()`; `update` steps the strip; `enter`
  reveals the entered section's own tab; the focused-pill expression is factored to one
  `tab_focus()` so draw and scroll can't disagree.
- `mod.rs` — `Rect::intersect`, in the retui core where the next clipped hit test can find it.

### Design note: what the strip does when the row is NOT focused

It tracks the **selected** pill rather than holding (this is where it departs from the season tabs,
which hold). The way back into the top band is the profile chip and then the Home pill — the strip's
left end — so a strip parked far to the right would be showing pills the next keypress cannot reach
without scrolling back anyway, under a row with no selected tab visible. Reveal is minimal-scroll,
so this is a no-op whenever the selected pill is already on screen, which is the whole of the
Library screen's life after `enter` placed it.

Known limitation, worth a follow-up if pointer parity matters: from Home's **grid** view, pointer
hover on the pills is deliberately disabled (it used to park focus on a tab so the next ENTER opened
a library), so a pointer-only user can click only the pills currently on screen. Every pill is
reachable by D-pad, and by pointer from the hero view where hover moves focus and the strip reveals.

### Verification (host tier)

- `make check` → **63 pass (+5)**. `make` (ARM cross-build) → clean, no new warnings.
- The >4-section case is proven here, since the dev server cannot exercise it:
  - `every_pill_scrolls_fully_into_the_strips_viewport` — for **1..=16 pills** and from any
    starting scroll (0, mid, negative, far past the end), the target for pill *i* puts that whole
    pill inside the viewport and never over-scrolls. This is the "no focusable index lacks a drawn
    rect" proof.
  - `the_strip_scrolls_only_once_it_outgrows_the_row_and_only_as_far_as_it_must` — a 4-pill row
    provably still fits and has no scroll range; a 12-pill row provably overflows, scrolls to its
    last pill, and **holds** for a pill already in view (at the start and mid-strip).
  - `a_stale_pill_index_clamps_instead_of_panicking` — graded on an overflowing row so the clamp
    has a real range: in-range scroll kept, over-scroll pulled to the end, negative pulled to 0.
  - `top_band_focus_walks_to_the_last_section_whatever_the_count` — for **N = 1..8**, RIGHT from
    the Home pill reaches the last pill and never lands on a non-pill; LEFT walks back through
    Home to the profile chip.
  - `set_hero_focus_clamps_onto_the_last_drawable_pill` — drives the real setter (the line the cap
    used to live on), not just the pure helper.
- A correctness review pass ran over the diff before commit; its findings on the clipped-rect hit
  test, the `&'static` borrow out of the label cache (now a scoped closure), the off-focus scroll
  rule, the chip/track collision and two vacuous assertions are all folded in above.

### Device verification: deferred to coordinator

Not run — the TV queue was centralised mid-task. Nothing here has been on the device.

**How many video sections the test server has: TWO.** `192.168.0.3:32400` returns three sections —
`1 movie "Movies"`, `2 show "TV Shows"`, `3 artist "Music"` — and `ensure_sections` skips
music/photo. So the row is **3 pills**, which fits un-scrolled: the device **cannot prove the >4
case at all**, and a device pass can only show non-regression of the shared row. Boot logs the
count itself as `pms: nmovies=<n> nsections=2`.

What to run, in one boot:

1. `./tests/run.py --fps` — covers `library-scroll` and `library-switch`, which drive the Library
   screen and `switch_section`, i.e. the shared row on both screens. No playback case is affected.
2. One FIFO drive to walk the whole band. Boot with a picker-suppressing trigger
   (`printf 0 > /tmp/plxnative-heroidx`) plus the injected token, then write to
   `/tmp/plxnative-remote`, one token per line, ~1s apart:

   ```
   up      # hero action row -> profile chip (focus -1)
   right   # chip -> pill 0 (Home)
   right   # -> pill 1 (Movies)
   right   # -> pill 2 (TV Shows) — the LAST pill on this server
   right   # clamped: must stay on pill 2, not fall off the band
   ok      # opens the last section
   ```

   Expected in `/tmp/plxnative-events.log`: `pms: ... nsections=2` at boot, then the once/sec
   heartbeat flipping from `FPS=<n> route=home` to `FPS=<n> route=library` after `ok`. There is no
   log line naming the section, so confirm *which* library opened from a capture:
   `tools/capture-screen.sh /tmp/unit-10.png DISPLAY` — the TV Shows pill should carry the selected
   treatment and the grid should be TV Shows.
3. Worth an eyeball in that capture: the tab row is centred and un-clipped (3 pills), and the
   profile chip sits cleanly beside it — the two z-order and geometry changes are the only things
   that can look different on a server this size.

Teardown: `tests/run.py` cleans up after itself; the by-hand boot needs the app closed and every
`/tmp/plxnative-*` trigger (including the injected token) cleared, sparing the three `*.log` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
