### PR TITLE
playback: which server an item came from is part of its identity

### DIFF
--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -2963,7 +2963,7 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                         if let Some((part, vc, ac, title, resume_ms, dur_ms)) = leaf {
                             if !part.is_empty() {
                                 log(&format!("plxnative-play: rk={rk} start"));
-                                crate::route::request_play(rk, &part, &vc, &ac, &title, "");
+                                crate::route::request_play(crate::route::surface_sid(), rk, &part, &vc, &ac, &title, "");
                                 let resume = crate::metadata::resume_ns(resume_ms, dur_ms);
                                 let fd = matches!(route, Route::Detail);
                                 start_playback(mt, resume, fd, HUD_HEADLESS_MS, &mut route, &mut played_from_detail, &mut hud_nav);

--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -894,7 +894,23 @@ pub(crate) fn playing_chapters() -> &'static [Chapter] {
 /// when it IS this item, so playing from a detail page costs no extra GET. Snapshotted into
 /// `ResolveEnv` and handed to the worker; splitting the fetch out lost this and quietly added a
 /// PMS round trip to every play from a detail page.
-pub(crate) fn cached_playing(rk: &str) -> Option<PlayingItem> {
+///
+/// `sid` is the server the item being played came from — the other half of its identity, since a
+/// ratingKey only names an item within one server.
+///
+/// **TODO(shared-servers): the test below is still the rk ALONE, and that is the one hole left in
+/// the playback path's otherwise end-to-end server capture.** It cannot be closed here: `Detail`
+/// does not yet carry the server it was loaded from, and guessing (`sid == current_server()`) would
+/// be a different claim that the real field then has to unpick. What it costs once two sources can
+/// share a shelf: the detail page holds rk `1` from server A, the user starts rk `1` from B's
+/// shelf, this returns A's `PlayingItem`, and the `.or_else(fetch_playing_item)` that would have
+/// gone to B never runs — so B's playback carries A's audio/subtitle `Stream` ids (which
+/// `put_selection` and the timeline report then send to B), A's `video_fps` in the Load esInfo, A's
+/// frame size in the local direct-play gate, and A's markers and chapters. Silently. The fix is a
+/// `sid` on `Detail` and `d.sid == sid &&` on the filter; the parameter is already here so that
+/// change is one line.
+pub(crate) fn cached_playing(sid: crate::plex::ServerId, rk: &str) -> Option<PlayingItem> {
+    let _ = sid; // see the TODO above — the pair test needs a field `Detail` does not have yet
     current().filter(|d| d.rk == rk && !d.audio.is_empty()).map(|d| PlayingItem {
         rk: rk.to_string(),
         audio: d.audio.clone(),
@@ -907,11 +923,14 @@ pub(crate) fn cached_playing(rk: &str) -> Option<PlayingItem> {
     })
 }
 
-pub(crate) fn fetch_playing_item(rk: &str) -> Option<PlayingItem> {
+/// `sid` names the server `rk` is a key on. It runs on the resolve worker, so the server must
+/// arrive by value: `client_opt()` here would fetch whichever server is CURRENT, and a ratingKey
+/// that also exists there would come back with a different film's stream list.
+pub(crate) fn fetch_playing_item(sid: crate::plex::ServerId, rk: &str) -> Option<PlayingItem> {
     if rk.is_empty() {
         return None;
     }
-    let it = crate::plex::client_opt().and_then(|c| c.metadata(rk));
+    let it = crate::plex::client_for(sid).and_then(|c| c.metadata(rk));
     // Markers and chapters hang off the ITEM, streams off its first Part — so a part-less response
     // still yields both of those instead of discarding all three. `Client::metadata` already sends
     // `includeChapters=1` (plex/library.rs), so the Chapter[] is on the wire either way: taking it

--- a/rust-modules/src/player/engine.rs
+++ b/rust-modules/src/player/engine.rs
@@ -475,16 +475,19 @@ pub(crate) fn start_bufferfeed(mt: &MainThread) -> bool {
     }
 
     // progress reporter: post the play position to /:/timeline (updates resume + watched).
-    // rk is captured now (fixed for the session); skipped for the sample/demo (no rk).
+    // rk AND the server it is a key on are captured now — both fixed for the session, both moved
+    // into the worker by value. The server used to be re-read inside the report, which made every
+    // tick a question about what the user was browsing rather than about what was playing; see
+    // `threads::timeline_thread`. Skipped for the sample/demo (no rk).
     let report_stop = threads::ReportStop::new();
     let report_th = if stream {
-        let rk = crate::route::cur_rk();
+        let (sid, rk) = (crate::route::cur_sid(), crate::route::cur_rk());
         if rk.is_empty() {
             None
         } else {
             // best-effort: refused, the only loss is that the resume point stops being posted
             let st = report_stop.clone();
-            crate::task::spawn("timeline", move || threads::timeline_thread(rk, st))
+            crate::task::spawn("timeline", move || threads::timeline_thread(sid, rk, st))
         }
     } else {
         None

--- a/rust-modules/src/player/threads.rs
+++ b/rust-modules/src/player/threads.rs
@@ -76,7 +76,16 @@ impl ReportStop {
     }
 }
 
-pub(crate) fn timeline_thread(rk: String, stop: std::sync::Arc<ReportStop>) {
+/// The ~10 s `/:/timeline` progress reporter.
+///
+/// `sid` rides beside `rk` for the same reason `rk` does: both are fixed for the session and both
+/// are captured BY VALUE at the spawn site. `rk` always was; the server was not, and the report
+/// resolved it per tick through `plex::client_opt()` — "whichever server is current *now*". A
+/// reporter for an item borrowed from a friend's share therefore wrote its resume point to whatever
+/// server the user had since navigated to, every ten seconds, invisibly: the POST's result is
+/// discarded, there is no host runtime to catch it, and the device harness grades progress from the
+/// app's own heartbeat rather than from the server it landed on.
+pub(crate) fn timeline_thread(sid: crate::plex::ServerId, rk: String, stop: std::sync::Arc<ReportStop>) {
     use crate::plex::TimelineState;
     loop {
         if stop.wait_or_stop(REPORT_INTERVAL_S) {
@@ -93,7 +102,7 @@ pub(crate) fn timeline_thread(rk: String, stop: std::sync::Arc<ReportStop>) {
         } else {
             TimelineState::Playing
         };
-        crate::route::report_timeline(&rk, state, t, d);
+        crate::route::report_timeline(sid, &rk, state, t, d);
         super::log(&format!("timeline {} t={}s/{}s", state.as_str(), t / 1000, d / 1000));
     }
 }

--- a/rust-modules/src/plex/mod.rs
+++ b/rust-modules/src/plex/mod.rs
@@ -60,6 +60,14 @@ pub use client::{Client, StreamUrl};
 // `register`, `set_current` and `ServerId` are the multi-server additions.
 #[allow(unused_imports)]
 pub use servers::{client, client_for, client_opt, count as server_count, current as current_server, install, register, set_current, ServerId};
+// The registry as a TEST FIXTURE, for suites outside this module (`route.rs` grades which server a
+// `/:/timeline` POST reaches). `register_for_test` skips the `session::load` the public `register`
+// does — that call mints and PERSISTS a device uuid, which a host test has no business writing —
+// and `reset_servers_for_test` is what keeps the table a per-test fixture instead of a growing
+// process-global holding clients whose loopback ports closed when their test returned. Both must be
+// called under `crate::testlock::serial`.
+#[cfg(test)]
+pub(crate) use servers::{register_with_client_id as register_for_test, reset_for_test as reset_servers_for_test};
 #[allow(unused_imports)]
 pub use models::*;
 #[allow(unused_imports)]

--- a/rust-modules/src/plex/servers.rs
+++ b/rust-modules/src/plex/servers.rs
@@ -173,7 +173,12 @@ pub fn register(machine_id: &str, host: &str, port: i32, token: &str) -> ServerI
 
 /// [`register`] with the device id supplied — the seam that keeps the session file out of the
 /// registry proper (and out of the tests).
-pub(super) fn register_with_client_id(machine_id: &str, host: &str, port: i32, token: &str, client_id: &str) -> ServerId {
+///
+/// `pub(crate)` rather than `pub(super)` because tests OUTSIDE `plex/` need it too (`route.rs`
+/// grades which server a `/:/timeline` POST reaches, which takes two registered clients): the
+/// public [`register`] resolves the device id through `session::load`, which MINTS AND PERSISTS a
+/// uuid when there is none, and a host test must not write one.
+pub(crate) fn register_with_client_id(machine_id: &str, host: &str, port: i32, token: &str, client_id: &str) -> ServerId {
     register_lazy(machine_id, host, port, token, &|| client_id.to_owned())
 }
 
@@ -237,8 +242,12 @@ pub fn install(host: &str, port: i32, token: &str) {
 /// Empty the table so each test starts from "nothing installed". Leaks whatever was registered
 /// (that is the ordinary lifecycle here, not a test-only wart) and must be called under
 /// [`crate::testlock::serial`] — the registry is a crate global.
+///
+/// `pub(crate)` for the same reason as [`register_with_client_id`]: a test outside `plex/` that
+/// registers a server owes the rest of the suite an empty table on the way out, or the next test
+/// to ask `client_opt()` gets `Some(a client whose port closed when that test returned)`.
 #[cfg(test)]
-pub(super) fn reset_for_test() {
+pub(crate) fn reset_for_test() {
     let _w = WRITE.lock().unwrap_or_else(|e| e.into_inner());
     for s in SLOTS.iter() {
         s.store(std::ptr::null_mut(), Ordering::Release);

--- a/rust-modules/src/route.rs
+++ b/rust-modules/src/route.rs
@@ -5,6 +5,7 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Mutex;
 use crate::pms::PmsMovie;
+use crate::plex::ServerId;
 use std::os::raw::c_char;
 use std::ptr::{addr_of, addr_of_mut};
 
@@ -29,6 +30,22 @@ static mut CUR_REMUX: bool = false;
 // ratingKey of the currently-playing item (movie or episode), so an audio-track
 // switch can force a fresh transcode of the same item.
 static mut CUR_RK: String = String::new();
+/// The SERVER the currently-playing item came from — the other half of its identity.
+///
+/// A ratingKey names an item only within one server: `1` is a real item on our own server and a
+/// different real item on a friend's share, and the same goes for `Part.id`, `Stream.id`,
+/// `playQueueID` and the resume point. Every PMS call in this file used to resolve its server
+/// implicitly, at the instant of the call, through `client_opt()` — i.e. whichever server happened
+/// to be CURRENT right then. Merged Home shelves make "the item is from B while current is A"
+/// ordinary, and every one of those calls would then land on A: the PlayQueue, the track PUT, the
+/// transcode stop, and — ten seconds at a time, forever — the progress report that writes the
+/// resume point.
+///
+/// So the server is captured ONCE, at [`request_play`], and carried by value from there:
+/// `ResolveEnv` → `Plan` → here. Nothing below this line re-resolves it. `UNSET` before the first
+/// play and on a plan that never resolved, which resolves to no client at all rather than to
+/// slot 0.
+static mut CUR_SID: ServerId = ServerId::UNSET;
 // current audio/subtitle selection carried by any TRANSCODE of the current item
 // (0 = server default / none). The subtitle is BURNED into the video (our client
 // profile advertises no soft-sub support, so Plex's decision is burn); direct-play
@@ -42,8 +59,15 @@ static mut CUR_PART_ID: i64 = 0;
 // X-Plex-Session-Identifier — they must match byte-for-byte so /status/sessions correlates the
 // transcode with the report. Regenerated on each play_movie/play_episode.
 static mut SESS: String = String::new();
-// GET /identity machineIdentifier, cached once — needed for the PlayQueue uri.
+// GET /identity machineIdentifier, cached — needed for the PlayQueue uri.
+//
+// It is cached PER SERVER, which is what `MACHINE_SID` is for: the id goes into
+// `uri=server://{machineIdentifier}/…` on the PlayQueue POST, so one cached globally is a
+// mis-addressed queue the moment a second server exists — server A's fingerprint POSTed to B,
+// naming a server B has never heard of. Only a cache learned from THIS playback's server is
+// usable, and `resolve_playqueue` prefers the registry's own per-server id over both.
 static mut MACHINE_ID: String = String::new();
+static mut MACHINE_SID: ServerId = ServerId::UNSET;
 // This playback's PlayQueue ids for the timeline (empty if /playQueues failed).
 static mut PQ_ID: String = String::new();
 static mut PQ_ITEM_ID: String = String::new();
@@ -128,6 +152,20 @@ pub(crate) fn cur_sub_sid() -> i64 {
 /// ratingKey of the currently-playing item (for /:/timeline progress reports).
 pub(crate) fn cur_rk() -> String {
     unsafe { (*addr_of!(CUR_RK)).clone() }
+}
+/// The server the currently-playing item came from — see [`CUR_SID`]. MAIN THREAD.
+///
+/// A worker must be handed this by value at its spawn site, never call it: read on a worker it is
+/// "whatever is playing now", which is the very race capturing the id was meant to end.
+pub(crate) fn cur_sid() -> ServerId {
+    unsafe { addr_of!(CUR_SID).read() }
+}
+/// The `Client` for the currently-playing item's server, `None` before the first play (or after a
+/// plan that never resolved). The main-thread twin of `client_for(env.sid)` on the resolve worker
+/// — every in-playback PMS call in this file goes through one of the two, and none through
+/// `client_opt()`, which answers with whatever server is CURRENT rather than the one playing.
+fn cur_client() -> Option<&'static crate::plex::Client> {
+    crate::plex::client_for(cur_sid())
 }
 pub(crate) fn cur_audio_sid() -> i64 {
     unsafe { addr_of!(CUR_AUDIO_SID).read() }
@@ -245,7 +283,10 @@ pub(crate) fn scrobble_stop(
     if final_report.is_none() && tsession.is_empty() && report_th.is_none() {
         return; // nothing to post and nobody to wait for
     }
-    let Some(c) = crate::plex::client_opt() else { return };
+    // The server this playback came FROM, not whichever one is current — the resume point and the
+    // transcode session both live there, and by the time a stop runs the user may well have walked
+    // back to a different source's Home.
+    let Some(c) = cur_client() else { return };
     // Serialise against a previous stop still in flight: these carry a position for a specific
     // item, and letting two race would let an older one land last. Normally free — the measured
     // baseline for a finished worker is 0 ms.
@@ -310,7 +351,7 @@ pub(crate) fn transcode_seek(offset_secs: i64) -> Option<String> {
     if rk.is_empty() {
         return None;
     }
-    let c = crate::plex::client_opt()?;
+    let c = cur_client()?;
     // NB: do NOT explicitly /stop the old encoder here — the session id is reused, so a stop
     // would cut the stream the demux thread is still reading out from under it. The caller
     // (the pump) instead reloads onto this new start.mkv?&offset= (same session), which tears
@@ -331,8 +372,11 @@ use crate::cbuf::set as set_c; // shared fixed-C-buffer write (the HUD TITLE/CTX
 /// Ask PMS whether `rk` should direct-play (Some(true) → serve the raw Part) or transcode
 /// (Some(false) → start.mkv). None when the server returns no usable Media decision, so the
 /// caller falls back to the local codec test. Registers the session as a side effect.
-fn server_decision(rk: &str, session: &str) -> Option<bool> {
-    let mc = match crate::plex::client_opt()?.mde_decision(rk, session) {
+///
+/// Takes the `Client` rather than looking one up: this runs on the resolve worker, and `rk` is only
+/// an item on the server the caller resolved from this playback's captured `ServerId`.
+fn server_decision(c: &crate::plex::Client, rk: &str, session: &str) -> Option<bool> {
+    let mc = match c.mde_decision(rk, session) {
         Some(mc) => mc,
         None => {
             // failed fetch OR unparseable (XML/truncated) body — keep the fallback visible
@@ -435,11 +479,16 @@ fn apply_decision_codecs(mc: &crate::plex::MediaContainer) {
 /// always burn) — a query-param subtitleStreamID does NOT suppress a default-selected
 /// sub, only the PUT does. So we PUT subtitleStreamID=0 to keep subs OFF (no burn), or
 /// the chosen id to burn it; audioStreamID only when the user switched (else keep default).
-fn put_selection(part: i64, aud: i64, sub: i64) {
+///
+/// `sid` names the server that owns `part` — the resolve worker passes the id it was given, and the
+/// in-playback callers pass [`cur_sid`]. A `Part.id` is server-local, so a PUT sent to the wrong
+/// one either 404s or, worse, re-selects streams on a stranger's part that happens to share the
+/// number.
+fn put_selection(sid: ServerId, part: i64, aud: i64, sub: i64) {
     if part <= 0 {
         return;
     }
-    let c = match crate::plex::client_opt() {
+    let c = match crate::plex::client_for(sid) {
         Some(c) => c,
         None => return,
     };
@@ -562,18 +611,38 @@ fn up_next_of(r: &crate::plex::QueueRow) -> Option<UpNext> {
 /// works, just without the queue ids (and the player without an Up Next).
 ///
 /// PURE: returns owned data for `apply_plan` to install.
-fn resolve_playqueue(rk: &str, session: &str, cached: &str) -> QueueInfo {
-    let mid = if cached.is_empty() {
-        crate::plex::client_opt().and_then(|c| c.machine_identity()).unwrap_or_default()
+///
+/// **The machine id is THIS server's, three ways, in order.** It goes into
+/// `uri=server://{machineIdentifier}/…`, so naming the wrong server is a POST that either fails or
+/// builds a queue nobody asked for.
+///   1. **The registry's own id for this client** — it is the key the server is filed under, so it
+///      cannot belong to another one. Free, and refreshed whenever the slot is re-pointed.
+///   2. `cached`, which `ResolveEnv` only fills in when the cache was learned from *this* server
+///      (see `MACHINE_SID`) — the legacy `install(host, port, token)` path registers with no id, so
+///      for the session's own server rung 1 is empty and this is what saves a round trip.
+///   3. `GET /identity`, whose answer travels back in `QueueInfo::machine_id` for `apply_plan` to
+///      cache against this server.
+fn resolve_playqueue(c: &crate::plex::Client, rk: &str, session: &str, cached: &str) -> QueueInfo {
+    let known = c.machine_id();
+    // `mid` is the FETCHED id and nothing else: apply_plan's "" means "leave the cache alone", and
+    // the first two rungs are already-known values with nothing to write back.
+    let mid = if known.is_empty() && cached.is_empty() {
+        c.machine_identity().unwrap_or_default()
     } else {
-        String::new() // unchanged — apply_plan's "" means "leave the cache alone"
+        String::new()
     };
-    let effective = if mid.is_empty() { cached } else { &mid };
+    let effective = if !known.is_empty() {
+        known
+    } else if !mid.is_empty() {
+        &mid
+    } else {
+        cached
+    };
     if effective.is_empty() {
         crate::player::log("playqueue: no machineIdentifier (skip)");
         return QueueInfo::default();
     }
-    match crate::plex::client_opt().and_then(|c| c.create_play_queue(effective, rk, session)) {
+    match c.create_play_queue(effective, rk, session) {
         Some(q) => {
             let up_next = q.next.as_ref().and_then(up_next_of);
             crate::player::log(&format!(
@@ -603,8 +672,17 @@ fn resolve_playqueue(rk: &str, session: &str, cached: &str) -> QueueInfo {
 /// that `apply_plan` reassigns on every landing — so a superseded worker could clone a buffer as
 /// it was being dropped (heap corruption on a device with no debugger), and read the two sids as
 /// non-atomic i64s, which on armv7 is a tearable two-word load.
+///
+/// The `sid` is the same idea one step further out: it is not a static the worker could read, it is
+/// a *function call* — `plex::client_opt()` — which is worse, because `Send` cannot see a function
+/// call and a worker that resolves its own server therefore compiles clean and passes every test.
+/// It is captured here, at the request, and every PMS call the worker makes is `client_for(sid)`.
 #[derive(Clone, Default)]
 pub(crate) struct ResolveEnv {
+    /// The server the item being played came from. Not "the current server" — see [`CUR_SID`].
+    pub sid: ServerId,
+    /// `MACHINE_ID`, but only when it was learned from `sid`'s own server (`MACHINE_SID`);
+    /// otherwise empty, so the worker re-asks rather than addressing a queue to the wrong machine.
     pub machine_id: String,
     pub audio_sid: i64,
     pub sub_sid: i64,
@@ -614,12 +692,15 @@ pub(crate) struct ResolveEnv {
 
 impl ResolveEnv {
     /// MAIN THREAD ONLY.
-    fn snapshot(rk: &str) -> ResolveEnv {
+    fn snapshot(sid: ServerId, rk: &str) -> ResolveEnv {
         ResolveEnv {
-            machine_id: unsafe { (*addr_of!(MACHINE_ID)).clone() },
+            sid,
+            machine_id: unsafe {
+                if addr_of!(MACHINE_SID).read() == sid { (*addr_of!(MACHINE_ID)).clone() } else { String::new() }
+            },
             audio_sid: cur_audio_sid(),
             sub_sid: cur_sub_sid(),
-            cached_item: crate::metadata::cached_playing(rk),
+            cached_item: crate::metadata::cached_playing(sid, rk),
         }
     }
 }
@@ -630,6 +711,11 @@ impl ResolveEnv {
 /// from the worker is how you reintroduce the races the audit found.
 #[derive(Default)]
 pub(crate) struct Plan {
+    /// The server this plan was resolved against — copied straight from [`ResolveEnv::sid`], so
+    /// what `apply_plan` installs as `CUR_SID` is the id the request captured and not a re-read of
+    /// whatever became current while the worker ran. `UNSET` only on the default `Plan` a panicking
+    /// resolve lands, which carries no URL either and so never starts an engine.
+    pub sid: ServerId,
     pub url: String,
     pub tsession: String,
     pub sess: String,
@@ -677,6 +763,12 @@ pub(crate) struct Plan {
 /// input arrives in `ResolveEnv`, every output leaves in `Plan`, and `apply_plan` installs both
 /// on the main thread. Write-purity alone is not enough: `apply_plan` reassigns the `MACHINE_ID`
 /// and `SESS` Strings, so a still-running superseded worker reading them is a use-after-free.
+///
+/// **And it must not ask which server is current.** `plex::client_opt()` / `plex::current_server()`
+/// are not statics, they are calls, so nothing in the type system stops a worker making one — but
+/// the answer is "whatever the user is looking at NOW", which for an item from a shared source is
+/// the wrong authority for every id in this function. The server arrives in `env.sid` and the only
+/// client here is `client_for` of it.
 fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveEnv) -> Plan {
     // The part id is derived from THIS call's `part`, before anything else runs, and published
     // here rather than by the caller after we return. It used to be written by play_movie /
@@ -687,12 +779,15 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     // The arguments ARE the source codecs, whatever this function goes on to choose — captured
     // once, here, so no later branch has to remember to.
     let mut plan = Plan {
+        // carried through every exit below, the failing ones included: a plan without a server is
+        // a plan `apply_plan` cannot install an honest `CUR_SID` from.
+        sid: env.sid,
         part_id: part_id_of(part),
         src_vcodec: vcodec.to_string(),
         src_acodec: acodec.to_string(),
         ..Default::default()
     };
-    let client = match crate::plex::client_opt() {
+    let client = match crate::plex::client_for(env.sid) {
         Some(c) => c,
         None => return plan,
     };
@@ -701,7 +796,7 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     let session = new_sess(rk);
     plan.sess = session.clone();
     if !rk.is_empty() {
-        let q = resolve_playqueue(rk, &session, &env.machine_id);
+        let q = resolve_playqueue(client, rk, &session, &env.machine_id);
         plan.machine_id = q.machine_id;
         plan.pq_id = q.id;
         plan.pq_item_id = q.item_id;
@@ -711,7 +806,7 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     // the playing item's OWN track lists (menu + audio pick + esInfo fps read them) — the
     // loaded detail can be a different item (show page / straight-from-Home play)
     // detail already had this item's streams — no GET
-    plan.playing = env.cached_item.clone().or_else(|| crate::metadata::fetch_playing_item(rk));
+    plan.playing = env.cached_item.clone().or_else(|| crate::metadata::fetch_playing_item(env.sid, rk));
     // Server-adjudicated: the Media Decision Engine decides direct-play vs transcode from our
     // capability profile. Falls back to the local codec test if the server returns no usable
     // decision; the local-sample/demo path (rk empty) skips the decision entirely.
@@ -765,7 +860,7 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     } else if rk.is_empty() {
         false
     } else {
-        server_decision(rk, &session).unwrap_or_else(|| crate::plex::is_dp_audio(acodec))
+        server_decision(client, rk, &session).unwrap_or_else(|| crate::plex::is_dp_audio(acodec))
     };
     if (directplay || rk.is_empty()) && !part.is_empty() {
         // direct-play: the pipeline decodes the SOURCE codecs natively, so the Load payload uses
@@ -832,7 +927,7 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     }
     // keep the flavor so a later seek rebuilds the same query for start.mkv?...&offset=T
     plan.remux = video_dp;
-    put_selection(plan.part_id, env.audio_sid, env.sub_sid); // audio/subtitle selection drives the encode/remux + burn
+    put_selection(env.sid, plan.part_id, env.audio_sid, env.sub_sid); // audio/subtitle selection drives the encode/remux + burn
     let sp = transcode_spec(rk, &session, video_dp, -1, env.audio_sid, env.sub_sid);
     if let Some(mc) = client.transcode_decision(&sp) {
         // The server has already answered, and it is allowed to answer NO. Stop here rather than
@@ -1100,9 +1195,25 @@ static PLAY_SLOT: Mutex<Option<(u32, Plan, String)>> = Mutex::new(None);
 /// True while a resolve is in flight — the HUD renders `PlaybackState::Resolving` from this.
 pub(crate) fn play_pending() -> bool { PLAY_BUSY.load(Ordering::SeqCst) }
 
+/// The server an item on a browsing surface came from. MAIN THREAD.
+///
+/// Today every surface is drawn from the CURRENT server, so this is `plex::current_server()` — and
+/// reading it HERE, on the main thread, at the instant the user pressed Play, is the entire point:
+/// from this line on the id travels by value and nothing downstream re-resolves it. When the stored
+/// rows carry their own server (the shared-server data-model step), each call site passes `m.sid` /
+/// `d.sid` instead and this helper goes away; it exists so there is exactly ONE line to change.
+pub(crate) fn surface_sid() -> ServerId {
+    crate::plex::current_server()
+}
+
 /// MAIN THREAD, NON-BLOCKING. Publishes the HUD strings immediately, supersedes any in-flight
 /// resolve, and spawns a worker. The caller flips the route this same frame.
-pub(crate) fn request_play(rk: &str, part: &str, vcodec: &str, acodec: &str, title: &str, ctx: &str) {
+///
+/// `sid` is the server the ITEM came from, which the caller knows and this function must not guess:
+/// with more than one source on Home, the item being started and the server currently being browsed
+/// routinely differ, and every id in the playback protocol below (`rk`, the Part, the streams, the
+/// PlayQueue, the resume point) belongs to the former.
+pub(crate) fn request_play(sid: ServerId, rk: &str, part: &str, vcodec: &str, acodec: &str, title: &str, ctx: &str) {
     if part.is_empty() && rk.is_empty() {
         return;
     }
@@ -1130,7 +1241,7 @@ pub(crate) fn request_play(rk: &str, part: &str, vcodec: &str, acodec: &str, tit
     crate::player::reset_audio_track();
     crate::player::reset_subtitle();
     // captured HERE, on the main thread, and moved into the worker — see ResolveEnv
-    let env = ResolveEnv::snapshot(rk);
+    let env = ResolveEnv::snapshot(sid, rk);
     let gen = PLAY_GEN.fetch_add(1, Ordering::SeqCst) + 1;
     PLAY_BUSY.store(true, Ordering::SeqCst);
     let (rk, part, vc, ac) = (rk.to_string(), part.to_string(), vcodec.to_string(), acodec.to_string());
@@ -1161,7 +1272,7 @@ pub(crate) fn request_play_movie(m: &PmsMovie) {
     }
     let rating = if m.rating.is_empty() { "NR" } else { &m.rating };
     let ctx = format!("{} \u{b7} {} \u{b7} {}", m.year, rating, crate::ui::fmt::dur_short(m.dur_ns / 1_000_000));
-    request_play(&m.rk, &m.part, &m.vcodec, &m.acodec, &m.title, &ctx);
+    request_play(surface_sid(), &m.rk, &m.part, &m.vcodec, &m.acodec, &m.title, &ctx);
 }
 
 /// Start the queued next episode. Takes the descriptor BY VALUE, and that is load-bearing rather
@@ -1175,7 +1286,11 @@ pub(crate) fn request_play_movie(m: &PmsMovie) {
 pub(crate) fn request_play_up_next(u: UpNext) {
     let ctx = crate::ui::fmt::episode_kicker(u.season, u.index, &u.ep_title);
     let title = if u.show_title.is_empty() { &u.ep_title } else { &u.show_title };
-    request_play(&u.rk, &u.part, &u.vcodec, &u.acodec, title, &ctx);
+    // The successor comes out of the PlayQueue of the item now playing, so its server is that
+    // item's — [`cur_sid`], not whatever surface is behind the player. Falls back to the browsing
+    // surface only if nothing is playing, which the Up Next control cannot actually reach.
+    let sid = if cur_sid().is_set() { cur_sid() } else { surface_sid() };
+    request_play(sid, &u.rk, &u.part, &u.vcodec, &u.acodec, title, &ctx);
 }
 
 /// Supersede an in-flight resolve (BACK during a load). The landing is dropped by generation.
@@ -1202,6 +1317,21 @@ pub(crate) fn pump_play() -> bool {
     PLAY_BUSY.store(false, Ordering::SeqCst);
     let ok = !plan.url.is_empty();
     apply_plan(plan, &rk);
+    // Warm the next episode's still NOW rather than at first draw. The URL has been known since
+    // this plan resolved — tens of minutes before the credits — and the fetch is async, so touching
+    // it here costs nothing and spares the control a skeleton for one image-transcode round trip at
+    // exactly the moment it appears in front of the user. `warm_tex`, not `resolve_tex`: this wants
+    // the fetch and nothing else, and a slot warmed tens of minutes early must NOT be carrying the
+    // evict-protection a draw takes (see `posters::poster_warm`). At the tile's OWN 480×270 —
+    // `(path, w, h, png)` IS the store key, so a warm at any other size buys nothing.
+    //
+    // It sits HERE, in the once-a-frame pump, rather than inside `apply_plan`: that function's
+    // contract is that it is the sole WRITER OF THE ROUTE STATICS, and a texture prefetch is not
+    // one of them. Keeping the two apart also keeps the install reachable from the host suite —
+    // `warm_tex` pulls in the poster cache and, through it, a GL call the dev Mac cannot link.
+    if let Some(u) = up_next() {
+        crate::ui::widgets::warm_tex(&u.thumb, 480, 270, 0);
+    }
     ok
 }
 
@@ -1220,16 +1350,6 @@ fn apply_plan(plan: Plan, rk: &str) {
         // true without a second clear anyone can forget.
         *addr_of_mut!(PLAY_VERDICT) = plan.verdict;
     }
-    // Warm the next episode's still NOW rather than at first draw. The URL has been known since
-    // this plan resolved — tens of minutes before the credits — and the fetch is async, so touching
-    // it here costs nothing and spares the control a skeleton for one image-transcode round trip at
-    // exactly the moment it appears in front of the user. `warm_tex`, not `resolve_tex`: this wants
-    // the fetch and nothing else, and a slot warmed tens of minutes early must NOT be carrying the
-    // evict-protection a draw takes (see `posters::poster_warm`). At the tile's OWN 480×270 —
-    // `(path, w, h, png)` IS the store key, so a warm at any other size buys nothing.
-    if let Some(u) = up_next() {
-        crate::ui::widgets::warm_tex(&u.thumb, 480, 270, 0);
-    }
     if !plan.vcodec.is_empty() {
         set_stream_codecs(&plan.vcodec, &plan.acodec); // the pair is only ever set together
         // …and what the FILE is, before any /decision output overwrites the pair above
@@ -1239,7 +1359,11 @@ fn apply_plan(plan: Plan, rk: &str) {
         addr_of_mut!(CUR_PART_ID).write(plan.part_id);
         *addr_of_mut!(SESS) = plan.sess;
         if !plan.machine_id.is_empty() {
+            // Cached AGAINST its server: the next playback only reuses it when it is playing from
+            // the same one (`ResolveEnv::snapshot`). One global cache is how server A's fingerprint
+            // ends up in a PlayQueue uri POSTed to server B.
             *addr_of_mut!(MACHINE_ID) = plan.machine_id;
+            addr_of_mut!(MACHINE_SID).write(plan.sid);
         }
         *addr_of_mut!(PQ_ID) = plan.pq_id;
         *addr_of_mut!(PQ_ITEM_ID) = plan.pq_item_id;
@@ -1251,7 +1375,12 @@ fn apply_plan(plan: Plan, rk: &str) {
         addr_of_mut!(CUR_REMUX).write(plan.remux);
         *addr_of_mut!(URL) = plan.url;
         *addr_of_mut!(TSESSION) = plan.tsession;
+        // The two halves of the playing item's identity, installed together and by the same
+        // writer — a ratingKey means nothing without the server it is a key ON. Everything after
+        // this point (the track PUT, a transcode seek, the retranscode, the stop, and the 10 s
+        // progress reporter engine.rs is about to spawn) resolves its server from this.
         *addr_of_mut!(CUR_RK) = rk.to_string();
+        addr_of_mut!(CUR_SID).write(plan.sid);
     }
     // SHARED.desired_audio_idx is read by the DEMUX THREAD on every reopen — main thread only.
     if let Some(ord) = plan.feed_audio_ordinal {
@@ -1280,7 +1409,7 @@ fn apply_plan(plan: Plan, rk: &str) {
 /// unchanged). Sets URL/TSESSION/TBASE, runs /decision, and returns the new start.mkv URL
 /// (the demux re-opens it from byte 0), or None.
 pub(crate) fn retranscode(offset_secs: i64) -> Option<String> {
-    let c = crate::plex::client_opt()?;
+    let c = cur_client()?;
     let rk = unsafe { (*addr_of!(CUR_RK)).clone() };
     if rk.is_empty() {
         return None;
@@ -1299,7 +1428,7 @@ pub(crate) fn retranscode(offset_secs: i64) -> Option<String> {
     // guess: apply_decision_codecs below replaces it with the server's actual output, but it
     // must still track devcaps, not the dev TV (issue #22's bug class).
     set_stream_codecs(crate::devcaps::caps().encode_vcodec(), "ac3");
-    put_selection(cur_part_id(), cur_audio_sid(), cur_sub_sid()); // drives the encode + burn
+    put_selection(cur_sid(), cur_part_id(), cur_audio_sid(), cur_sub_sid()); // drives the encode + burn
     let qsess = sess();
     let sp = transcode_spec(&rk, &qsess, false, offset_secs.max(0), cur_audio_sid(), cur_sub_sid());
     if let Some(mc) = c.transcode_decision(&sp) {
@@ -1346,7 +1475,7 @@ pub(crate) fn commit_audio_selection(idx: i32, codec: &str, stream_id: i64) {
         // persist the USER's pick server-side (official-client behavior): /status/sessions'
         // selected-stream display keys on the part selection, not the timeline report. Only
         // user picks persist — the start-of-play auto-pick (eng preference) reports only.
-        put_selection(cur_part_id(), cur_audio_sid(), cur_sub_sid());
+        put_selection(cur_sid(), cur_part_id(), cur_audio_sid(), cur_sub_sid());
         crate::player::request_audio_track(idx, codec);
     } else {
         crate::player::request_audio_switch(stream_id);
@@ -1364,16 +1493,25 @@ pub(crate) fn commit_subtitle_selection(sub_idx: i32, stream_id: i64) {
     } else {
         // persist the pick server-side (and subs Off PUTs subtitleStreamID=0, clearing a
         // stale server-side selection that would otherwise burn on the next transcode)
-        put_selection(cur_part_id(), cur_audio_sid(), cur_sub_sid());
+        put_selection(cur_sid(), cur_part_id(), cur_audio_sid(), cur_sub_sid());
     }
 }
 
-/// POST one /:/timeline progress report for `rk`, carrying this playback's session + PlayQueue
-/// + selected-stream state — so /status/sessions shows the right track and the Direct Play vs
-/// Transcode badge. The ONE timeline call site (the ~10s reporter thread and the final
-/// state=stopped report both come through here).
-pub(crate) fn report_timeline(rk: &str, state: crate::plex::TimelineState, t_ms: i64, d_ms: i64) {
-    let c = match crate::plex::client_opt() {
+/// POST one /:/timeline progress report for `rk` to `sid`'s server, carrying this playback's
+/// session + PlayQueue + selected-stream state — so /status/sessions shows the right track and the
+/// Direct Play vs Transcode badge. The ONE timeline call site (the ~10s reporter thread and the
+/// final state=stopped report both come through here).
+///
+/// **`sid` is an argument, and that is the whole point.** This runs on the reporter WORKER, once
+/// every ten seconds for the life of a playback, and it used to resolve its server by calling
+/// `client_opt()` — i.e. it asked, on each tick, "which server is the user browsing right now?".
+/// The rk is a key on the server the item came from; posted to any other one it either 404s or
+/// silently moves a stranger's resume point. Nothing about that is visible from the app: the POST
+/// is fire-and-forget, the host suite has no runtime, and the device harness grades progress from
+/// the app's own heartbeat, not from the server. So the reporter captures the id at its spawn site
+/// (`engine.rs`, beside the `rk` it already captured) and hands it back here.
+pub(crate) fn report_timeline(sid: ServerId, rk: &str, state: crate::plex::TimelineState, t_ms: i64, d_ms: i64) {
+    let c = match crate::plex::client_for(sid) {
         Some(c) => c,
         None => return,
     };
@@ -1764,5 +1902,145 @@ mod tests {
 
         // no verdict block at all (an older server, or a body we could not parse into one)
         assert!(refusal(&mc(br#"{"MediaContainer":{"size":1}}"#)).is_none(), "absent is not a refusal");
+    }
+
+    // ---- the playing item's SERVER: captured once, carried by value ---------------------------
+    // A ratingKey, a Part id, a Stream id, a playQueueID and a resume point are all keys on ONE
+    // server. Every PMS call in this file used to find its server by asking which one was current
+    // at the instant of the call, so an item borrowed from a shared source was resolved, queued,
+    // PUT, stopped and — every ten seconds — reported to whichever server the user had since
+    // wandered off to. None of that is observable from inside the app, which is why these exist.
+
+    /// Take the crate-wide serialization lock and empty the server registry, so each test below
+    /// starts from "nothing installed" and, more importantly, LEAVES the table that way. A test
+    /// that registers a loopback server and walks off owes the next one an empty table: its ports
+    /// close when it returns, so what it leaves behind is a `client_opt()` that answers `Some` with
+    /// a client nothing will ever answer.
+    fn fresh_registry() -> std::sync::MutexGuard<'static, ()> {
+        let g = crate::testlock::serial();
+        crate::plex::reset_servers_for_test();
+        g
+    }
+
+    /// A `ServerId` naming a slot nothing is registered in — so `client_for` answers `None` and
+    /// `build_stream` takes its no-client exit without opening a socket.
+    fn unregistered_sid() -> ServerId {
+        let id = ServerId::from_raw(crate::plex::server_count() as u16 + 1);
+        assert!(crate::plex::client_for(id).is_none(), "the test needs an EMPTY slot");
+        id
+    }
+
+    /// The identity round trip: `request_play`'s captured id reaches `CUR_SID` unchanged, through
+    /// `ResolveEnv` (the main-thread snapshot) and `Plan` (the worker's output).
+    ///
+    /// Graded on the resolve that FAILS, deliberately — it is the exit `build_stream` takes first,
+    /// before any network, and a plan that carries no server is one `apply_plan` cannot install an
+    /// honest `CUR_SID` from. Every richer exit builds on the same field.
+    #[test]
+    fn a_plan_round_trips_the_server_the_request_captured() {
+        let _g = fresh_registry();
+        let sid = unregistered_sid();
+
+        let env = ResolveEnv::snapshot(sid, "rk-7");
+        assert_eq!(env.sid, sid, "the snapshot carries the id the request was made with");
+
+        let plan = build_stream("rk-7", "/library/parts/5/1/f.mkv", "h264", "ac3", &env);
+        assert_eq!(plan.sid, sid, "a plan that could not resolve still names its server");
+        assert!(plan.url.is_empty(), "no client for that slot, so nothing resolved");
+        assert_eq!(plan.part_id, 5, "…and the rest of the plan is built as usual");
+
+        apply_plan(plan, "rk-7");
+        assert_eq!(cur_sid(), sid, "the installed identity is the captured one");
+        assert_eq!(cur_rk(), "rk-7", "and its other half");
+    }
+
+    /// The `/identity` cache is keyed to the server that taught it. It feeds
+    /// `uri=server://{machineIdentifier}/…` on the PlayQueue POST, so one cached globally is
+    /// server A's fingerprint sent to server B — naming a machine B has never heard of, on a POST
+    /// that is best-effort and therefore fails silently.
+    #[test]
+    fn the_machine_id_cache_is_scoped_to_the_server_that_taught_it() {
+        let _g = fresh_registry();
+        let a = ServerId::from_raw(crate::plex::server_count() as u16 + 1);
+        let b = ServerId::from_raw(crate::plex::server_count() as u16 + 2);
+
+        apply_plan(Plan { sid: a, machine_id: "MACHINE-A".into(), ..Default::default() }, "rk-a");
+        assert_eq!(ResolveEnv::snapshot(a, "rk-a").machine_id, "MACHINE-A", "its own server reuses it");
+        assert_eq!(
+            ResolveEnv::snapshot(b, "rk-b").machine_id, "",
+            "another server must re-ask rather than inherit A's fingerprint"
+        );
+
+        // …and an empty `machine_id` means "leave the cache alone", not "the cache is now B's"
+        apply_plan(Plan { sid: b, ..Default::default() }, "rk-b");
+        assert_eq!(ResolveEnv::snapshot(a, "rk-a").machine_id, "MACHINE-A");
+        assert_eq!(ResolveEnv::snapshot(b, "rk-b").machine_id, "");
+    }
+
+    /// A one-shot loopback PMS: accepts ONE connection, hands its request line back down the
+    /// channel, and answers 200 so the client's read terminates. Real sockets, like `stream.rs`'s
+    /// own tests — which server a POST actually reached is the only thing the timeline routing can
+    /// be graded on without a television.
+    fn stub_pms() -> (i32, std::sync::mpsc::Receiver<String>, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead, BufReader, Write};
+        let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = l.local_addr().unwrap().port() as i32;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = std::thread::spawn(move || {
+            if let Some(Ok(s)) = l.incoming().next() {
+                let mut line = String::new();
+                let _ = BufReader::new(&s).read_line(&mut line);
+                let mut s = s;
+                let _ = s.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+                let _ = tx.send(line);
+            }
+        });
+        (port, rx, h)
+    }
+
+    /// **The one that had to ship in the same commit as `CUR_SID`.** The `/:/timeline` report runs
+    /// on a worker every ten seconds and used to read the current server fresh on each tick — the
+    /// only place in the playback path with no capture at all. Split from the rest, the app
+    /// resolves correctly, plays correctly, and quietly writes the resume point of a friend's film
+    /// onto your own server for as long as it plays.
+    ///
+    /// Two servers on loopback, the item playing from B, the user browsing A: the POST must land on
+    /// B. The closing report to A is the control — it proves the two stubs are distinguishable, so
+    /// "A heard nothing" is a fact about the routing and not about a listener that never worked.
+    #[test]
+    fn the_timeline_reaches_the_server_the_item_came_from_not_the_current_one() {
+        use std::time::Duration;
+        let _g = fresh_registry();
+        let (pa, rx_a, ha) = stub_pms();
+        let (pb, rx_b, hb) = stub_pms();
+        // `register_for_test`, not the public `register`: the latter resolves the device id through
+        // `session::load`, which mints and PERSISTS a uuid on a host that has no session file.
+        let a = crate::plex::register_for_test("route-test-A", "127.0.0.1", pa, "tok-a", "cid-route-test");
+        let b = crate::plex::register_for_test("route-test-B", "127.0.0.1", pb, "tok-b", "cid-route-test");
+        assert_ne!(a, b, "two servers, two slots");
+
+        // an item from B starts playing, then the user walks back to their OWN server's Home
+        apply_plan(Plan { sid: b, ..Default::default() }, "rk-b");
+        assert!(crate::plex::set_current(a));
+        assert_eq!(cur_sid(), b, "what is PLAYING does not move when the browsed server does");
+
+        report_timeline(cur_sid(), "rk-b", crate::plex::TimelineState::Playing, 1_000, 2_000);
+        let got = rx_b.recv_timeout(Duration::from_secs(5)).expect("B never received the report");
+        assert!(got.contains("ratingKey=rk-b"), "B got something else: {got}");
+        assert!(
+            rx_a.recv_timeout(Duration::from_millis(300)).is_err(),
+            "the current server must not receive another server's progress"
+        );
+
+        // control: the same call named at A does reach A, so the assertion above is about routing
+        report_timeline(a, "rk-a", crate::plex::TimelineState::Stopped, 0, 2_000);
+        let got = rx_a.recv_timeout(Duration::from_secs(5)).expect("A never received its own report");
+        assert!(got.contains("ratingKey=rk-a"), "A got something else: {got}");
+
+        ha.join().unwrap();
+        hb.join().unwrap();
+        // Hand the table back empty. Both stubs' ports close as this returns, so anything left
+        // registered is a client that answers nothing — and `CURRENT` still points at one of them.
+        crate::plex::reset_servers_for_test();
     }
 }

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -2848,7 +2848,7 @@ pub(crate) fn on_ok() -> bool {
                 } else if let Some(d) = metadata::current() {
                     // a hub refetch can orphan the page's catalog row (the item left the hubs) —
                     // the loaded Detail carries everything the string-based route entry needs
-                    crate::route::request_play(&d.rk, &d.part, &d.vcodec, &d.acodec, &d.title, "");
+                    crate::route::request_play(crate::route::surface_sid(), &d.rk, &d.part, &d.vcodec, &d.acodec, &d.title, "");
                 } else {
                     return false;
                 }
@@ -3361,7 +3361,7 @@ fn play_episode(d: &metadata::Detail, ep: &metadata::Episode) -> bool {
         detail_rk: d.rk.clone(),
     }));
     set_resume(ep.resume_ms, ep.dur_ms);
-    crate::route::request_play(&ep.rk, &ep.part, &ep.vcodec, &ep.acodec, &hud_title, &hud_ctx);
+    crate::route::request_play(crate::route::surface_sid(), &ep.rk, &ep.part, &ep.vcodec, &ep.acodec, &hud_title, &hud_ctx);
     true
 }
 
@@ -3964,6 +3964,15 @@ mod tests {
         v.col = col;
         v.ep_row = EpRow::Still; // the filmstrip sub-row is retained state; no test may inherit one
         v.tabs = TabStrip::new(); // …and so are the season strip's capsules
+        // …and so is the per-section column memory, which is the one that got away. `move_focus`
+        // seeds `col` from `saved_col[ns]` when it ENTERS the episode/related/cast row, so a test
+        // that walked one of those strips left the next test's first DOWN landing on ITS column
+        // rather than on the one this mount just asked for. Order-dependent, therefore invisible
+        // until the set of tests changes: it surfaced when route.rs gained a case that holds
+        // `testlock` across real socket I/O, which re-ordered who runs beside whom.
+        // `reset_view_state` — the production reset this helper stands in for — has always cleared
+        // it; the fixture simply did not.
+        v.saved_col = [0; 6];
         v.last_resume_ns = 0;
         v.hero_had_restart = restart;
     }


### PR DESCRIPTION
Playback becomes per-server: the server an item came from is captured once, at the request, and carried by value through the whole playback protocol.

## The problem

A `ratingKey` names an item on ONE server. So does a `Part.id`, a `Stream.id`, a `playQueueID`, and the resume point. Today every PMS call on the playback path resolves its server **implicitly, at the instant of the call**, via `plex::client_opt()` — which means *"whichever server the user is browsing right now"*.

With one server that is always the right answer. With a friend's share merged into Home, "the item is from B while current is A" is ordinary, and then the resolve, the PlayQueue, `/decision`, the track PUT, the transcode stop and **every progress report** go to A. The resolve worker alone asked the question **four independent times**, so a switch landing mid-resolve could split one playback across two servers.

## What changed

The server is captured **once**, on the main thread, at `request_play` — the same instant and the same discipline as every other `ResolveEnv` field — and carried by value from there:

```
request_play(sid, …) → ResolveEnv.sid → Plan.sid → CUR_SID  (installed by apply_plan)
```

`apply_plan` stays the sole writer of the route statics and now installs `CUR_SID` in lockstep with `CUR_RK`. Every call in the chain became `client_for(sid)`:

| site | now resolves from |
|---|---|
| `build_stream`'s client bind | `env.sid` |
| `resolve_playqueue` (machine id + `create_play_queue`) | the client passed in |
| `server_decision` / `mde_decision` | the client passed in |
| `put_selection` / `select_streams` | `env.sid` (worker) / `cur_sid()` (in-playback) |
| `transcode_seek`, `retranscode` | `cur_sid()` |
| `scrobble_stop`'s captured client | `cur_sid()`, read on the main thread |
| `report_timeline` | its **argument** — see below |
| `metadata::fetch_playing_item` | `sid` |

`plex::client_opt()` is worth naming as the hazard it is, and `build_stream`'s doc now does: it is not a static a worker could be caught reading, it is a **function call**, so `Send` cannot see it, and a worker that resolves its own server compiles clean and passes every test we have.

## The part that is a review argument, not a test result

**`report_timeline` had to ship in the same commit as `CUR_SID`, and no suite on either tier can prove it.**

The `/:/timeline` reporter runs on a worker every ten seconds for the whole of a playback, and it was the only place in the playback path with **no capture at all** — it re-read the current server on each tick. Split from `CUR_SID`, the app would resolve correctly, play correctly, and quietly write the resume point of a borrowed film onto your own server every ten seconds for as long as it played.

Nothing in either tier would show it:

- the POST is fire-and-forget — its result is discarded, so the app itself cannot notice;
- there is no host runtime, so no host test reaches the live reporter;
- `tests/run.py` grades playback progress from the app's own **heartbeat** (`pos=` on the `loop=` line), not from the server the report reached — so a report landing on the wrong server passes `timeline_climb` and `timeline_post` exactly like a correct one;
- and the harness could not reach a second server at all until the injection landed on this base branch.

So the fix is structural and must be read rather than measured: `report_timeline` takes the `ServerId` as an argument, and `engine.rs` captures it **at the spawn site**, beside the `rk` it already captured by value:

```rust
let (sid, rk) = (crate::route::cur_sid(), crate::route::cur_rk());
…
crate::task::spawn("timeline", move || threads::timeline_thread(sid, rk, st))
```

Two things to check by reading: (1) `cur_sid()` is read on the main thread, after `apply_plan` has installed it and before the worker exists; (2) nothing inside `timeline_thread` or `report_timeline` consults the registry's *current* pointer any more.

The nearest thing to a test is `the_timeline_reaches_the_server_the_item_came_from_not_the_current_one` (below), which grades the routing of one report against two real loopback servers. It cannot grade the **capture** — only that the argument is honoured.

## Machine id: per-server, and the registry outranks the cache

`MACHINE_ID` was "fetched once and never refreshed", and it feeds `uri=server://{machineIdentifier}/…` on the PlayQueue POST. Cached globally, that is server A's fingerprint POSTed to B — naming a server B has never heard of, on a best-effort POST that fails silently.

It is now keyed to the server that taught it (`MACHINE_SID`), and `resolve_playqueue` prefers, in order: the **registry's own per-server id** (`Client::machine_id()`, which cannot belong to another server), then this server's cached one, then `GET /identity`. A server registered with an id skips the round trip entirely.

## Host tests

Three new, and the pure parts only — the rest is the argument above.

- `a_plan_round_trips_the_server_the_request_captured` — graded on the resolve that **fails**, which is the exit `build_stream` takes before any network: a plan that could not resolve still names its server, and `apply_plan` installs it.
- `the_machine_id_cache_is_scoped_to_the_server_that_taught_it` — from both sides: its own server reuses the cache, another server gets nothing and must re-ask.
- `the_timeline_reaches_the_server_the_item_came_from_not_the_current_one` — two real loopback servers (the `stream.rs` idiom). The item plays from B, the user switches to A, the POST must land on B; a closing report to A is the control, so *"A heard nothing"* is a fact about the routing and not about a listener that never worked.

That last one needed `plex`'s registry test seams widened to `pub(crate)` (`register_with_client_id`, `reset_for_test`). The public `register` resolves the device id through `session::load`, which **mints and persists** a uuid — a host test has no business writing one — and the reset is what hands the table back empty, so the next test does not find a `client_opt()` answering `Some` with a client whose port closed when this test returned.

## Two things that moved for a reason

**The Up Next still-warm left `apply_plan` for `pump_play`,** its only caller. `apply_plan`'s contract is to be the sole writer of the route statics; a texture prefetch is not one of them. It is also what lets the host suite reach the install at all — `warm_tex` drags in the poster cache and, through it, a GL call the dev Mac cannot link. Behaviour is identical: one non-test caller, and `UP_NEXT` is installed before either point.

**`ui::detail`'s test `mount` now resets `saved_col`.** It reset the filmstrip sub-row and the season capsules as retained state ("no test may inherit one") but not the per-section column memory that `move_focus` seeds from when it enters a strip — so a test that walked one strip decided where the next test's first DOWN landed. Order-dependent, and therefore invisible until the set of tests changes: it surfaced when `route.rs` gained a case that holds `testlock` across real socket I/O and re-ordered who runs beside whom. `reset_view_state` — the production reset the fixture stands in for — has always cleared it.

## The one hole left, deliberately

`metadata::cached_playing` takes the `ServerId` and does not yet use it: `Detail` carries no server, so the match is still the `rk` alone. It is written up at the call site as a `TODO(shared-servers)` with what it costs once two sources share a shelf (B's playback running on A's stream ids, fps, frame size, markers and chapters — silently) and the one-line shape of the fix (`d.sid == sid &&`). The equality tests inside `metadata.rs` belong to the sibling unit that adds the field; the signature is already threaded so that change is one line.

## Verification

- **Device: `./tests/run.py` → 21 passed, 0 failed, 0 known-gap of 21.** The whole matrix, not just the fps scenes — this touches the playback identity path, so the codec, seek, resume, audio-switch and subtitle cases all apply. `timeline_climb` and `timeline_post` pass on every case that carries them.
- **Host: `make check` green ×3**, plus 12 consecutive runs at `--test-threads=16` (which is how the fixture flake above was found and confirmed fixed). 421 tests.
- **ARM: `make` links clean.**

## Not touched

Below `route::url()` nothing changed — the engine consumes an absolute URL that already carries its host, port and token. `ff.rs`, `stream.rs`, `aq.rs` and the Starfish seam are untouched.

**Known gap for whoever picks it up:** `player::error_shape` still reads `plex::serverinfo::subscription()`, which is a single global refreshed by `install`. For an item borrowed from a friend's server the relevant Plex Pass state is *theirs*, so the "this needs a subscription" read-out can name the wrong server's. It is a diagnostics surface and never a routing input (its own module doc says so), and making `serverinfo` per-server is a `plex/` change outside this unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxZ585ehWMnuScciTQ9WgV
