### PR TITLE
detail: media technical fields in the DTO + the resolution badge on the hero

### DIFF
--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -217,6 +217,15 @@ pub(crate) struct Detail {
     pub(crate) vcodec: String, // Media[0].videoCodec (drives the direct-play/transcode decision)
     pub(crate) acodec: String, // Media[0].audioCodec
     pub(crate) video_fps: f64, // video Stream frameRate (0 = unknown); feeds the Load esInfo
+    // ---- the PRIMARY version's technical fields (plex::Metadata::primary_media = Media[0], NOT a
+    // best-of pick — a multi-version item has more, and choosing among them needs a version picker
+    // that does not exist yet). For a SHOW these are borrowed from its first episode, like the
+    // About footer's audio/subtitle lists. `bitrate`/`width`/`height` are unused by the UI today
+    // and carried for the video-quality ladder ("26.1 Mbps 4K (Original)").
+    pub(crate) video_resolution: String, // "4k" | "1080" | "720" | "sd" — the hero's media badge
+    pub(crate) width: i64,               // stored frame size, not the resolution class (1918x802
+    pub(crate) height: i64,              // is a 1080p scope movie) — badge off video_resolution
+    pub(crate) bitrate: i64,             // kbps, whole-stream
     pub(crate) art: String,
     pub(crate) thumb: String,
     pub(crate) genres: Vec<String>,
@@ -310,7 +319,7 @@ pub(crate) fn sync_now_playing() {
 // ---- fetches (all via the typed crate::plex client; serde DTOs, no Value scraping) ----
 fn fetch_detail(rk: &str) -> Option<Detail> {
     let it = crate::plex::client().metadata(rk)?;
-    let media0 = it.media.first();
+    let media0 = it.primary_media();
     let mut d = Detail {
         rk: rk.to_string(),
         is_show: it.kind == "show",
@@ -336,6 +345,12 @@ fn fetch_detail(rk: &str) -> Option<Detail> {
         vcodec: media0.map(|m| m.video_codec.clone()).unwrap_or_default(),
         acodec: media0.map(|m| m.audio_codec.clone()).unwrap_or_default(),
         video_fps: 0.0, // set from the video Stream by parse_streams below
+        // likewise set by parse_streams (one assignment point), which for a SHOW runs a second
+        // time over its first episode — the show container carries no Media of its own
+        video_resolution: String::new(),
+        width: 0,
+        height: 0,
+        bitrate: 0,
         art: it.art.clone(),
         thumb: it.thumb.clone(),
         genres: it.genre.iter().map(|t| t.tag.clone()).collect(),
@@ -400,8 +415,17 @@ fn convert_streams(streams: &[crate::plex::Stream]) -> (Vec<Stream>, Vec<Stream>
     (audio, subs, fps)
 }
 
-/// parse an item's Media[0].Part[0].Stream[] into d.audio / d.subs (the About footer)
+/// parse an item's Media[0].Part[0].Stream[] into d.audio / d.subs (the About footer), plus that
+/// same version's technical fields (resolution/size/bitrate — the hero's media badge). Both ride
+/// the ONE version (see `plex::Metadata::primary_media`), and both are borrowed from a show's
+/// first episode by the same call in `fetch_item_streams`, so they can't describe different files.
 fn parse_streams(it: &crate::plex::Metadata, d: &mut Detail) {
+    if let Some(m) = it.primary_media() {
+        d.video_resolution = m.video_resolution.clone();
+        d.width = m.width;
+        d.height = m.height;
+        d.bitrate = m.bitrate;
+    }
     if let Some(p) = it.first_part() {
         let (audio, subs, fps) = convert_streams(&p.stream);
         d.audio = audio;

--- a/rust-modules/src/plex/models.rs
+++ b/rust-modules/src/plex/models.rs
@@ -192,6 +192,17 @@ impl Metadata {
     pub fn first_part(&self) -> Option<&MediaPart> {
         self.media.first().and_then(|m| m.part.first())
     }
+
+    /// `Media[0]` — the FIRST version listed, **not** a chosen-best one, and the honest name for
+    /// what every caller here actually reads. An item can carry SEVERAL `Media[]` versions
+    /// (docs/pms-api.md §4; the dev library really does — one episode ships a 4k and a 1080
+    /// version, another two 4k versions at different bitrates), and picking among them by
+    /// codec/resolution needs a version picker this client does not have yet. So anything derived
+    /// from this describes **version 0**, and a UI that shows it should be read that way.
+    /// [`first_part`](Self::first_part) carries the same caveat.
+    pub fn primary_media(&self) -> Option<&Media> {
+        self.media.first()
+    }
 }
 
 #[derive(Deserialize, Default)]
@@ -200,6 +211,21 @@ pub struct Media {
     pub video_codec: String,
     #[serde(rename = "audioCodec", default)]
     pub audio_codec: String,
+    /// Whole-stream bitrate in **kbps** (PMS's unit) — the source rung of the video-quality ladder
+    /// ("26.1 Mbps 4K (Original)") and the input to any bandwidth cap.
+    #[serde(default, deserialize_with = "de_i64")]
+    pub bitrate: i64,
+    /// Coded frame size. Note it is the STORED size, not the resolution class: a 2.35:1 1080p
+    /// movie is 1918x802 on this server, so `height` alone would label it 720p — prefer
+    /// [`video_resolution`](Self::video_resolution) for a badge and keep these for the ladder.
+    #[serde(default, deserialize_with = "de_i64")]
+    pub width: i64,
+    #[serde(default, deserialize_with = "de_i64")]
+    pub height: i64,
+    /// PMS's coarse resolution class, always a STRING even when it looks numeric — verified live:
+    /// `"4k"`, `"1080"`, `"720"`, `"576"`, `"sd"`. The version-picker key per docs/pms-api.md §4.
+    #[serde(rename = "videoResolution", default, deserialize_with = "de_str")]
+    pub video_resolution: String,
     #[serde(rename = "Part", default)]
     pub part: Vec<MediaPart>,
 }
@@ -406,6 +432,30 @@ fn de_opt_i64<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Option<i64>, D::
     })
 }
 
+/// Lenient String: a JSON string, a number stringified, or null → "". `videoResolution` is a
+/// string on this server ("1080"/"4k", verified live) but reads like a number, and a strict
+/// `String` that meets one is a WHOLE-`MediaContainer` parse failure — the same blast radius
+/// `de_i64` exists to avoid, just pointing the other way. Use it for any stringly-typed number.
+fn de_str<'de, D: serde::Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StrIntFloatBool {
+        S(String),
+        I(i64),
+        F(f64),
+        // no arm for a shape = the whole container fails on it, which is the one outcome this
+        // adapter exists to prevent — so carry the bool too (`de_i64` learned that the hard way)
+        B(bool),
+    }
+    Ok(match Option::<StrIntFloatBool>::deserialize(d)? {
+        Some(StrIntFloatBool::S(s)) => s,
+        Some(StrIntFloatBool::I(n)) => n.to_string(),
+        Some(StrIntFloatBool::F(f)) => f.to_string(),
+        Some(StrIntFloatBool::B(b)) => b.to_string(),
+        None => String::new(),
+    })
+}
+
 /// Accept `{…}` OR `[{…}]` (D-1) and return the first, or None.
 fn de_ultrablur<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Option<UltraBlurColors>, D::Error> {
     #[derive(Deserialize)]
@@ -419,4 +469,47 @@ fn de_ultrablur<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Option<UltraBl
         Some(OneOrMany::Many(v)) => v.into_iter().next(),
         None => None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Envelope;
+
+    /// The `Media[]` technical fields feed the resolution badge and (later) the quality ladder, and
+    /// PMS is free to string-encode any of them. A strict field there does not lose one number —
+    /// it fails the WHOLE `MediaContainer`, i.e. the entire detail page. Both encodings must land,
+    /// and the several-versions case must stay several (`primary_media` is version 0, not the only
+    /// one) — see docs/pms-api.md §4.
+    #[test]
+    fn media_technical_fields_survive_both_encodings_and_keep_every_version() {
+        let json = br#"{"MediaContainer":{"Metadata":[{"ratingKey":"1859","title":"Every Summer After",
+            "Media":[
+              {"bitrate":14663,"width":3840,"height":2160,"videoResolution":"4k","videoCodec":"hevc",
+               "Part":[{"id":1,"key":"/library/parts/1/1/file.mkv"}]},
+              {"bitrate":"2372","width":"1920","height":"1080","videoResolution":1080,
+               "videoCodec":"h264","Part":[{"id":2,"key":"/library/parts/2/1/file.mkv"}]}
+            ]}]}}"#;
+        let env: Envelope = serde_json::from_slice(json).expect("lenient parse");
+        let it = &env.media_container.metadata[0];
+        assert_eq!(it.media.len(), 2, "both versions are kept for a future picker");
+
+        let v0 = it.primary_media().expect("Media[0]");
+        assert_eq!((v0.bitrate, v0.width, v0.height), (14663, 3840, 2160));
+        assert_eq!(v0.video_resolution, "4k");
+        // version 1 sends the same fields string-encoded, and videoResolution as a bare NUMBER
+        let v1 = &it.media[1];
+        assert_eq!((v1.bitrate, v1.width, v1.height), (2372, 1920, 1080));
+        assert_eq!(v1.video_resolution, "1080");
+        // the two versions therefore badge differently ("4K" vs "1080p" — see ui::fmt::resolution's
+        // own tests), which is the whole reason the accessor has to name WHICH one it returned.
+    }
+
+    /// A show container carries no `Media` at all — the accessor must say so rather than panic,
+    /// because the detail page asks every item for its primary version.
+    #[test]
+    fn a_show_container_has_no_primary_media() {
+        let json = br#"{"MediaContainer":{"Metadata":[{"ratingKey":"9","type":"show","title":"A Show"}]}}"#;
+        let env: Envelope = serde_json::from_slice(json).expect("parse");
+        assert!(env.media_container.metadata[0].primary_media().is_none());
+    }
 }

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -791,7 +791,7 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
         hero_synopsis(summary).draw(p, Rect::new(tx, syn_y, 900.0, 0.0));
     }
 
-    // ---- date · runtime ----
+    // ---- date · runtime · media badges ----
     if let Some(d) = d {
         let mut info = pretty_date(&d.aired, d.year);
         if d.dur_ms >= 60_000 {
@@ -800,9 +800,14 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
             }
             info.push_str(&crate::ui::fmt::dur_long(d.dur_ms));
         }
+        let mut bx = tx;
         if let Ok(ic) = CString::new(info) {
-            p.text(ic.as_ptr(), tx, date_y, theme::size::CAPTION, dim, 0, 0);
+            let w = p.text(ic.as_ptr(), tx, date_y, theme::size::CAPTION, dim, 0, 0);
+            if w > 0.0 {
+                bx += w + theme::space::MD;
+            }
         }
+        draw_media_badges(p, d, bx, date_y);
     }
 
     // ---- buttons (btn_y from hero_layout) ----
@@ -819,6 +824,33 @@ fn draw_hero(p: Painter, env: &Env, m: Option<&PmsMovie>) {
             }
         }
     }
+}
+
+/// The hero's media chips, flowed left→right from `x` and cap-band-centred on the text line drawn
+/// at `text_y` (so they sit ON the date/runtime line, not near it). Returns the width consumed.
+///
+/// They describe the item's PRIMARY version — `Media[0]`, see `plex::Metadata::primary_media` — so
+/// a multi-version item (the dev library has episodes with both a 4k and a 1080 version) is badged
+/// by whichever one PMS lists first, until there is a version picker to choose with. Today the row
+/// is the resolution alone; the audio/subtitle chips the reference client shows beside it are the
+/// same `badge` leaf and belong here when they land.
+fn draw_media_badges(p: Painter, d: &metadata::Detail, x: f32, text_y: f32) -> f32 {
+    let mut bx = x;
+    // one Option per chip — the audio/subtitle chips the reference client shows beside the
+    // resolution join this list (and nothing else changes) when they land
+    let chips = [crate::ui::fmt::resolution(&d.video_resolution, d.width, d.height)];
+    for text in chips.into_iter().flatten() {
+        // the gap separates chips, so it is never left dangling after the last one
+        if bx > x {
+            bx += theme::space::XS;
+        }
+        // cap-band centre of the line drawn at `text_y` (the inverse of text::text_vcenter_y),
+        // computed here rather than up front so an empty row touches no glyph cache
+        let (cap_top, baseline) = crate::text::text_cap_band(theme::size::CAPTION, 0);
+        let cy = text_y + (cap_top + baseline) * 0.5;
+        bx += crate::ui::widgets::badge(p, bx, cy, &text, crate::ui::widgets::BadgeStyle::Filled);
+    }
+    bx - x
 }
 
 fn draw_buttons(p: Painter, env: &Env, y: f32) {

--- a/rust-modules/src/ui/fmt.rs
+++ b/rust-modules/src/ui/fmt.rs
@@ -54,3 +54,75 @@ pub(crate) fn clock(ms: i64) -> String {
 pub(crate) fn episode_kicker(season: i64, index: i64, title: &str) -> String {
     format!("S{season}, E{index} \u{b7} {title}")
 }
+
+/// The media badge for a video version — `"4K"` / `"1080p"` / `"SD"`, or None when the item has no
+/// video (a show container, a music item, an unparsed response).
+///
+/// `res` is PMS's `Media.videoResolution` and is PREFERRED over the frame size, because the frame
+/// size is the STORED one: a 2.35:1 1080p film is 1918x802 on the dev server, and a height rule
+/// would badge it 720p. Verified values are `"4k"`, `"1080"`, `"720"`, `"576"`, `"sd"` — and PMS
+/// sends every one of them as a numeric-looking STRING, which is exactly the shape this maps.
+/// `width`/`height` are only the fallback for a version that omits the class.
+pub(crate) fn resolution(res: &str, width: i64, height: i64) -> Option<String> {
+    let r = res.trim().to_ascii_lowercase();
+    if !r.is_empty() {
+        // "4k"/"8k" are already the badge; a bare number is a scan-line count ("1080" → "1080p");
+        // anything else (e.g. "sd") is a class name and reads as itself, upper-cased.
+        return Some(match r.as_str() {
+            _ if r.chars().all(|c| c.is_ascii_digit()) => format!("{r}p"),
+            _ => r.to_ascii_uppercase(),
+        });
+    }
+    // No class: fall back to the frame WIDTH, which (unlike height) is constant across aspect
+    // ratios. Thresholds sit below each nominal width (3840/2560/1920/1280/1024) so a cropped or
+    // anamorphic frame still lands in its own class, and the buckets are the SAME vocabulary the
+    // class path emits — the two paths must not disagree about the same file.
+    // saturating: these are wire values via the lenient `de_i64`, so a garbage 19-digit height
+    // must not overflow (a debug-build panic, a silently wrapped badge in release)
+    let w = if width > 0 { width } else { height.saturating_mul(16) / 9 };
+    Some(match w {
+        w if w <= 0 => return None,
+        w if w >= 3000 => "4K".to_string(),
+        w if w >= 2400 => "1440p".to_string(),
+        w if w >= 1700 => "1080p".to_string(),
+        w if w >= 1100 => "720p".to_string(),
+        w if w >= 900 => "576p".to_string(),
+        _ => "SD".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolution;
+
+    /// The mapping is fed PMS's own values, and PMS string-encodes them — including the ones that
+    /// look like integers ("1080"), which is the case that must come out as "1080p" and not as a
+    /// number or an empty badge.
+    #[test]
+    fn resolution_labels_pms_string_encoded_classes() {
+        // verified live on the dev server: every videoResolution is a JSON string
+        assert_eq!(resolution("4k", 3840, 2160).as_deref(), Some("4K"));
+        assert_eq!(resolution("1080", 1920, 1080).as_deref(), Some("1080p"));
+        assert_eq!(resolution("720", 1280, 720).as_deref(), Some("720p"));
+        assert_eq!(resolution("576", 1024, 576).as_deref(), Some("576p"));
+        assert_eq!(resolution("sd", 826, 452).as_deref(), Some("SD"));
+        // whitespace/casing from the wire must not produce a second spelling of a badge
+        assert_eq!(resolution(" 4K ", 0, 0).as_deref(), Some("4K"));
+        // the class WINS over the frame size: a 2.35:1 1080p film is 1918x802 (a height rule
+        // would call it 720p, a width rule 1080p — either way the server's own answer decides)
+        assert_eq!(resolution("1080", 1918, 802).as_deref(), Some("1080p"));
+    }
+
+    #[test]
+    fn resolution_falls_back_to_frame_width() {
+        assert_eq!(resolution("", 3840, 2160).as_deref(), Some("4K"));
+        assert_eq!(resolution("", 1918, 802).as_deref(), Some("1080p")); // scope 1080p, by WIDTH
+        assert_eq!(resolution("", 1280, 720).as_deref(), Some("720p"));
+        assert_eq!(resolution("", 720, 480).as_deref(), Some("SD"));
+        // the fallback speaks the class path's vocabulary: the same file must not badge "576p"
+        // with a videoResolution and "SD" without one
+        assert_eq!(resolution("", 1024, 576).as_deref(), resolution("576", 1024, 576).as_deref());
+        assert_eq!(resolution("", 0, 1080).as_deref(), Some("1080p")); // width absent → from height
+        assert_eq!(resolution("", 0, 0), None); // no video at all (a show container) → no badge
+    }
+}


### PR DESCRIPTION
Closes the **media badges** gap from `docs/parity-gaps.md` §2 theme G (showdetail), and the DTO half of the *"source bitrate, width/height and videoResolution are not in the data model"* gap that blocks the video-quality ladder.

## What changed

| File | Change |
|---|---|
| `plex/models.rs` | `Media` gains `bitrate` / `width` / `height` / `videoResolution`; new `Metadata::primary_media()`; new lenient `de_str` |
| `metadata.rs` | `Detail` carries the four fields; `parse_streams` is their single assignment point |
| `ui/fmt.rs` | new `resolution()` display formatter + 2 tests |
| `ui/detail.rs` | `draw_media_badges` — the chip row on the hero's date/runtime line |

**Lenient parsing, both directions.** `bitrate`/`width`/`height` go through the existing `de_i64`. `videoResolution` is a numeric-*looking* string (`"1080"`, `"4k"` — verified live), so it gets a new `de_str` that also accepts a bare number/bool: a strict `String` meeting a number fails the **whole `MediaContainer`**, not one field — the same blast radius `de_i64` exists to avoid, pointing the other way.

**Label policy.** `fmt::resolution()` prefers `videoResolution` over the frame size, because the frame size is the *stored* one: *The Substance* is 1918x802 on this server, and a height rule badges a 1080p scope film 720p. Frame size is only the fallback for a version that omits the class, and its buckets emit the same vocabulary so the two paths cannot disagree about one file.

**Where the numbers go.** `width`/`height`/`bitrate` are unused by the UI today and carried deliberately: they are the input to the video-quality ladder's "26.1 Mbps 4K (Original)" rung in a later batch.

## The Media[0] limitation (please read before merging)

`docs/pms-api.md` §4 warns that an item can carry several `Media[]` versions and that a picker "must iterate `Media[]` and choose by codec/resolution, not take [0] blindly". **This PR does not build the picker, and does not deepen the assumption** — every read in the detail/playback path already took `[0]`. What it does is make it *honest*:

- the accessor is named for what it returns — `Metadata::primary_media()`, doc'd as "the FIRST version listed, **not** a chosen-best one";
- `Detail`'s new fields, `parse_streams` and `draw_media_badges` each say in-place that they describe version 0;
- a host test asserts both versions survive the parse, so the picker has data to pick from when it lands.

This is live, not hypothetical: on the dev server `rk=1859` ("Every Summer After") ships a **4k** and a **1080** version, and `rk=1886`+ ship two 4k versions at different bitrates. The badge follows PMS's ordering — which is also what `transcoder.rs` pins the decision to (`mediaIndex=0`), so the badge and playback can never name different versions.

For a **show** the fields are borrowed from its first episode, exactly like the About footer's Languages list (same call, same version), and they do not re-derive on a season switch — same caveat as that list.

## Verification

**Host** — `make check` **62 passed** (58 baseline + 4), `make` (ARM cross-build) links clean, no new warnings.

New tests: `ui::fmt` resolution mapping incl. the string-encoded-number case (`"1080"` → `1080p`) and the class-beats-frame-size case (1918x802 stays 1080p); the width fallback agreeing with the class path; `plex::models` both encodings landing on one item while keeping both versions, and a show container having no primary media.

**Device** — deployed to the TV (md5-verified), then two detail-page captures graded against what the server actually reports:

| rk | title | server `videoResolution` (w×h) | badge drawn |
|---|---|---|---|
| 4 | The Substance | `"1080"` (1918×802) | **1080p** ✅ |
| 367 | The Hobbit: An Unexpected Journey | `"4k"` (3840×2160) | **4K** ✅ |

rk 4 is the interesting one: deriving from `height` would have drawn *720p*.

`./tests/run.py --fps` — **5/5 pass**, including the screen this touches: `fps:detail-transition` robust_min **51fps** vs floor 45 (home-hero 59, home-grid 60, library-scroll 60, library-switch 56). TV left clean (triggers cleared, app closed, lock released).

## Device verification: already done — nothing needed from the coordinator

The device pass above ran under the TV lock and is complete; **no re-run is required.** If you want to reproduce it anyway, this is the exact recipe and nothing more:

```bash
make deploy
./tests/run.py --fps          # 5 scenes, ~2 min; watch fps:detail-transition vs floor 45

# then one detail-page capture per item (token + rk are the only triggers needed):
TOK=$(grep PMS_TOKEN src/config.local.h | sed 's/.*"\(.*\)".*/\1/')
ssh root@192.168.0.114 "rm -f /tmp/plxnative-detail* /tmp/plxnative-auto* /tmp/plxnative-heroidx \
    /tmp/plxnative-lib* /tmp/plxnative-grid /tmp/plxnative-profile; \
    printf '%s' '$TOK' > /tmp/plxnative-token; printf '4' > /tmp/plxnative-detail"
make run RUN_SECS=16
tools/capture-screen.sh /tmp/unit-6-rk4.png DISPLAY     # expect "1080p" beside "2 hr 21 min"
```

Expected values, so this checks correctness and not just presence: **rk 4 → `1080p`** (server says `videoResolution="1080"`, frame 1918×802) and, repeating with `printf '367'`, **rk 367 → `4K`** (server says `"4k"`). The chip sits on the hero's date/runtime line, immediately right of the runtime. No `plxnative-remote` FIFO tokens are needed — the `plxnative-detail` trigger lands on the page directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuSHrq9oydnX7nhKE1Hvc
