### PR TITLE
plex: a relay is a 2 Mbit/s tunnel, so the plan changes, not a number

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,11 @@ used: **libcurl** (`net.rs`) does the plex.tv account/login TLS+DNS that the raw
   `player/` (buffer-feed engine + worker threads — **`rust-modules/src/player/CLAUDE.md` is the
   playback deep-dive; read it before touching playback**), `ff.rs` (THE demuxer — the **bundled,
   pinned** libavformat shipped beside the binary, *not* the TV's), `stream.rs`/`aq.rs` (HTTP socket
-  → AU pipeline), `net.rs` (libcurl/TLS), and the Plex data layer.
+  → AU pipeline), `net.rs` (libcurl/TLS), and the Plex data layer (`plex/` — **its own
+  `rust-modules/src/plex/CLAUDE.md`**, which the rest of this file never pointed at: read it before
+  adding a PMS query, and before assuming there is one server. There is a REGISTRY behind
+  `client()` now — the app can hold a friend's shared server beside your own, each with its own
+  token, `ratingKey` space and watch state. `docs/shared-servers.md` is the design note).
 - `rust-modules/src/ui/` — **the UI, as a shared design system**: `theme.rs` tokens, the retui core
   (`mod.rs` `Painter`/`View`), reusable components (`widgets.rs`/`table.rs`/`label.rs`/`icons.rs`),
   and the screens (`home.rs`/`detail.rs`/`player_hud.rs`/…). **`rust-modules/src/ui/CLAUDE.md` is the

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,29 @@ RUST_ENV = RUSTFLAGS="-C target-cpu=cortex-a9 -C target-feature=-neon $(RUST_DEB
 #   libpf-1.0 carries mediapipeline::CustomPipeline (the webOS<11 seek path).
 LIBS_REAL = -lSDL2 -lSDL2_ttf -lGLESv2 -lluna-service2 -lglib-2.0 \
             -lwayland-client -lplayerAPIs -lpf-1.0
-# NOT LISTED, DELIBERATELY: FFmpeg, libcurl and libAcbAPI. Their SONAMEs move between releases
-# (FFmpeg 55->57->58->59->60, curl .so.5->.so.4, ACB deleted outright at webOS 5.0), and a
-# DT_NEEDED entry for a name the device lacks kills the process at exec() — before main, before
-# the event log exists. They are dlopen'd by SONAME candidate list instead: see
-# rust-modules/src/dynlib.rs, and the video-plane comment at the top of src/starfish.c.
+# NOT LISTED, DELIBERATELY — but for TWO different reasons, and this comment used to give only
+# the first, for all three.
+#
+#   libcurl and libAcbAPI: their SONAMEs MOVE between releases (curl .so.5 -> .so.4, ACB deleted
+#   outright at webOS 5.0). A DT_NEEDED entry is a hard requirement for one exact name, cannot say
+#   "either of these", and a name the device lacks kills the process at exec() — before main,
+#   before the event log exists. So they are dlopen'd by SONAME CANDIDATE LIST:
+#   rust-modules/src/dynlib.rs, and the video-plane comment at the top of src/starfish.c.
+#
+#   FFmpeg is not a version question at all any more: we SHIP our own, pinned (the bundled-FFmpeg
+#   section below builds libav*-plx.so.63/63/61 and stages them into pkg/). It is unlinked because
+#   those files land BESIDE the binary, which is on no library search path, and they carry no rpath
+#   — so a DT_NEEDED entry would be resolved at exec() against the system path, where it either
+#   finds nothing (dead before main) or finds the TELEVISION's copy, which is the wrong one:
+#   webOS 11.2.0 ships FFmpeg 6 itself. ff.rs::load_libraries opens the three by ABSOLUTE PATH out
+#   of paths::app_dir(), one pinned SONAME each, in dependency order under RTLD_GLOBAL — not a
+#   candidate list, and nothing is being tolerated.
+#
+# The old wording ("FFmpeg 55->57->58->59->60") described the app that read the TV's FFmpeg, and it
+# survived the bundling by 100 lines. Left alone it points the next reader at version tolerance we
+# no longer need and at a library we no longer use — which is how "just use the TV's libavformat
+# for https" keeps coming back, when the copy we ship is configured --disable-network and cannot
+# open a URL at all. Root CLAUDE.md's "Linking" section carries the same account at length.
 
 # Rust-first build. The app is Rust (rust-modules/, compiled to a staticlib and
 # linked in); C is only main.c (boot shim) + starfish.c (the StarfishMediaAPIs

--- a/docs/shared-servers.md
+++ b/docs/shared-servers.md
@@ -1,9 +1,11 @@
 # Shared (non-owned) Plex servers — how Plex structures them, and how to integrate one
 
-**Status:** design note, 2026-08-11. Written after being granted access to a friend's server.
-Everything in §2 was **measured live** against that server, from the dev Mac *and* from the TV
-itself. Everything in §1 is Plex's model as documented by its own client libraries. §5's plan is
-sequenced, and steps 0 and 4a have landed (see §9).
+**Status:** design note, 2026-08-11; landed-work section refreshed 2026-08-13. Written after being
+granted access to a friend's server. Everything in §2 was **measured live** against that server,
+from the dev Mac *and* from the TV itself. Everything in §1 is Plex's model as documented by its own
+client libraries. §5's plan is sequenced; **§9 is the record of what has actually landed**, and it
+is the section to read before starting a step — several of them are now partly done, and one (the
+relay policy, step 9) is done ahead of the transport work that can exercise it.
 
 Addresses, tokens, machine identifiers and the owner's username are deliberately **not** recorded
 here — the same redaction rule `ui/stats.rs` applies to the diagnostics panel.
@@ -80,9 +82,10 @@ Three findings, each load-bearing:
 
 **(a) `local: true` is a trap.** The flag means "this address is RFC1918", not "*you* are on that
 LAN" — `publicAddressMatches` is the field that means the latter, and it is `false` here. Our
-current selector (`auth.rs:396`) filters on exactly `c.local && !c.relay`, so if it ever reached
-this resource it would pick the owner's `172.20.x.x` and hang for 8 seconds — or, worse, reach a
-*different machine* on our own LAN at that address. This is why the probe must verify
+current selector (`auth::choose_local_connection`) filters on `c.local && !c.relay` (plus an IPv4
+guard added 2026-08-14, §9), so if it ever reached this resource it would pick the owner's
+`172.20.x.x` and hang for 8 seconds — or, worse, reach a *different machine* on our own LAN at that
+address. This is why the probe must verify
 `machineIdentifier`, and why non-owned `local` connections should be dropped outright.
 
 **(b) The per-server token is mandatory, and provably so.** Against the share's
@@ -114,40 +117,40 @@ Also measured, because they shape the playback story:
 
 ---
 
-## 3. What the app does today
+## 3. What the app did on 2026-08-11 — and what of it is still true
 
-**It already fetches the whole list, then throws it away.** `plex/account.rs:98-100` requests
-`?includeHttps=1&includeRelay=1`. `Resource` (`account.rs:145-159`) keeps six fields and drops
-`sourceTitle`, `ownerId`, `home`, `presence`, `publicAddressMatches`, `httpsRequired`.
-`Connection.protocol` and `Connection.uri` are parsed and **never read** by anything.
+*The first three paragraphs describe the app as this note found it. Two of them have since been
+answered (§9); they are kept because the collision table below is only readable against them.*
 
-**`owned` is already a preference, not a wall.** `auth.rs:389-400` tries owned servers first and
-falls back to any server — the real filter is `c.local && !c.relay && !c.address.is_empty()` on
-*both* passes (`auth.rs:396`). A remote server dies at `auth.rs:403` with *"No local Plex server
-found on this network."* `Resource::local_connection()` (`account.rs:166-171`), whose lenient
-fallback is the shape a remote server needs, is **dead code — zero callers**.
+**It already fetched the whole list, then threw it away.** `plex/account.rs` requested
+`?includeHttps=1&includeRelay=1`; `Resource` kept six fields and dropped `sourceTitle`, `ownerId`,
+`home`, `presence`, `publicAddressMatches`, `httpsRequired`; `Connection.protocol` and
+`Connection.uri` were parsed and never read. **Fixed** — the roster DTOs are widened and
+null-tolerant (§9).
 
-**One server, forever.** `plex/client.rs:149-162`:
+**`owned` is a preference, not a wall — and this part is STILL LIVE.** `auth.rs` tries owned servers
+first and falls back to any server, but the real filter is `c.local && !c.relay &&
+!c.address.is_empty()` on *both* passes (now `auth::choose_local_connection`, plus the IPv4 guard of
+§9), so a remote-only server dies with *"no server with a local connection (remote-only can't be
+reached)"*. `probe.rs` knows better and nothing calls it
+yet: **the 8-second trap of §2(a) is still what the running app would do.** This line is step 4's
+whole reason to exist.
 
-```rust
-static PLEX: OnceLock<Client> = OnceLock::new();
-pub fn install(host: &str, port: i32, token: &str) {
-    match PLEX.get() { None => { let _ = PLEX.set(Client::new(host, port, token)); }
-                       Some(c) => c.set_token(token), } }
-```
-
-Host and port freeze at first install; a second `install` with a *different* server is silently
-just a token swap. `client()` hands a `&'static Client` to ~30 sites outside `plex/`. **This
-singleton, not the UI, is the feature.**
+**One server, forever — FIXED.** `plex/client.rs` held a `static PLEX: OnceLock<Client>` whose host
+and port froze at the first `install`, so a second `install` naming a *different* server was
+silently just a token swap against the first one's address — a mis-target no call site could see.
+`servers.rs` replaced it with a registry keyed on `machineIdentifier` (§9); `client()` still hands a
+`&'static Client` to ~30 sites outside `plex/` and now means "the current server".
 
 The globals that would collide across two servers — each an equality test or a bare index with no
-server dimension:
+server dimension. **Line numbers are as of 2026-08-11 and have moved; the entries themselves were
+re-verified 2026-08-13 and all but one still hold:**
 
 | site | what collides |
 |---|---|
 | `pms.rs:66-68` `index_of_rk` | `position(\|m\| m.rk == rk)`; callers `app.rs:1664`, `app.rs:2801`, `ui/detail.rs:2754`, `:2761`. A detail page mounts the wrong item |
 | `posters.rs:449-452` | every poster fetched from the singleton's host — and this bypasses `client.rs`, contradicting its own module doc |
-| `posters.rs:124-128` | `KeyMemo` keyed `(path,w,h,png)`: no host, no token; flushed only on a *profile* switch |
+| `posters.rs:124-128` | `KeyMemo` keyed `(path,w,h,png)`: no host, no token. **Half-fixed:** it still carries no host, but token generations are now unique per `Client`, so the memo also flushes when `client()` starts answering with a different server — it used to flush only on a *profile* switch, which would have served server B its cards from A's memoised paths |
 | `metadata.rs:834-843` | `cached_playing(rk)` — server A's track list applied to server B's item |
 | `metadata.rs:1291-1307` | `pump_season`'s `d.rk != r.rk` ownership test |
 | `browse.rs:32-36` | `BrowseSection.key: i64` — **verified collision**: both servers have section `1` |
@@ -193,18 +196,22 @@ is all-or-nothing, so one missing libcurl symbol sets `CURL_OK=false` and kills 
 probe first, and put optional symbols in a **second** `dynlib!` table. And `plex/client.rs` has no
 test module at all, so any step touching `StreamUrl::parse` must bring its own tests.
 
+**Status is in the first cell of each row, and §9 is the account.** A step marked LANDED is done as
+described unless the cell says otherwise; the plan text itself is left as written, because what it
+asked for is how to read what shipped.
+
 | # | Step | Effort | What it buys |
 |---|---|---|---|
-| 0 | **Parse what plex.tv already sends.** Widen `Resource`/`Connection` (`account.rs:145-190`) with `sourceTitle`, `ownerId`, `home`, `presence`, `publicAddressMatches`, `httpsRequired`, `IPv6`; add `includeIPv6=1`; log one line per resource + connection. Selection untouched. **Every new string must be `Option<String>`** — plex.tv sends explicit `null`, serde's `default` does not cover it, and one nullable field fails the whole parse and kills sign-in (`account.rs:209-212` already records this trap). | ½ d | Observation |
-| 1 | **Server registry, one slot.** New `plex/servers.rs`: `ServerId(u16)`, `Server`, `Conn{scheme,…}`, a `CLIENTS` table + `CURRENT`. `install` registers slot 1; `client()`/`client_opt()` keep their signatures and now mean "the current server". `TOKEN_GEN` moves **into** `Client`. Zero call-site changes. Note `client()` is hot — `posters::poster_key` calls it three times per key per tile per frame, so use an atomic-pointer table, not an `RwLock`. | ½–1 d | Foundation |
-| 2 | **Thread `ServerId` through the stored structs** — `PmsMovie`, `BrowseSection`, `Detail`, `PlayingItem`, `Person`, `Pslot`, `trail::Node`, `ResolveEnv`/`Plan`, `UpNext`/`QueueRow`. Every rk equality test becomes a pair. The rule is **capture at the spawn site**, never read the current server inside a worker (`browse.rs:576` says so explicitly; `ResolveEnv` is the template). Behaviour change: none. | 2–3 d | The mechanical diff |
+| 0 **LANDED** | **Parse what plex.tv already sends.** Widen `Resource`/`Connection` (`account.rs:145-190`) with `sourceTitle`, `ownerId`, `home`, `presence`, `publicAddressMatches`, `httpsRequired`, `IPv6`; add `includeIPv6=1`; log one line per resource + connection. Selection untouched. **Every new string must be `Option<String>`** — plex.tv sends explicit `null`, serde's `default` does not cover it, and one nullable field fails the whole parse and kills sign-in (`account.rs:209-212` already records this trap). | ½ d | Observation |
+| 1 **LANDED** | **Server registry** — shipped with N slots rather than the one this row asked for; the ceiling is `MAX_SERVERS = 16`. New `plex/servers.rs`: `ServerId(u16)`, `Server`, `Conn{scheme,…}`, a `CLIENTS` table + `CURRENT`. `install` registers slot 1; `client()`/`client_opt()` keep their signatures and now mean "the current server". `TOKEN_GEN` moves **into** `Client`. Zero call-site changes. Note `client()` is hot — `posters::poster_key` calls it three times per key per tile per frame, so use an atomic-pointer table, not an `RwLock`. | ½–1 d | Foundation |
+| 2 | **Thread `ServerId` through the stored structs** — `PmsMovie`, `BrowseSection`, `Detail`, `PlayingItem`, `Person`, `Pslot`, `trail::Node`, `ResolveEnv`/`Plan`, `UpNext`/`QueueRow`. Every rk equality test becomes a pair. The rule is **capture at the spawn site**, never read the current server inside a worker (`ResolveEnv`'s doc is the template and gives the general form of it; the `browse.rs:576` citation this row gave does not survive — that line has moved and carries no such comment). Behaviour change: none. | 2–3 d | The mechanical diff |
 | 3 | **Move the ~30 call sites onto `client_for(sid)`.** `posters.rs:452` becomes `client_for(slot.sid)?.fetch_built(&key)` — **token-free**, because the poster key already ends in `with_token(…)` and `get_bytes` would append a second one. Ship gate: byte-identical event log across `tests/run.py`. | 1 d | Correctness |
-| 4 | **Probe + race.** New `plex/probe.rs`: drop `local` on `!owned` unless `publicAddressMatches` (§2a); drop http when `httpsRequired`; otherwise synthesize `http://{addr}:{port}` **— this is the step that makes the current share work**; rank local→remote→relay; probe in parallel; **verify `machineIdentifier`**; treat 401 as its own state. `auth.rs:379-418` becomes `ingest()` + `activate_best()`, keeping today's scan as a fallback. Pump it where `pms::pump` lives (route-gated), not beside `route::pump_play`, and call `ui::idle::invalidate()` on any landing that repaints. | 1–1½ d | **The share becomes reachable** |
+| 4 **HALF LANDED — the policy, not the race** | **Probe + race.** New `plex/probe.rs`: drop `local` on `!owned` unless `publicAddressMatches` (§2a); drop http when `httpsRequired`; otherwise synthesize `http://{addr}:{port}` **— this is the step that makes the current share work**; rank local→remote→relay; probe in parallel; **verify `machineIdentifier`**; treat 401 as its own state. `auth.rs:379-418` becomes `ingest()` + `activate_best()`, keeping today's scan as a fallback. Pump it where `pms::pump` lives (route-gated), not beside `route::pump_play`, and call `ui::idle::invalidate()` on any landing that repaints. | 1–1½ d | **The share becomes reachable** |
 | 5 | **Persist the registry; boot from the hint.** `session.rs` gains `servers: Vec<ServerRec>` + `current_machine_id`, every field `#[serde(default)]`, legacy `ServerRef` still written for one release. A corrupt `servers` array must not fail the whole `Session` parse — that is a silent sign-out at every boot. No timestamps: this TV's wall clock is ~3 h skewed. | 1 d | Fast boot |
 | 6 | **TLS control plane.** New `http.rs` façade — `Scheme::Http` → `stream.rs` unchanged, `Scheme::Https` → curl. Generalise `net.rs:131` `perform`: per-call timeout (its `TIMEOUT=25` is right for an API call and fatal for media), `CUSTOMREQUEST` for the PUT verb it has never had, persistent handle **only if** `HTTPHEADER`/`POSTFIELDS`/`POST` are explicitly cleared each call (`auth.rs:285` is a header-less call that would otherwise read freed memory). | 1–1½ d | Any https-only share browses |
 | 7 | **TLS media plane.** Second `dynlib!` table (`curl_multi_*`, all probed PRESENT); `AvioState` gains a source enum; `read_cb`/`seek_cb` dispatch; pump `curl_multi` **from inside `read_cb`** so the demux thread self-polls its abort flag and teardown collapses to "set the flag, join". Preserve the seek abort guard (`ff.rs:1288`) verbatim. The two existing abort-guard tests construct `AvioState` by literal, so this breaks them at compile time — extend them. | 2–4 d | Any share plays |
-| 8 | **N servers live** — the Sources list as a library-toolbar chip with a two-level panel (§6), `sourceTitle` as the row subtitle, attribution in **text not artwork** (a corner badge fails the one-mark-per-tile rule — see §6). Four structural hazards: `install_pms` fetches hubs and sections **blocking on the main thread**, so fanning out over N servers freezes boot; `pms::fetch_build` is an all-or-nothing `?` chain, so one dead share blanks Home; `ensure_sections` early-returns while non-empty, which is the only thing keeping the page mailbox sound; and `install_pms` must split into *identity change* (wipe all) vs *server activation* (wipe nothing). Continue Watching is the one shelf that should merge (by `lastViewedAt`, which `pms.rs:307` already sorts). | 2–4 d | The product |
-| 9 | **Relay policy.** There is no bitrate field to clamp: `TranscodeSpec` has none and `maxVideoBitrate` is a literal on the re-encode branch only. Respecting relay's 2 Mbps means **forcing a transcode decision** in `build_stream` — a policy change, not a parameter. | ½–1 d | Correctness on relay |
+| 8 **STARTED** — the shelf heading can name a source (deliverable C), and `HubRow.source` is `""` at both construction sites, so nothing is reachable until this step populates it | **N servers live** — the Sources list as a library-toolbar chip with a two-level panel (§6), `sourceTitle` as the row subtitle, attribution in **text not artwork** (a corner badge fails the one-mark-per-tile rule — see §6). Four structural hazards: `install_pms` fetches hubs and sections **blocking on the main thread**, so fanning out over N servers freezes boot; `pms::fetch_build` is an all-or-nothing `?` chain, so one dead share blanks Home; `ensure_sections` early-returns while non-empty, which is the only thing keeping the page mailbox sound; and `install_pms` must split into *identity change* (wipe all) vs *server activation* (wipe nothing). Continue Watching is the one shelf that should merge (by `lastViewedAt`, which `pms.rs:307` already sorts). | 2–4 d | The product |
+| 9 **LANDED, UNVERIFIABLE** | **Relay policy.** There is no bitrate field to clamp: `TranscodeSpec` has none and `maxVideoBitrate` is a literal on the re-encode branch only. Respecting relay's 2 Mbps means **forcing a transcode decision** in `build_stream` — a policy change, not a parameter. | ½–1 d | Correctness on relay |
 
 **Shortest path to seeing the share on screen: 0 → 1 → 4**, plus enough of 2/3 to keep the caches
 honest. Steps 6–7 are what make it robust for *any* share rather than this one.
@@ -220,8 +227,15 @@ because `OnceLock` cannot re-point at all.
 ## 6. How it appears in the UI — SUPERSEDED by the design
 
 **The design team answered this brief on 2026-08-13 and changed three of its five deliverables.**
-The canvas (`Shared Sources.dc.html`, project `3ec1f4af…`) is the source of truth; what follows is
-only its shape, so this doc does not point the next implementer the wrong way.
+The canvas (`Shared Sources.dc.html`, project `3ec1f4af…`) is the source of truth — **open it before
+building any of this**; what follows is only its shape, kept here so this doc does not point the
+next implementer the wrong way. Where the two disagree, the canvas wins. In particular the earlier
+draft of this section put the Sources list in the **account popover** and gave the **tab strip** a
+per-source annotation, and both are wrong: it is a library-toolbar chip, and the strip carries
+nothing new at any number of friends.
+
+**Deliverable C is the one with code behind it** (§9): a shelf heading can already name its source,
+and does so as a second text run on the same painter, absent rather than empty when there is none.
 
 **With one source, none of it is drawn** — not a bare suffix, not an empty slot. The Sources row is
 not built, the strip has three pills, the headings carry no annotation.
@@ -273,38 +287,62 @@ from "the unwatched angle", which `23f28ce6` replaced with the white tick over a
    at 31 Mbit/s; TrueHD is not in the direct-play audio set, so this goes down the transcode path
    over a WAN link measured at 38.8 Mbit/s. Expect this, not direct play, to be the common case —
    and it argues for a remote-aware bitrate policy well before relay does (step 9).
-2. **The harness cannot grade any of this yet.** `/tmp/plxnative-token` carries exactly one token,
-   so a second server's `accessToken` cannot be injected headlessly. Steps 4–8 are not gradeable by
-   `tests/run.py` until that overlay grows a second entry.
+2. ~~**The harness cannot grade any of this yet.**~~ **ANSWERED** (§9): `/tmp/plxnative-servers`
+   carries a JSON array of ADDITIONAL servers — host, port, machineIdentifier and the token to trust
+   them with — beside the unchanged `/tmp/plxnative-token`, and `run.py` resolves the second token
+   from `/api/v2/resources` so no new secret is stored. One limitation stands and is not a bug to
+   fix: there is **no managed-user token for someone else's server**, so a case that PLAYS from a
+   share plays as YOU there. `test_user` isolation stops at the account boundary.
 3. **plex.direct DNS from inside the app's jail** (curl uses c-ares; the jail's resolv view differs
    from the ssh shell's). Prove by logging the resolved address on the first remote request.
 4. **TLS on 256 KB stacks, concurrently** — `task::spawn_small`'s stack, with seven worker kinds
    each doing a handshake. Device-verify under a full Home + library scroll.
 5. **Relay end to end** has never been observed by this codebase: `includeRelay=1` has been
-   requested forever and every relay connection unconditionally discarded. The 2 Mbps cap and port
-   8443 are documentation, not measurement.
+   requested forever and every relay connection unconditionally discarded (`auth.rs:396`). The
+   2 Mbps cap and port 8443 are documentation, not measurement. **A policy now exists in code
+   anyway** (`plex::link_policy`, §9) and is unverified for exactly this reason — and it cannot be
+   verified from here even deliberately: **this account's share advertises no relay connection at
+   all** (§2), so there is nothing to dial. Confirming it needs a server that is genuinely
+   relay-only — an owner behind CGNAT, or one who turns their port forward off for an afternoon.
 
-## 8. Doc corrections this work turned up
+## 8. Doc corrections this work turned up — and where they stand
 
-All confirmed in code, all worth fixing at the source so the next reader is not misled:
+All were confirmed in code. **All four are now fixed at the source**, which is the point of listing
+them; they are kept here as a record of what the wrong text was costing, because that is the part a
+re-read cannot recover.
 
-- Root `CLAUDE.md` says `stream.rs` has "no chunked decoding". It has had chunked since
-  `stream.rs:116-147` / `:368-421`.
-- Root `CLAUDE.md` and `player/CLAUDE.md` describe `ff.rs` as "the TV's own libavformat", dlopen'd
-  by SONAME candidate list. FFmpeg is **bundled and pinned** (majors 63/63/61, `-plx` suffix,
-  loaded by absolute path). This is what makes "use FFmpeg's https protocol" a decided question
-  rather than an open one.
-- Root `CLAUDE.md` still claims the dual-FFmpeg-header ABI gate.
-- The host suite is **396** tests as of 2026-08-13 (386 before this note's two units), not the 284 recorded.
-  Re-derive it rather than trusting any number written down: `cargo test --lib -- --list | grep -c ': test'`.
+- Root `CLAUDE.md` said `stream.rs` had "no chunked decoding". It has decoded chunked since
+  `HttpStream`'s `chunked`/`chunk_left` and `hs_next_chunk`. **Fixed.** Left alone it made
+  `stream.rs` read as less capable than it is, and sent work to `net.rs`/curl that the raw socket
+  could already do.
+- Root `CLAUDE.md` and `player/CLAUDE.md` described `ff.rs` as "the TV's own libavformat", dlopen'd
+  by SONAME candidate list. FFmpeg is **bundled and pinned** (majors 63/63/61, `-plx` suffix, opened
+  by absolute path out of `paths::app_dir()`). **Fixed in both** — and on 2026-08-13 also in the
+  **Makefile itself**, whose `LIBS_REAL` comment still filed FFmpeg beside curl and ACB as "SONAME
+  moves, 55→57→58→59→60", a hundred lines above the rules that build and stage the pinned copy. That
+  is the wording that keeps "just use the TV's FFmpeg for https" coming back, when what we ship is
+  configured `--disable-network` and cannot open a URL at all.
+- Root `CLAUDE.md` claimed the dual-FFmpeg-header ABI gate (n3.3 + n4.0, "two ABI tables").
+  **Fixed:** one header tree, one table, and the vendored trees are gone — `vendor/` holds nanosvg
+  and nothing else, so anyone who went looking found nothing and had no way to tell which half of
+  the sentence was wrong.
+- The host suite is **424** tests as of 2026-08-14 — it was recorded as 284, then as 396 in this
+  note's own first draft, which was already stale when it was written. **Do not trust any number in
+  any document, including this one.** Re-derive:
+  `cd rust-modules && cargo +nightly test --lib -- --list | grep -c ': test'`.
 
 ---
 
-## 9. What has landed (2026-08-13)
+## 9. What has landed (2026-08-13 → 2026-08-14)
 
-Two host-testable units, no behaviour change, `make check` at **396 passed**. Neither has a caller
-yet: the live selector at `auth.rs:390-400` still filters on `c.local && !c.relay` on both passes, so
-the 8-second trap of §2(a) is **still live in the running app**. This is foundation, not the feature.
+Seven host-testable units, `make check` at **424 passed** and `make` (ARM) green throughout. **One
+sentence dominates all of it: none of this has a caller in the live sign-in path.**
+`auth::choose_local_connection` still filters `c.local && !c.relay` on both passes, so the 8-second
+trap of §2(a) is **exactly as live in the running app as it was on 2026-08-11**, and the app still
+browses one server. This is foundation plus a policy layer, not the feature — the step that connects
+them is 4's second half, the race and `activate_best`.
+
+**The data layer**
 
 - **`plex/account.rs` — the roster DTOs widened** to `sourceTitle`, `ownerId`, `home`, `presence`,
   `publicAddressMatches`, `httpsRequired` and `Connection.IPv6`, with `includeIPv6=1` on the query.
@@ -313,15 +351,63 @@ the 8-second trap of §2(a) is **still live in the running app**. This is founda
   `de_i64` — because `#[serde(default)]` covers an *absent* field and not a present `null`, and one
   strict field meeting one null fails the whole array and ends sign-in at "no server found".
   `Resource::local_connection()` (dead, zero callers) is deleted; `probe.rs` supersedes it.
+- **`plex/servers.rs` — the registry**, keyed on `machineIdentifier`, replacing the `OnceLock`
+  singleton whose host and port froze at the first `install`. `client()`/`client_opt()` keep their
+  signatures and mean "the current server", so ~30 call sites outside `plex/` read unchanged;
+  `client_for(id)`, `register`, `set_current` and `ServerId` are the additions. Why it is an
+  **atomic-pointer table** rather than a lock, why every slot's `Client` is **leaked**, and why
+  token generations come from a **process-global sequence** are all consequences of one fact —
+  `client()` is a hot path (`posters::poster_key` calls it three times per key, per visible tile,
+  per frame) — and the full account now lives where implementers will meet it, in
+  **`rust-modules/src/plex/CLAUDE.md`**.
 - **`plex/probe.rs` — the connection policy, pure.** No socket, no thread, no clock, so all of it is
   host-testable on Darwin. Builds and ranks candidate origins: drops a `local` connection on a
   non-owned server unless `publicAddressMatches`, suppresses every plain-http candidate when the
   owner set `httpsRequired`, and ranks local → remote → relay. It also carries, as doc, the two rules
   a real prober must honour and this module cannot: verify `machineIdentifier` on the response before
   accepting a connection, and treat `401` as its own state rather than "unreachable".
+- **The relay policy — `plex::link_policy`, plus `Client::set_link`/`link()` to carry the fact.**
+  A relay is a ~2 Mbit/s tunnel, so a plan that ships the file's own bytes over one stalls mid-film
+  with nothing on any surface saying why. The policy denies **direct play and the container remux**,
+  leaving the re-encode — the only flavor whose query lets the server pick a rate. Denying the
+  remux is the half that is easy to miss: it copies the codecs and deliberately sends no cap, so it
+  is the same 31 Mbit/s one layer down. It is a **branch, never a parameter** — `TranscodeSpec` has
+  no bitrate field, a cap is meaningless on direct play, and the server is the only party that knows
+  the tunnel's real ceiling. `route::build_stream` consults it beside the codec gates.
+  **Unverified against a real relay, and not verifiable from this account** — see §7 question 5;
+  what is asserted is the shape, not the 2 Mbps.
 
-Two of the tests are worth knowing about, because both were written after a mutation showed the
-suite could not see the bug:
+- **The sign-in chooser keeps to IPv4** (`auth::choose_local_connection`, extracted from
+  `discover_and_store` so the rule is gradeable at all). This one is a REGRESSION THIS WORK CAUSED
+  and did not notice for three commits: adding `includeIPv6=1` to the roster query means plex.tv now
+  offers v6 connections, and the live chooser takes the FIRST `local` match and **persists** it —
+  so a server listing its LAN v6 ahead of its v4 would have signed in "successfully" to an empty
+  Home and written that address into the session file, making every later boot start there too.
+  `stream.rs::http_open` parses a dotted quad by hand (`AF_INET`, no DNS), so a v6 literal is not
+  slower, it is undialable. Found by review, not by the suite; the suite can see it now.
+
+**The screens and the harness**
+
+- **A shelf heading can name its source** (deliverable C): `Recently Added in LDN Films · bamx23`,
+  a second run on the same painter so the annotation cannot detach from the title under the shelf's
+  lift or snap fade, and **absent rather than empty** when there is no source — no gap, no dot, no
+  draw call, which is what makes it free for the single-server install. `HubRow.source` is `""` at
+  both construction sites, so nothing new is reachable until step 8 populates it. One visible change
+  rode along: shelf headings moved from `TEXT_PRIMARY` to the shared `TEXT_HEADING` ink.
+- **A failed browse page is a STATE** (`SecFetch { Loading, Ready, Failed }`), found while mapping
+  this work but a bug on the user's OWN server: a failed first page armed the retry cooldown and
+  nothing else, so `total` stayed `-1`, `loading_initial()` was `total < 0`, and the grid spun for
+  the rest of the session with nothing on screen admitting it. An EMPTY answer is `Ready`, never
+  `Failed`. A failed *sections* list still spins, one layer up in `ensure_sections`, and belongs
+  with deliverable D.
+- **The harness can hand the TV a second server** — `/tmp/plxnative-servers`, a JSON array of
+  additional servers beside the unchanged token file, deliberately **not** DIAG-exempt (it must
+  suppress the who's-watching picker like the token file, or a headless run grades the wrong
+  screen). Its own connection ranking does **not** copy the app's sign-in rule, for the reason §2(a)
+  gives: public wins for a non-owned server, dotted quads beat hostnames, relay last.
+
+Three tests are worth knowing about, because each was written after a mutation showed the suite
+could not see the bug:
 
 - The owned-server fixture carries **`publicAddressMatches: false`** — the value the live capture
   actually returns. With `true` there, deleting `&& !res.owned` from the drop rule passed the entire
@@ -329,7 +415,12 @@ suite could not see the bug:
 - An explicit `null` on every string and on `connections` itself is asserted to cost that field and
   never the roster — the second server in that fixture is a good one, and the test is really about
   it still arriving.
+- The relay policy is graded from **both ends**: the pure answer per tier, and a server whose only
+  advertised address is a relay, run through `probe::candidates` so that the ranking and the policy
+  are pinned to the same `Location` vocabulary. An unknown link is asserted to restrict **nothing** —
+  that is the case every play takes today, so a wrong answer there would be wrong for everybody.
 
-**Next**, in order: the server registry behind an unchanged `client()` (step 1), then threading
-`ServerId` through the stored structs (step 2). Nothing in the design's canvas can be drawn until
-those exist — the app can hold exactly one server (`plex/client.rs:149`).
+**Next**, in order: threading `ServerId` through the stored structs (step 2, the mechanical diff),
+then the probe RACE and `activate_best` (step 4's second half), which is the first change any of
+this will let a user see. Until then the registry holds one server because nobody registers a
+second one.

--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -373,6 +373,43 @@ fn poll_for_token(ac: &AccountClient, id: i64, expires_in: i64) -> Option<String
     None
 }
 
+/// An OWNED server's `local` connection, else any server's — the live sign-in rule, pulled out of
+/// [`discover_and_store`] so it can be graded on the host. `plex::probe` is the richer version of
+/// this and supersedes it at step 4 of `docs/shared-servers.md`; until something calls that, THIS
+/// is what every sign-in runs, so its two limits are the app's limits.
+///
+/// **A dialable address here means an IPv4 LITERAL on our own LAN**, and both halves are transport
+/// facts rather than preferences:
+///
+/// * `stream.rs::http_open` parses the host as a dotted quad by hand (`AF_INET`, no DNS), so a v6
+///   literal is not slower — it cannot be dialled at all. Since the roster query started sending
+///   `includeIPv6=1`, plex.tv will happily offer one, and this chooser takes the FIRST match and
+///   PERSISTS it: without the guard, a server advertising its LAN v6 ahead of its v4 signs in
+///   "successfully" to an empty Home *and* writes that address to the session file, so every later
+///   boot starts there too. `probe.rs` ranks v6 last for the same reason.
+/// * `local` is required because a remote address needs DNS/TLS this socket does not have. Note
+///   what §2(a) of the shared-servers note proves about that flag on a SHARED server: it means
+///   "RFC1918", not "your LAN", so this rule reaching a share would pick the owner's `172.20.x.x`
+///   and hang for 8 s. That is the trap `probe.rs` exists to close, and it is still open here.
+fn choose_local_connection(
+    resources: &[crate::plex::account::Resource],
+) -> Option<(&crate::plex::account::Resource, &crate::plex::account::Connection)> {
+    let find = |owned_only: bool| {
+        resources
+            .iter()
+            .filter(|r| r.is_server() && (!owned_only || r.owned))
+            .find_map(|r| {
+                r.connections
+                    .iter()
+                    .find(|c| {
+                        c.local && !c.relay && !c.address.is_empty() && !c.ipv6 && !c.address.contains(':')
+                    })
+                    .map(|c| (r, c))
+            })
+    };
+    find(true).or_else(|| find(false))
+}
+
 /// Pick an OWNED server with a `local` connection (offline-capable, numeric address the plain-HTTP
 /// PMS socket can reach), else any server with one, and store it in the working session. A
 /// remote-only server is unusable here — the PMS socket does no DNS/TLS — so we require a local one.
@@ -386,18 +423,7 @@ fn discover_and_store(ac: &AccountClient) -> bool {
     };
     let servers = resources.iter().filter(|r| r.is_server()).count();
     log(&format!("auth: resources n={} servers={}", resources.len(), servers));
-    let find = |owned_only: bool| {
-        resources
-            .iter()
-            .filter(|r| r.is_server() && (!owned_only || r.owned))
-            .find_map(|r| {
-                r.connections
-                    .iter()
-                    .find(|c| c.local && !c.relay && !c.address.is_empty())
-                    .map(|c| (r, c))
-            })
-    };
-    let (r, conn) = match find(true).or_else(|| find(false)) {
+    let (r, conn) = match choose_local_connection(&resources) {
         Some(x) => x,
         None => {
             log("auth: no server with a local connection (remote-only can't be reached)");
@@ -518,4 +544,61 @@ fn set_error(msg: &str) {
         c.error = msg.to_owned();
         c.phase = Phase::Error;
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plex::account::Resource;
+
+    fn roster(json: &str) -> Vec<Resource> {
+        serde_json::from_str(json).expect("fixture parses")
+    }
+
+    /// The address this picks is PERSISTED, so picking an undialable one is not a slow sign-in — it
+    /// is a permanently empty Home, on every boot after it too. `stream.rs` speaks IPv4 literals
+    /// only, and the roster query asks plex.tv for `includeIPv6=1`, so a server listing its LAN v6
+    /// FIRST is the shape that breaks: this chooser takes the first match. It must step past the v6
+    /// to the v4 behind it.
+    #[test]
+    fn a_lan_ipv6_is_stepped_over_for_the_ipv4_behind_it() {
+        let rs = roster(
+            r#"[{"name":"mine","clientIdentifier":"aaaa1111","provides":"server","owned":true,
+                 "connections":[
+                   {"address":"2001:db8::1","port":32400,"local":true,"relay":false,"IPv6":true},
+                   {"address":"192.168.0.10","port":32400,"local":true,"relay":false,"IPv6":false}]}]"#,
+        );
+        let (_, c) = super::choose_local_connection(&rs).expect("a dialable connection");
+        assert_eq!(c.address, "192.168.0.10", "the v6 literal cannot be dialled by stream.rs at all");
+
+        // …and a v6 whose flag is absent is caught by the address itself. The roster flags are
+        // null-tolerant now, so `IPv6:false` on a colon-bearing address must not be believed.
+        let rs = roster(
+            r#"[{"name":"mine","clientIdentifier":"aaaa1111","provides":"server","owned":true,
+                 "connections":[{"address":"fd00::5","port":32400,"local":true,"relay":false,"IPv6":false}]}]"#,
+        );
+        assert!(super::choose_local_connection(&rs).is_none(), "nothing dialable is None, not a v6");
+    }
+
+    /// The two passes, unchanged by the guard above: an owned server wins even when a shared one is
+    /// listed first and looks perfectly good, and a relay is never a "local" connection. (What this
+    /// rule still gets wrong on a SHARE — `local` meaning RFC1918 rather than "your LAN", §2(a) of
+    /// `docs/shared-servers.md` — is `probe.rs`'s job and is not asserted here, because nothing
+    /// calls probe yet and this is a pin of the LIVE behaviour.)
+    #[test]
+    fn an_owned_server_outranks_a_shared_one_and_a_relay_is_never_chosen() {
+        let rs = roster(
+            r#"[{"name":"theirs","clientIdentifier":"bbbb2222","provides":"server","owned":false,
+                 "connections":[{"address":"172.20.4.7","port":32400,"local":true,"relay":false,"IPv6":false}]},
+                {"name":"mine","clientIdentifier":"aaaa1111","provides":"server","owned":true,
+                 "connections":[{"address":"192.168.0.10","port":32400,"local":true,"relay":false,"IPv6":false}]}]"#,
+        );
+        let (r, c) = super::choose_local_connection(&rs).expect("the owned server");
+        assert_eq!((r.name.as_str(), c.address.as_str()), ("mine", "192.168.0.10"));
+
+        let rs = roster(
+            r#"[{"name":"relayed","clientIdentifier":"cccc3333","provides":"server","owned":true,
+                 "connections":[{"address":"10.0.0.9","port":8443,"local":true,"relay":true,"IPv6":false}]}]"#,
+        );
+        assert!(super::choose_local_connection(&rs).is_none(), "a relay is not a local connection");
+    }
 }

--- a/rust-modules/src/plex/CLAUDE.md
+++ b/rust-modules/src/plex/CLAUDE.md
@@ -1,7 +1,9 @@
 # plex/ — the Plex data layer (typed PMS + plex.tv client)
 
 This is the **typed Plex client**: account/login (`account.rs`, `session.rs`), the HTTP client
-(`client.rs`), library/hubs/metadata reads (`library.rs`/`hubs.rs`/`models.rs`), and the whole
+(`client.rs` — one server) and the registry that holds them (`servers.rs` — WHICH servers exist and
+which is current, with `probe.rs` deciding which of a server's addresses is worth dialling),
+library/hubs/metadata reads (`library.rs`/`hubs.rs`/`models.rs`), and the whole
 playback protocol — the MDE/transcode decision + capability profile (`transcoder.rs`), the
 timeline/PlayQueue/identity session ops (`timeline.rs`), stream selection + the direct-play
 target (`library.rs`), with typed request params in `params.rs`. **Every PMS query in the app
@@ -18,7 +20,89 @@ container/codec path. Every "just transcode it" shortcut pushes work onto the se
 quality — reach for it only when direct-play genuinely can't work. See `[[server-hevc-encode-gating]]`
 and the `soft-subs` note below for why "direct-play everything" keeps paying off.
 
+## More than one server: the registry (`servers.rs`)
+
+**A friend's shared server is not a second address, it is a second AUTHORITY** — its own
+`machineIdentifier`, its own per-(user, server) `accessToken`, its own `ratingKey` space and its own
+watch state. Measured live against a real share (`docs/shared-servers.md` §2): our own server's
+token gets a **401** from it, and its section key `1` is a different library from our section key
+`1`. So this layer is keyed on servers, not on one host and port.
+
+`client()` and `client_opt()` still mean what they always did, they just mean **the CURRENT
+server** now — which is why nothing outside `plex/` changed when the `OnceLock<Client>` singleton
+became a table. `client_for(id)` is the multi-server addition; `register(machine_id, host, port,
+token)` puts a server in the table; `install(host, port, token)` is the SESSION path (boot, QR
+login, profile switch) and always retargets. Slots are keyed on `machineIdentifier` because that is
+the only identity that survives a server changing address — and a `register` that has *learned* an
+id **adopts** an address-only slot instead of adding a second one for the same machine.
+
+Three design choices carry the weight, and each is a prevented bug rather than a preference:
+
+- **An atomic-pointer table, not an `RwLock`.** `client()` is a HOT path: `posters::poster_key`
+  calls it **three times per key, for every visible art tile, every frame** (~25–40 tiles × 60 fps).
+  A read is one relaxed load, one acquire load, a deref — no lock, no refcount, no allocation. An
+  `RwLock` would add an atomic RMW pair per call plus a fairness stall every time a login writes,
+  and an `Arc` would change every call site's type to buy a refcount bump per tile per frame.
+- **Each slot's `Client` is LEAKED, deliberately.** That is what makes handing out `&'static
+  Client` sound without an `Arc`: the reference a worker took at frame N must still be valid when a
+  re-point lands at frame N+1 with that worker mid-request. Re-pointing publishes a NEW leaked
+  `Client` over the pointer, so the worst case for the old reference is **one request sent to where
+  that server used to be** — never a dangling pointer, which is the failure that has no debugger on
+  this device. The leak is bounded: a handful of small structs, written on login / profile switch /
+  server switch, never per frame.
+- **Token generations come from a process-global sequence, so no two clients ever share one.**
+  `token_gen` was a single process-wide counter, which cannot express "server B's token changed".
+  Its only reader is `posters::poster_key`'s memo and that memo compares **one number** — so two
+  servers whose generations happened to agree would mean that the moment `client()` started
+  answering with B, the memo said nothing had changed and served B its cards from **A's memoised,
+  token-bearing paths**. Uniqueness makes "did this number move" also answer "is this even the same
+  server".
+
+## Granted, pinned, reachable — three states, and never the same question
+
+The whole shared-source feature rests on keeping these apart:
+
+- **granted** — plex.tv's answer. `/api/v2/resources` says this account may use this server and
+  hands over the `accessToken` that proves it. Not a setting of ours; it is the owner's decision.
+- **pinned** — the only thing the USER controls, and it governs **Home only**. Tabs, the browse
+  grid, sort, the A–Z rail and every other browsing surface come from the grant; pinning decides
+  whether a source's shelves merge into Home.
+- **reachable** — a fact about NOW: something answered at one of its addresses, *as the right
+  machine*. It changes while nobody touches anything, and it is never a reason to forget the grant
+  or the pin.
+
+Collapsing any two of them produces a specific wrong behaviour rather than a vague one. A `401` read
+as "unreachable" sends the user to look at their friend's router when the fix is to refetch
+`/resources` (every other address of that server will answer identically). An unreachable server
+read as un-granted drops the source out of the Sources list, so there is nothing left to retry.
+A pinned-but-dead source drawn as a shelf is a spinner that never ends — the design's answer is that
+a dead source is **absent** from Home and states itself in its own library section instead.
+
 ## Gotchas that bite (all verified in code)
+
+- **`Connection.local` does not mean what it looks like, and the cost is 8 seconds.** It means "this
+  address is RFC1918", NOT "you are on that LAN" — a share advertises the *owner's* `172.20.x.x`.
+  `publicAddressMatches` is the field that means the latter. `probe.rs` drops a `local` connection
+  on a non-owned server unless that flag is set, because dialling it costs an 8 s timeout — and the
+  worse outcome is that it SUCCEEDS, against a different machine of ours at that address. That is
+  also why a probe must **verify `machineIdentifier` on the response** before accepting a
+  connection, and why `probe.rs` is pure (no socket, no clock): the rules are then gradeable on the
+  dev Mac, which is the only tier that can grade them at all.
+- **A capped link is answered by the transcode FLAVOR, never by a bitrate parameter.** Plex's relay
+  is a ~2 Mbit/s tunnel, so `transcoder::link_policy` denies direct play *and* the container remux
+  over one — the remux is the half that is easy to miss, since it copies the codecs and deliberately
+  sends no cap, i.e. the same bytes at the same rate one layer down. `TranscodeSpec` has no bitrate
+  field and must not grow one. **No relay connection has ever been observed by this codebase**, so
+  that policy is reasoned, not measured; read its doc before touching it.
+- **Capture the server at the SPAWN SITE**, the rule the multi-server work inherits from
+  `route::ResolveEnv` — whose doc says why in general: a worker reads no `static mut`, because the
+  main thread reassigns those under it. "Which server is current" is exactly such a value, and a
+  worker that asks *after* the user switched lands an answer belonging to the other machine's
+  `ratingKey` space. Pass a `ServerId` (or the `&'static Client`) in with the job. One narrow
+  exception exists today and is worth knowing rather than copying: `build_stream` reads
+  `client_opt()` on the resolve worker. That is sound — the registry read is atomic and its clients
+  are never freed — but it means "the current server", not "the server this play started from", and
+  it is the line to change when a play can begin on a server that is not current.
 
 - **Content negotiation: send `Accept: application/json` explicitly.** PMS returns **XML** for
   `Accept: */*` (or no Accept), and only JSON for an explicit `application/json`. A request that

--- a/rust-modules/src/plex/client.rs
+++ b/rust-modules/src/plex/client.rs
@@ -15,8 +15,9 @@
 //! Client` is handed out live next door in [`super::servers`] — this file is the type, that
 //! file is the table.
 use super::models::{Envelope, MediaContainer};
+use super::probe::Location;
 use super::servers::ServerId;
-use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering::Relaxed};
 use std::sync::RwLock;
 
 const ACCEPT_JSON: &str = "Accept: application/json\r\n";
@@ -67,6 +68,20 @@ pub struct Client {
     // share a value: a cache that only compares "did this number move" therefore also flushes
     // when `client()` starts answering with a different server.
     token_gen: AtomicU32,
+    /// HOW this server is reached — the tier of the connection that won the probe, or "nobody has
+    /// said yet" ([`LINK_UNKNOWN`]). A property of the SERVER, not of the request, which is why it
+    /// lives beside its address rather than being recomputed at a call site.
+    ///
+    /// It exists because one tier changes what playback may ask for: Plex's relay is a capped
+    /// tunnel, so a plan that streams the file's own bytes over it stalls. The policy that reads
+    /// this is [`super::transcoder::link_policy`] — this field is only the fact.
+    ///
+    /// Interior-mutable and lock-free: written once per activation (a cold path), read once per
+    /// playback resolve on a WORKER thread. `Relaxed` is enough because the value stands alone —
+    /// nothing else is published with it, and a resolve that raced an activation by a microsecond
+    /// would have read the old value a microsecond earlier anyway. A re-point does not carry it
+    /// over: a new address is a new tier, and whoever re-points is the one who knows it.
+    link: AtomicU8,
 }
 
 /// The source of every [`Client::token_gen`] value, process-wide. Only the UNIQUENESS matters
@@ -74,6 +89,31 @@ pub struct Client {
 static GEN_SEQ: AtomicU32 = AtomicU32::new(1);
 fn next_gen() -> u32 {
     GEN_SEQ.fetch_add(1, Relaxed)
+}
+
+/// [`Client::link`] before anything has told us how this server is reached — the state every
+/// client is in today, since nothing dials from a [`Location`] yet. Distinct from every real tier
+/// on purpose: "unknown" is not "local", and the policy treats the two differently.
+const LINK_UNKNOWN: u8 = 0;
+
+/// `Location` ⇄ `u8`, so the tier fits in an atomic. Written as two total matches rather than a
+/// cast: `Location`'s declaration ORDER is its preference order (`probe`'s derived `Ord` is the
+/// ranking), so a discriminant cast would silently tie the stored encoding to that ordering and
+/// break the moment a tier is inserted in the middle.
+fn link_code(l: Location) -> u8 {
+    match l {
+        Location::Local => 1,
+        Location::Remote => 2,
+        Location::Relay => 3,
+    }
+}
+fn link_of_code(c: u8) -> Option<Location> {
+    match c {
+        1 => Some(Location::Local),
+        2 => Some(Location::Remote),
+        3 => Some(Location::Relay),
+        _ => None,
+    }
 }
 
 /// The device facts of the playback identity. Shared with the plex.tv transport — see
@@ -103,6 +143,7 @@ impl Client {
             version: super::identity::VERSION.into(),
             platform: super::identity::PLATFORM.into(),
             token_gen: AtomicU32::new(next_gen()),
+            link: AtomicU8::new(LINK_UNKNOWN),
         }
     }
 
@@ -150,6 +191,27 @@ impl Client {
     /// The server's `machineIdentifier`, `""` if it has not been learned yet.
     pub fn machine_id(&self) -> &str {
         &self.machine_id
+    }
+    /// Record which tier of connection reached this server — for the code that ACTIVATES a
+    /// candidate (`probe::candidates` ranks them; racing and dialling them lands with the
+    /// transport work). Call it once the probe has answered and the address is the one in use;
+    /// until someone does, [`Client::link`] is `None` and playback policy is unrestricted.
+    ///
+    /// **ORDER MATTERS: register the address FIRST, then set the link on the client you get back**
+    /// (`let id = register(mid, host, port, tok); client_for(id).unwrap().set_link(l);`). A
+    /// `register` whose address differs RE-POINTS the slot — it publishes a fresh `Client`, which
+    /// starts at `LINK_UNKNOWN` — so a tier set before that call is simply gone, and the policy
+    /// silently reverts to unrestricted. That reset is deliberate rather than a wart: an address
+    /// change is exactly the event that can turn a LAN connection into a relay, so the old tier is
+    /// not evidence about the new one.
+    pub fn set_link(&self, l: Location) {
+        self.link.store(link_code(l), Relaxed);
+    }
+    /// How this server is reached, `None` while nothing has said. Feed it to
+    /// [`super::transcoder::link_policy`] rather than matching on it at a call site — a relay is
+    /// not the only fact a tier could ever carry, and the policy is the one place that decides.
+    pub fn link(&self) -> Option<Location> {
+        link_of_code(self.link.load(Relaxed))
     }
 
     // ---- transport choke points: the only code that touches crate::stream ----
@@ -323,6 +385,22 @@ mod tests {
             .contains("X-Plex-Client-Identifier=cid-42"));
         // a client built outside the registry says so rather than claiming slot 0
         assert!(!Client::new(ServerId::UNSET, "", "1.2.3.4", 32400, "t", "cid").id().is_set());
+    }
+
+    /// A fresh client knows nothing about how it is reached, and says so rather than guessing a
+    /// tier. That default is load-bearing: `transcoder::link_policy` reads `None` as "no
+    /// restriction", so every client built before an activation path exists plays exactly as it
+    /// did — and a client that IS told it is on a relay carries that fact to the resolve worker
+    /// without the worker having to ask a global which server is current.
+    #[test]
+    fn a_client_starts_with_no_known_link_and_remembers_the_one_it_is_told() {
+        let c = a_client("mach-A", "tok-a");
+        assert_eq!(c.link(), None, "nothing has probed anything yet");
+
+        for l in [Location::Local, Location::Remote, Location::Relay] {
+            c.set_link(l);
+            assert_eq!(c.link(), Some(l), "the tier must round trip through the atomic");
+        }
     }
 
     /// The token generation is per-CLIENT (it was a process-global `TOKEN_GEN`). Two properties

--- a/rust-modules/src/plex/mod.rs
+++ b/rust-modules/src/plex/mod.rs
@@ -71,5 +71,8 @@ pub use params::*;
 pub use timeline::{queue_index_of, QueueRow};
 // DP_AUDIO_CODECS rides along for `devcaps`, which intersects it with the device's own codec
 // table — the caps snapshot is what `is_dp_audio` and the profile string then both read.
+// `link_policy` is the other gate on the same decision: `is_dp_audio` asks what the PIPELINE can
+// decode, `link_policy` asks what the CONNECTION can carry, and `route::build_stream` must pass
+// both before it streams a file itself.
 #[allow(unused_imports)]
-pub use transcoder::{is_dp_audio, DP_AUDIO_CODECS};
+pub use transcoder::{is_dp_audio, link_policy, LinkPolicy, DP_AUDIO_CODECS};

--- a/rust-modules/src/plex/params.rs
+++ b/rust-modules/src/plex/params.rs
@@ -9,6 +9,16 @@
 /// `route::universal_base`: the CURRENT audio/subtitle selection rides every transcode of the
 /// item, and `session` is the per-playback id shared with the timeline
 /// (`X-Plex-Session-Identifier == session=`, byte-for-byte, so /status/sessions correlates).
+///
+/// **There is no bitrate field here, and a capped link is not answered by adding one.** The only
+/// bitrate literal in the whole spec is `maxVideoBitrate`, on the RE-ENCODE branch of
+/// `transcoder::transcode_query`; the [`remux`](Self::remux) branch deliberately sends no cap at
+/// all, because a resolution or bitrate cap is precisely what makes PMS re-encode instead of copy.
+/// And on the third path — direct play, this client's default and its whole point — a cap means
+/// nothing, since no encoder is running to obey it. So a link with a ceiling (Plex's 2 Mbit/s
+/// relay) is answered by choosing the FLAVOR — deny direct play, deny the remux, let the server
+/// pick a rate on the branch that has one — never by asking for a number:
+/// `transcoder::link_policy` is that decision, with the reasoning and the honesty note.
 pub struct TranscodeSpec<'a> {
     pub rating_key: &'a str,
     /// The per-playback opaque session id (`route::sess()`).

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -15,6 +15,7 @@
 use super::client::{Client, QueryBuilder, StreamUrl};
 use super::models::MediaContainer;
 use super::params::TranscodeSpec;
+use super::probe::Location;
 
 /// The AUDIO codec set the buffer-feed PIPELINE decodes. This is the software half of a
 /// two-sided test — what our demuxer/payload path can feed, before asking whether this
@@ -26,6 +27,76 @@ use super::params::TranscodeSpec;
 pub const DP_AUDIO_CODECS: &str = "aac,ac3,eac3";
 pub fn is_dp_audio(codec: &str) -> bool {
     crate::devcaps::caps().audio_has(codec)
+}
+
+// ---- the relay policy: what the LINK to a server allows a plan to ask for -------------------
+
+/// What the connection tier a server is reached over lets a playback plan ask for. Both fields
+/// are true on every tier but [`Location::Relay`] — see [`link_policy`], which is where the
+/// reasoning lives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LinkPolicy {
+    /// May the client stream the source file itself? False forces the transcode branch.
+    pub direct_play: bool,
+    /// May that transcode be a container-only REMUX — codecs copied, no cap? False forces the
+    /// RE-ENCODE flavor, the only one whose query carries a bound the server can come in under.
+    pub remux: bool,
+}
+
+impl LinkPolicy {
+    /// Everything allowed: every tier but relay, and every link nothing has told us about.
+    ///
+    /// **Unknown must be permissive, and that is a decision rather than a default.** Nothing in
+    /// this app dials from a [`Location`] yet — `probe::candidates` ranks addresses and the racing
+    /// lands with the transport work — so `Client::link()` is `None` on every play today. Reading
+    /// `None` as "assume relay" would downgrade every direct play on earth to a server-side
+    /// encode, to prevent a stall on a connection this codebase has never once made.
+    pub const UNRESTRICTED: LinkPolicy = LinkPolicy { direct_play: true, remux: true };
+}
+
+/// **The relay policy**, and the only place it is spelled out. `None` = nobody has said how this
+/// server is reached (see [`LinkPolicy::UNRESTRICTED`]).
+///
+/// Plex's relay is a tunnel the server holds open to a Plex relay host: a second https connection,
+/// conventionally port 8443, **capped at 2 Mbit/s**, with the server transcoding down to fit
+/// whatever the client asks for. [`probe`](super::probe) ranks it last, so it only ever wins when
+/// there is nothing else — a share behind CGNAT, an owner with no port forward. When it does win,
+/// the two fast paths this client is built around become the wrong answer, and both have to go:
+///
+/// * **No direct play.** Direct play streams the file's own bytes, and a library's own bytes are
+///   tens of Mbit/s (the share measured on 2026-08-11: 31 Mbit/s — `docs/shared-servers.md` §2)
+///   down a 2 Mbit/s pipe. The server cannot rescue it, because nothing is being transcoded and
+///   so there is nothing for it to fit; the cap arrives as a stall two minutes into the film,
+///   with the AU queue draining and no error on any surface. Forcing the transcode branch turns
+///   that into a `/decision` the server answers with something that fits.
+/// * **No container REMUX either** — the half that is easy to miss, because a remux *feels* like
+///   a concession already. It is not: a remux copies the codecs and deliberately sends **no
+///   cap** (`transcode_query` below omits `videoResolution`/`maxVideoBitrate` on that branch,
+///   because a cap is exactly what would force the re-encode it is trying to avoid). So it ships
+///   the same bytes at the same rate one layer down, and stalls identically. Denying it leaves
+///   the re-encode, which is the only flavor whose whole point is that the server picks the rate.
+///
+/// **Not a parameter, deliberately.** [`TranscodeSpec`] has no bitrate field and this does not add
+/// one. A cap is meaningless on direct play — no encoder is running to obey it — and on the
+/// re-encode branch the server already receives an upper bound it is free to come in far under.
+/// The relay's real ceiling is known to the server, which is on the other end of the tunnel and
+/// applies it; the policy's whole job is to stop asking for the two flavors that leave it no way
+/// to.
+///
+/// **No relay connection has ever been observed by this codebase.** `includeRelay=1` has been on
+/// the `/resources` query since the first login and every relay connection was then discarded
+/// unconditionally (`auth::choose_local_connection` filters `c.local && !c.relay`), so nothing here
+/// has ever dialled one. The 2 Mbit/s figure and the port-8443 convention are Plex's documentation, not our
+/// measurement, and this policy is **unverified against a real relay** — `docs/shared-servers.md`
+/// §7 question 5. What is asserted is the shape, not the number: whatever the ceiling turns out to
+/// be, only the server can apply it, and only if an encoder runs.
+pub fn link_policy(link: Option<Location>) -> LinkPolicy {
+    match link {
+        Some(Location::Relay) => LinkPolicy { direct_play: false, remux: false },
+        // Exhaustive on purpose: a new tier must come here and say what it allows, rather than
+        // inheriting "unrestricted" from a wildcard because nobody thought about it.
+        Some(Location::Local) | Some(Location::Remote) | None => LinkPolicy::UNRESTRICTED,
+    }
 }
 
 /// Capability profile (X-Plex-Client-Profile-Extra, raw form — the QueryBuilder encodes it),
@@ -211,7 +282,57 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use super::{link_policy, Location, LinkPolicy};
     use crate::devcaps::Caps;
+
+    // ---- the relay policy ---------------------------------------------------------------
+
+    /// Relay denies BOTH flavors that put the file's own bytes on the wire. Direct play is the
+    /// obvious one; the remux is the one a "force a transcode" instinct leaves behind, and it is
+    /// no better — it copies the codecs and its query carries no cap by design, so it is the same
+    /// 31 Mbit/s down the same 2 Mbit/s tunnel. What survives is the re-encode, where the server
+    /// is the one choosing the rate.
+    #[test]
+    fn a_relay_link_forbids_both_flavors_that_ship_the_file_at_its_own_rate() {
+        let p = link_policy(Some(Location::Relay));
+        assert!(!p.direct_play, "a relay cannot carry the source file");
+        assert!(!p.remux, "a remux is the same bytes at the same rate, one layer down");
+    }
+
+    /// Every other tier — and a link nobody has described — must change nothing at all. This is
+    /// the assertion that keeps the policy free for the single-server LAN install: `Client::link`
+    /// is `None` on every play today, so a wrong answer here would be a wrong answer for
+    /// everybody, on a code path they all take.
+    #[test]
+    fn every_other_tier_and_an_unknown_link_leave_playback_alone() {
+        for l in [Some(Location::Local), Some(Location::Remote), None] {
+            assert_eq!(link_policy(l), LinkPolicy::UNRESTRICTED, "link {l:?} must restrict nothing");
+        }
+    }
+
+    /// The policy's input is the tier of the connection that WON, so grade it from the other end:
+    /// a server whose only advertised address is a relay (a share behind CGNAT — the case relay
+    /// exists for) can be reached one way, and that way forces the transcode branch. This pins
+    /// the join between `probe`'s ranking and this policy: they must speak the same `Location`,
+    /// and the last-ranked tier must be the restricted one.
+    #[test]
+    fn a_server_reachable_only_by_relay_forces_the_transcode_branch() {
+        let res: super::super::account::Resource = serde_json::from_str(
+            r#"{"name":"cgnat-share","clientIdentifier":"cccc3333","provides":"server","owned":false,
+                "connections":[{"protocol":"https","address":"plex-relay.example.net","port":8443,
+                 "uri":"https://plex-relay.example.net:8443","local":false,"relay":true}]}"#,
+        )
+        .expect("fixture parses");
+
+        let cs = super::super::probe::candidates(&res);
+        assert_eq!(cs.len(), 1, "a relay gets no plain-http twin: {cs:#?}");
+        assert_eq!(cs[0].location, Location::Relay);
+
+        let p = link_policy(Some(cs[0].location));
+        assert_eq!(p, LinkPolicy { direct_play: false, remux: false });
+    }
+
+    // ---- the capability profile ----------------------------------------------------------
 
     /// Split a codec list out of the given profile segment ("add-direct-play-profile…" or
     /// "add-transcode-target…") — shared by every derivation test below.

--- a/rust-modules/src/route.rs
+++ b/rust-modules/src/route.rs
@@ -748,7 +748,15 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     // (step 7) gets an owned copy instead, and never touches the `&'static` store.
     let tracks = plan.playing.as_ref().map(|p| p.audio.as_slice()).unwrap_or(&[]);
     let audio_sel = if rk.is_empty() { None } else { pick_dp_audio(tracks, acodec) };
-    let directplay = if !video_dp {
+    // What the CONNECTION to this server allows, beside what the pipeline can decode: a Plex
+    // relay is a ~2 Mbit/s tunnel, so neither of the two flavors that ship the file's own bytes
+    // (direct play, and the uncapped container remux) can be asked for over one. Unrestricted on
+    // every other tier and on a server whose link nobody has recorded, which is all of them today.
+    // The reasoning, and what is measured versus documented, is at `plex::link_policy`.
+    let link = crate::plex::link_policy(client.link());
+    let directplay = if !link.direct_play {
+        false
+    } else if !video_dp {
         // The buffer-feed pipeline only decodes what the Load payload declares — H264/H265,
         // and H265 only on a SoC whose table lists the decoder (devcaps). Anything else
         // (AV1/VP9/MPEG-2/…) MUST transcode: we can't feed it even if the server's /decision
@@ -814,7 +822,11 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
     // profile_for). The guess below is only the /decision-unreachable fallback: decision_codecs
     // overrides it with the server's ACTUAL output, but the guess still tracks devcaps because
     // a payload naming hevc on a SoC without the decoder configures a pipeline that cannot start.
-    if video_dp {
+    // A direct-playable source means "ask Plex to REMUX" — unless the link forbids a copy, in
+    // which case this is a re-encode after all and every line below must agree (the payload guess,
+    // the stored flavor a seek rebuilds from, and the /decision query itself).
+    let remux = video_dp && link.remux;
+    if remux {
         let achosen = audio_sel.as_ref().map(|(_, c, _)| c.clone()).unwrap_or_else(|| acodec.to_string());
         plan.vcodec = vcodec.to_string();
         plan.acodec = achosen;
@@ -831,9 +843,9 @@ fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env: &ResolveE
         plan.audio_sid = *asid;
     }
     // keep the flavor so a later seek rebuilds the same query for start.mkv?...&offset=T
-    plan.remux = video_dp;
+    plan.remux = remux;
     put_selection(plan.part_id, env.audio_sid, env.sub_sid); // audio/subtitle selection drives the encode/remux + burn
-    let sp = transcode_spec(rk, &session, video_dp, -1, env.audio_sid, env.sub_sid);
+    let sp = transcode_spec(rk, &session, remux, -1, env.audio_sid, env.sub_sid);
     if let Some(mc) = client.transcode_decision(&sp) {
         // The server has already answered, and it is allowed to answer NO. Stop here rather than
         // stream a `start.mkv` it has just said it cannot produce: the plan leaves with no URL —


### PR DESCRIPTION
The last unit of the shared-servers feature: the **relay bandwidth policy**, and the documentation the rest of the feature reads.

## The policy

Plex's relay is the only connection with a ceiling — a tunnel to a Plex relay host, conventionally `:8443`, capped at 2 Mbps with the server transcoding down to fit. `probe.rs` already ranks it last; what was missing was what playback should do when it wins.

It is a **branch, not a parameter**, because there is no parameter to reach for: `TranscodeSpec` has no bitrate field, `maxVideoBitrate` is a literal on the re-encode branch alone, and on direct play a cap means nothing since no encoder is running to obey it. So `plex::link_policy` denies two things over a relay:

* **direct play** — 31 Mbit/s (the measured share) down a 2 Mbit/s pipe arrives as a stall two minutes in, with nothing on any surface saying why;
* **the container remux** — the half that is easy to miss. It copies the codecs and deliberately sends *no cap*, because a cap is what would force the re-encode it is avoiding. Same bytes, same rate, one layer down.

What survives is the re-encode, the only flavor whose point is that the **server** picks the rate — and the server, on the far end of the tunnel, is the only party that knows the real ceiling.

The tier is now a property of the server (`Client::set_link`/`link()`, lock-free, `LINK_UNKNOWN` until told). `route::build_stream` reads it off the client it already holds — no new global for the resolve worker — and one derived `remux` local keeps the payload guess, the stored flavor a seek rebuilds from, and the `/decision` query in agreement. **route.rs touch: 3 behavioural lines** (`directplay` gate, `let remux = video_dp && link.remux`, and the three `video_dp`→`remux` uses that follow).

**Nothing calls `set_link` yet**, so `link()` is `None` everywhere and the policy is `UNRESTRICTED`: byte-identical behaviour today. "Unknown" is deliberately permissive — assuming relay would downgrade every direct play on earth to a server-side encode to prevent a stall on a connection this codebase has never made.

### Honesty

**No relay connection has ever been observed by this codebase.** `includeRelay=1` has been requested since the first login and every relay connection then discarded unconditionally. The 2 Mbps and the `:8443` are Plex's documentation, not measurement — and this account's share advertises **no relay at all**, so the policy is not merely untested but untestable from here. Said at the policy itself, and in §7 of the design note.

## A regression this work caused, found by review

`includeIPv6=1` on the roster query means plex.tv now offers v6 connections, and the live sign-in chooser takes the **first** `local` match and **persists** it. `stream.rs` parses a dotted quad by hand (`AF_INET`, no DNS), so a v6 literal is undialable: a server listing its LAN v6 first would have signed in "successfully" to an empty Home *and* written that address into the session file, breaking every later boot too. Chooser extracted as `auth::choose_local_connection` (it was not gradeable at all before), guarded on the flag *and* a colon in the address, with the two tests that would have caught it.

## Docs

* **`plex/CLAUDE.md`** gains the registry section it never had — why atomic pointers (`client()` is called three times per key, per visible tile, per frame), why each `Client` is leaked (a re-point costs a worker one request to a stale address, never a dangling pointer), why token generations are globally unique (the poster memo compares one number), plus **granted / pinned / reachable** and what collapsing any two of them causes.
* **`Makefile`** — the surviving half of the self-contradiction: it justified not linking FFmpeg by "SONAMEs move, 55→57→58→59→60", a hundred lines above the rules that build and stage a *pinned* copy. The real reason is different in kind (staged beside the binary, no search path, no rpath — a `DT_NEEDED` would resolve at `exec()` to nothing or to the *television's* FFmpeg). The root `CLAUDE.md` had already been corrected at `97cac1b9`; this was the last place carrying the old model, which is how "just use the TV's FFmpeg for https" keeps coming back.
* **`docs/shared-servers.md`** — §3 separates fixed from still-live (the 8-second trap is exactly as live as it was), §5 marks each step's status, §6 defers to `Shared Sources.dc.html` and names the two things its own earlier draft got wrong (Sources is a library-toolbar chip, the tab strip carries nothing), §7 retires the harness question, §8 shows all four corrections landed, §9 covers all seven units. Measured-facts sections untouched.

## Verification

`make check` **424 passed** ×3 (418 at base) + lint; `make` (ARM) green. **No device run, deliberately:** the documentation half cannot be observed on a television, and the relay half cannot be reached — this account's share advertises no relay connection, so there is nothing to exercise. The TV lock was not taken.

## Findings for other units (from the review, not fixed here)

* `probe.rs:202` — the rank key has no dotted-quad-over-hostname tiebreak, so on the module's own fixture the unresolvable hostname sorts *ahead* of the address measured working. The module doc says the stable order "is not ours to reorder", so this is the probe owner's call; `tests/run.py::pick_connection` already implements the tiebreak.
* `plex/serverinfo.rs:102` (and the same comment at `app.rs:501`) — its correctness argument is "host/port fix at the first install", which the registry deletes; `refresh()`'s single-flight can now let an in-flight fetch for A answer for B.
* `tests/run.py:1660` — the FPS path drops `_skipped`, so scenes skipped for a missing second server vanish from the output and the run exits naming the wrong cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxZ585ehWMnuScciTQ9WgV
