### PR TITLE
home: the hero says whose film it is, and opens on one of yours

### DIFF
--- a/rust-modules/src/pms.rs
+++ b/rust-modules/src/pms.rs
@@ -202,16 +202,63 @@ fn hubs() -> &'static Vec<HubRow> {
 
 // ---- rotating hero pool: curated catalog indices (Continue Watching then Recently Added) ----
 const HERO_MAX: usize = 8;
-static mut HERO_POOL: Vec<usize> = Vec::new();
+
+/// One page of the rotating billboard: a catalog index, plus the handle of the SERVER the shelf it
+/// was drawn from came from ("bamx23") — empty for the signed-in user's own, exactly as
+/// [`HubRow::source`] means it.
+///
+/// The handle is carried on the SLOT rather than looked up from the item's shelf at draw time, and
+/// that is the point of the type existing at all: the pool is the one place in the app that lifts
+/// items OUT of their shelf order ([`own_items_first`] promotes an owned page to the front), so a
+/// pool entry that only knew its catalog index would have to find its way back to a hub through a
+/// range scan to answer "whose is this" — for a fact the build already had in its hand.
+struct HeroSlot {
+    idx: usize,
+    source: String,
+}
+static mut HERO_POOL: Vec<HeroSlot> = Vec::new();
+
+fn pool() -> &'static Vec<HeroSlot> {
+    unsafe { &*std::ptr::addr_of!(HERO_POOL) }
+}
 
 /// number of items in the rotating hero pool
 pub(crate) fn hero_pool_len() -> usize {
-    unsafe { std::ptr::addr_of!(HERO_POOL).as_ref().map(|v| v.len()).unwrap_or(0) }
+    pool().len()
 }
 /// hero-pool item `i`, or None
 pub(crate) fn hero_pool_item(i: usize) -> Option<&'static PmsMovie> {
-    let idx = unsafe { std::ptr::addr_of!(HERO_POOL).as_ref() }.and_then(|v| v.get(i)).copied()?;
-    movie(idx)
+    movie(pool().get(i)?.idx)
+}
+/// Handle of the server hero-pool page `i` came from ("bamx23"), or **empty** for the signed-in
+/// user's own — see [`HeroSlot`]. The hero's meta line draws no run at all for the empty case
+/// (`ui::home::meta_source_flow`), so a single-server library pays nothing for this. Borrowed on the
+/// same terms as [`hub_title`]: main-thread only, valid until the next hub commit.
+pub(crate) fn hero_pool_source(i: usize) -> &'static str {
+    pool().get(i).map(|s| s.source.as_str()).unwrap_or("")
+}
+
+/// **Own items first — an ORDERING, not a filter** (Shared Sources, deliverable C).
+///
+/// A borrowed item may not hold the FIRST rotation while the owner contributes at least one, so the
+/// app's front door opens on your own library and a friend's film arrives one 8-second flip in,
+/// attributed. Everything else about the pool is untouched: it stays merged, in the order the
+/// shelves produced it, and the promoted page is lifted out and re-inserted rather than sorted, so
+/// `[B1, B2, O1, O2, B3]` becomes `[O1, B1, B2, O2, B3]` — one page moves, nothing is dropped and
+/// nothing else is reordered.
+///
+/// Filtering instead would leave a borrowed-only account with **no hero at all**, and would overrule
+/// a pin the user made; that is why a pool with nothing of our own in it is left exactly as it is and
+/// opens on a borrowed page. This is also why the rule needs no switch of its own: the pool is built
+/// from included sources only, so a borrowed hero is always the consequence of a pin.
+fn own_items_first(pool: &mut Vec<HeroSlot>) {
+    if pool.first().map(|s| s.source.is_empty()).unwrap_or(true) {
+        return; // nothing pooled, or one of ours already opens the door
+    }
+    if let Some(k) = pool.iter().position(|s| s.source.is_empty()) {
+        let own = pool.remove(k);
+        pool.insert(0, own);
+    }
 }
 
 /// number of home hubs
@@ -281,7 +328,7 @@ pub(crate) fn pms_fetch_hubs() -> c_int {
 
 /// The catalog/hubs/pool triple a fetch produces, before it is committed. Owned data only, so
 /// the off-thread refetch can build it on a worker and hand it over through a mailbox.
-type HubBuild = (Vec<PmsMovie>, Vec<HubRow>, Vec<usize>);
+type HubBuild = (Vec<PmsMovie>, Vec<HubRow>, Vec<HeroSlot>);
 
 /// GET /hubs and project it — the whole fetch, minus the commit. `None` = the request failed
 /// (transport, HTTP, or parse), which is NOT the same as a server with no hubs (`Some` with an
@@ -302,7 +349,7 @@ fn fetch_build() -> Option<HubBuild> {
 fn build_hubs(mc: &crate::plex::MediaContainer, cw: &crate::plex::MediaContainer) -> HubBuild {
     let mut new_cat: Vec<PmsMovie> = Vec::new();
     let mut new_hubs: Vec<HubRow> = Vec::new();
-    let mut new_pool: Vec<usize> = Vec::new();
+    let mut new_pool: Vec<HeroSlot> = Vec::new();
     const SKIP: [&str; 6] = ["album", "artist", "track", "photo", "clip", "playlist"];
 
     // Build the display shelves as ordered lists of item refs.
@@ -390,12 +437,15 @@ fn build_hubs(mc: &crate::plex::MediaContainer, cw: &crate::plex::MediaContainer
             if m.art.is_empty() || m.kind == 2 {
                 continue; // need landscape art; skip seasons
             }
-            if new_pool.iter().any(|&j| new_cat[j].rk == m.rk) {
+            if new_pool.iter().any(|s| new_cat[s.idx].rk == m.rk) {
                 continue; // dedup by ratingKey
             }
-            new_pool.push(idx);
+            new_pool.push(HeroSlot { idx, source: hub.source.clone() });
         }
     }
+    // …and only now is the order decided: the pool is assembled shelf by shelf, so which server
+    // opens the door is not knowable until every shelf has contributed.
+    own_items_first(&mut new_pool);
     (new_cat, new_hubs, new_pool)
 }
 
@@ -728,6 +778,71 @@ mod tests {
         assert_eq!(hub_len(0), 2, "the stale build must not replace the current catalog");
         assert_eq!(hub_state(), HubState::Ready, "nor be counted as a failure of the current one");
         reset();
+    }
+
+    // ---- own-items-first: which server opens the front door (Shared Sources, deliverable C) ----
+    //
+    // Pure list arithmetic over `HeroSlot`, so these touch no static and take no lock. The pool is
+    // spelled as a source string per page — "" is ours, anything else a friend's handle — which is
+    // exactly what `build_hubs` hands `own_items_first` after every shelf has contributed.
+
+    /// A pool from a source-per-page spelling, and the spelling back out of one.
+    fn pool_of(sources: &[&str]) -> Vec<HeroSlot> {
+        sources.iter().enumerate().map(|(i, s)| HeroSlot { idx: i, source: s.to_string() }).collect()
+    }
+    fn sources_of(pool: &[HeroSlot]) -> Vec<&str> {
+        pool.iter().map(|s| s.source.as_str()).collect()
+    }
+
+    /// **The rule.** A borrowed film may not be the first thing the app shows while the owner has
+    /// contributed one — the door opens on your own library and a friend's arrives one flip in.
+    /// And it is an ORDERING: the pool stays merged, exactly one page moves, and everything else
+    /// keeps the order the shelves produced it in (a sort would have swept every borrowed page to
+    /// the tail, which is a filter wearing an ordering's clothes).
+    #[test]
+    fn a_borrowed_page_never_opens_the_door_while_we_have_one_of_our_own() {
+        let mut p = pool_of(&["bamx23", "bamx23", "", "", "ldn"]);
+        own_items_first(&mut p);
+        assert_eq!(sources_of(&p), ["", "bamx23", "bamx23", "", "ldn"], "one page is promoted, nothing else moves");
+        assert_eq!(p.iter().map(|s| s.idx).collect::<Vec<_>>(), [2, 0, 1, 3, 4], "every page survives — this is not a filter");
+    }
+
+    /// Already ours at the front: the rule must be a no-op, not a re-shuffle that happens to look
+    /// the same. (It is also the ONE-SERVER case, where the whole feature must be invisible: every
+    /// page's source is empty, so the first page is ours and nothing is touched.)
+    #[test]
+    fn a_pool_that_already_opens_on_one_of_ours_is_left_exactly_alone() {
+        for spelling in [vec!["", "", ""], vec!["", "bamx23", ""], vec!["", "bamx23"]] {
+            let mut p = pool_of(&spelling);
+            own_items_first(&mut p);
+            assert_eq!(sources_of(&p), spelling, "an already-owned first page must not reorder the pool");
+        }
+    }
+
+    /// A borrowed-ONLY account keeps its borrowed hero, first rotation and all. Filtering instead
+    /// would leave the front door with no billboard at all — and would overrule a pin the user
+    /// made, which is the whole reason this is an ordering.
+    #[test]
+    fn a_borrowed_only_account_still_gets_a_hero_and_it_holds_the_first_rotation() {
+        let mut p = pool_of(&["bamx23", "ldn", "bamx23"]);
+        own_items_first(&mut p);
+        assert_eq!(sources_of(&p), ["bamx23", "ldn", "bamx23"], "nothing of ours to promote — leave the pool as it is");
+        assert_eq!(p.len(), 3, "and above all: do not empty the billboard");
+    }
+
+    /// The degenerate ends, because this runs on every commit: an empty pool must not index into
+    /// nothing, and a single borrowed page must survive (it is the borrowed-only account's whole
+    /// billboard).
+    #[test]
+    fn the_ordering_holds_at_the_empty_and_single_page_ends() {
+        let mut empty: Vec<HeroSlot> = Vec::new();
+        own_items_first(&mut empty);
+        assert!(empty.is_empty());
+        for one in [vec![""], vec!["bamx23"]] {
+            let mut p = pool_of(&one);
+            own_items_first(&mut p);
+            assert_eq!(sources_of(&p), one);
+        }
     }
 
     /// `reset` is the profile-switch wipe: the previous user's shelves must not survive it, and

--- a/rust-modules/src/ui/home.rs
+++ b/rust-modules/src/ui/home.rs
@@ -9,6 +9,7 @@ use crate::ui::consts::*;
 use crate::ui::icons::Icon;
 use crate::ui::card_row::{self, CardRow, RowStyle};
 use crate::ui::hero_logo::{self, HeroLogo, LogoRung};
+use crate::ui::label::{Label, VAlign};
 use crate::ui::text_view::TextView;
 use crate::ui::theme;
 use crate::ui::widgets::{AmbientWash, Art, Button, CircleButton, PageDots, HERO_BASE_SCRIM_Y0};
@@ -264,6 +265,56 @@ fn hero_item_at(i: c_int) -> Option<&'static PmsMovie> {
         return None;
     }
     crate::pms::hero_pool_item(i as usize)
+}
+
+/// Whose server hero page `i` came from, as the owner's handle — **empty for our own**, which is
+/// every page on a single-server install. [`hero_item_at`]'s twin, and it has to be one: the
+/// billboard is nobody's focused tile, so the shelf heading below it is describing something else
+/// entirely and the run on the meta line is the only thing on the screen that says whose the film is.
+fn hero_source_at(i: c_int) -> &'static str {
+    or_dev_source(if i < 0 { "" } else { crate::pms::hero_pool_source(i as usize) })
+}
+
+/// Whose server the CURRENT hero came from — [`hero_item`]'s twin, and it follows that function's
+/// empty-pool fallback rather than reporting "ours" for it: with nothing pooled the hero is the
+/// first card of the first shelf, so its source is that shelf's.
+fn hero_source() -> &'static str {
+    if crate::pms::hero_pool_len() == 0 {
+        return or_dev_source(crate::pms::hub_source(0));
+    }
+    hero_source_at(hero_index() as c_int)
+}
+
+/// The real answer, or [`dev_source`]'s stand-in when there is none. **Both hero source accessors
+/// go through it**, and that is the point: a flip draws the outgoing page through `hero_source_at`
+/// and the incoming one through `hero_source`, so a stand-in applied to only one of them would pop
+/// the run into existence halfway through the slide — at exactly the moment the trigger exists to
+/// let someone judge it.
+fn or_dev_source(real: &'static str) -> &'static str {
+    if real.is_empty() {
+        dev_source()
+    } else {
+        real
+    }
+}
+
+/// `/tmp/plxnative-shared=<handle>` — the SAME trigger the detail page's own source run reads, and
+/// deliberately not a second one: it stamps one handle onto every item a session loads, which is
+/// what a fully-borrowed library looks like, and one file arming both surfaces is the only way to
+/// see them agree. An empty file means no handle, exactly as it does there.
+///
+/// It stands in ONLY where the real answer is empty, so it can never contradict a source the data
+/// layer actually has, and it is read once: the trigger surface is boot state, and a per-frame
+/// `stat` inside the hero's draw is not.
+///
+/// It is needed because this unit's whole visible half is unreachable in the product today — every
+/// `HubRow::source` is `""` until the multi-server layer lands — and the two things the design
+/// states about this run are things only a panel can settle: that it sits inside the corner wedge,
+/// and that it ends well short of the last fifth of the frame. Compiled out with the `devtriggers`
+/// feature, like every other trigger (`crate::dev`).
+fn dev_source() -> &'static str {
+    static SEEN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    SEEN.get_or_init(|| crate::dev::read("shared").unwrap_or_default())
 }
 
 /// Hero action-row focus: -1 = the profile chip, 0 = Play/Continue pill, 1 = info, 2 = chevron.
@@ -695,6 +746,108 @@ pub(crate) fn hero_stack_top(title_h: f32, meta_h: f32, syn_h: f32) -> f32 {
     HERO_TEXT_BOTTOM - (title_h + theme::space::MD + meta_h + syn_h)
 }
 
+/// **The hero meta line's right bound**, and the only width budget this line has ever had — three
+/// fifths of the frame.
+///
+/// The line is bottom-left copy over a full-bleed photograph, so it is legible only inside the
+/// corner wedge, which is gone by `widgets::HERO_SCRIM_W` (four fifths, 1536) and leaves the last
+/// fifth of the picture completely alone. Ending the line at three fifths keeps a whole fifth of the
+/// panel between it and that edge — "well short of the last fifth", the design's own words — so the
+/// run always sits where the wedge is still carrying weight, and never wanders into the side of the
+/// frame the composition is usually about.
+///
+/// It bounds the SOURCE run only. The line's own facts keep wrapping to [`HERO_COL_W`] exactly as
+/// they always have, which is what makes the annotation free for a single-server install and is why
+/// the handle is what truncates when the two together are too long: the run is the last thing on the
+/// line and a fact about where the item came from, so it is the right thing to lose first — and
+/// losing it is a truncation, never a second line. The hero column is a FOUR-line composition
+/// (title band, this line, three of synopsis) anchored on [`HERO_TEXT_BOTTOM`]; a fifth line would
+/// push the pinned action row into the peeking shelf.
+const HERO_META_R: f32 = 0.60 * SCR_W; // 1152
+/// [`HERO_META_R`] in the meta flow's own coordinates, whose origin is the text column's left edge.
+const META_FLOW_W: f32 = HERO_META_R - MARGIN_X;
+
+/// The words the run is made of. "Shared by bamx23" — the PERSON, not the machine: the same handle
+/// the shelf headings carry, never a server's own name.
+fn shared_by(source: &str) -> String {
+    format!("Shared by {source}")
+}
+
+/// The hero meta line's SOURCE annotation, flowed onto the end of a line whose own facts have
+/// already been laid out to `base_w`: `· Shared by bamx23`, after a middot at `TEXT_SEPARATOR`'s
+/// .45, both runs on the line's own **BODY** rung and one step of ink under it.
+///
+/// **With no source there is no flow at all** — no pad, no dot, no run, no draw call, and the meta
+/// line is left byte for byte the one it has always been. That is the design's "with one source,
+/// none of this is drawn" as absence rather than as a branch that draws nothing visible.
+///
+/// The rung is the part that does NOT travel from the detail page's version of this run. There it is
+/// `CAPTION`, because that line sits under a page of copy; here it is `BODY`, because this line is
+/// read from across the room. A rung is a role — what transfers is the step of INK
+/// (`TEXT_SECONDARY` → `TEXT_TERTIARY`), which is what makes the annotation quieter than the facts
+/// it joins on every screen that carries it.
+///
+/// `run(text, dx, budget, sz, bold, ink) -> advance` is the seam, as in [`heading_flow`]: the draw
+/// passes a closure that elides to `budget` and paints, the host tests pass one that measures. So
+/// the drawn flow and the graded one are one expression. Each run's `budget` is the distance from
+/// where it starts to [`META_FLOW_W`], which is what makes the line TRUNCATE instead of ever
+/// becoming two: there is no wrap in this flow to reach, only a right bound to elide against.
+/// Returns the whole line's advance, source run included.
+fn meta_source_flow(base_w: f32, source: &str, mut run: impl FnMut(&str, f32, f32, c_int, c_int, [f32; 4]) -> f32) -> f32 {
+    if source.is_empty() {
+        return base_w; // one source: the meta line is the item's facts and nothing else
+    }
+    let mut dx = base_w + SOURCE_PAD;
+    dx += run("\u{b7}", dx, META_FLOW_W - dx, theme::size::BODY, 0, theme::TEXT_SEPARATOR);
+    dx += SOURCE_PAD;
+    dx += run(&shared_by(source), dx, META_FLOW_W - dx, theme::size::BODY, 0, theme::TEXT_TERTIARY);
+    dx
+}
+
+/// Draw [`meta_source_flow`] with its runs' cap tops on `y` — the meta line's own, since every run
+/// shares that line's rung and weight and therefore its cap band. `base_w` is how wide the facts
+/// ahead of it actually drew ([`meta_drawn_w`]); the runs ride the painter handed in, so the hero's
+/// slide carries the annotation with the line it belongs to.
+fn draw_meta_source(p: Painter, source: &str, x: f32, y: f32, base_w: f32) {
+    meta_source_flow(base_w, source, |s, dx, budget, sz, bold, ink| {
+        // the CString must outlive the draw call, not the closure (`ui/CLAUDE.md`'s first gotcha)
+        match CString::new(crate::text::elide(s, budget, sz, bold, false)) {
+            Ok(cs) => {
+                let mut lab = Label::new(cs.as_ptr(), sz, ink).v(VAlign::CapTop);
+                if bold == 1 {
+                    lab = lab.bold();
+                }
+                lab.draw(p, Rect::new(x + dx, y, budget, 0.0))
+            }
+            Err(_) => 0.0,
+        }
+    });
+}
+
+/// How wide the meta line's own facts DREW, so the source run can be flowed onto their end rather
+/// than onto a guess. The line is a one-line [`TextView`], whose wrap rebuilds it as its words
+/// joined by single spaces — which is the string itself, since every separator on it is authored as
+/// one space — so a line that fits measures exactly. A line that did NOT fit was ellipsized to fill
+/// the column, and reports the column: the run then starts at the column's edge, one pad past the
+/// ellipsis. `truncates` shares the draw's memoized wrap, so asking costs nothing.
+///
+/// The clamp is not belt-and-braces. `truncates` answers "were WORDS left unplaced", and a single
+/// token too wide for the column leaves none — `TextView` ellipsizes that case in its own safety
+/// pass instead, so the measured string can be wider than anything that was drawn. Unclamped, the
+/// run would then start in mid-air past the ellipsis, and a truly absurd one could hand the flow a
+/// negative budget, which `text::elide` reads as "no bound at all" and would paint straight past
+/// the frame.
+fn meta_drawn_w(tv: &TextView<'_>, meta: &str, col_w: f32) -> f32 {
+    if tv.truncates(col_w) {
+        return col_w;
+    }
+    CString::new(meta)
+        .ok()
+        .map(|c| crate::text::text_width(c.as_ptr(), theme::size::BODY, 0))
+        .unwrap_or(0.0)
+        .min(col_w)
+}
+
 /// One hero item's sliding content column: title band (clearLogo or text) → small meta/kicker →
 /// synopsis. For an EPISODE the show is the star: the show's clearLogo/title in the title band and
 /// a "S1 E4 · Episode title" kicker — the episode's own name never headlines. The column is
@@ -704,12 +857,21 @@ pub(crate) fn hero_stack_top(title_h: f32, meta_h: f32, syn_h: f32) -> f32 {
 /// `theme::space` rung and every step advances by the *measured* height of the element just drawn —
 /// except the title band, whose height is the RESERVED `hero_logo::band_h` rather than the drawn
 /// logo's, so the stack cannot lurch the moment a texture lands (see `ui::hero_logo`).
-fn hero_content(hero: &PmsMovie, p: Painter, dx: f32) {
+///
+/// `source` is whose server this item came from, empty for our own ([`hero_source_at`]). It rides
+/// the meta line as that line's LAST run and changes nothing else about the column — including its
+/// height, which is measured from the facts alone: the annotation is bounded to one line by
+/// construction ([`meta_source_flow`]), so it can never reflow the stack it sits in.
+fn hero_content(hero: &PmsMovie, source: &str, p: Painter, dx: f32) {
     let tx = MARGIN_X;
     let col_w = HERO_COL_W;
     // a column the slide has carried off the panel costs a full text layout + glyph draws for
-    // nothing (same rule as the backdrop layer's cull)
-    if !on_axis(tx + dx, col_w, SCR_W, 0.0) {
+    // nothing (same rule as the backdrop layer's cull). The box is the column's — EXCEPT when a
+    // source run is on the meta line, which is the one thing here that draws outside the column
+    // (out to [`META_FLOW_W`]): culled on the column's width, a slide would take the whole block
+    // away while ~400px of that line was still on the panel, and the tail of the meta line would
+    // blink out ahead of the item it belongs to.
+    if !on_axis(tx + dx, if source.is_empty() { col_w } else { META_FLOW_W }, SCR_W, 0.0) {
         return;
     }
     let d_a = theme::TEXT_SECONDARY;
@@ -758,6 +920,7 @@ fn hero_content(hero: &PmsMovie, p: Painter, dx: f32) {
     HeroLogo::new(hero_logo_rk(hero), title, LogoRung::Hero).draw(p, Rect::new(tx, y, col_w, title_h));
     y += title_h + theme::space::MD;
     meta_tv.draw(p, Rect::new(tx, y, col_w, 0.0));
+    draw_meta_source(p, source, tx, y, meta_drawn_w(&meta_tv, &meta, col_w));
     y += meta_h;
     if let Some(tv) = syn {
         tv.draw(p, Rect::new(tx, y + theme::space::SM, col_w, 0.0));
@@ -816,14 +979,14 @@ impl View for Hero {
         if let Some((prev, dx_out, dx_in)) = hero_slide_state() {
             if let Some(ph) = hero_item_at(prev) {
                 let po = p.translate(dx_out, 0.0);
-                hero_content(ph, po, dx_out);
+                hero_content(ph, hero_source_at(prev), po, dx_out);
                 hero_actions(ph, env, po, dx_out, false);
             }
             let pi = p.translate(dx_in, 0.0);
-            hero_content(hero, pi, dx_in);
+            hero_content(hero, hero_source(), pi, dx_in);
             hero_actions(hero, env, pi, dx_in, true);
         } else {
-            hero_content(hero, p, 0.0);
+            hero_content(hero, hero_source(), p, 0.0);
             hero_actions(hero, env, p, 0.0, true);
         }
 
@@ -956,8 +1119,11 @@ impl View for Grid {
     }
 }
 
-/// Pad either side of the shelf heading's `·`, on the shared gap scale — the same "hairline gap
-/// between two things that belong to one line" rung `detail::dotted_run` spends on its own dots.
+/// Pad either side of the `·` that introduces a SOURCE annotation, on the shared gap scale — the
+/// same "hairline gap between two things that belong to one line" rung `detail::dotted_run` spends
+/// on its own dots. One value, because this screen states a source in two places — the shelf
+/// heading ([`heading_flow`]) and the hero's meta line ([`meta_source_flow`]) — and they are one
+/// annotation in two positions, not two spacings.
 const SOURCE_PAD: f32 = theme::space::XS;
 
 /// The shelf heading, flowed left→right from the heading origin: the hub's title, and — only when
@@ -2005,5 +2171,137 @@ mod tests {
             "the dot and the handle are one annotation: same rung, same weight, so they drop onto the title's baseline together"
         );
         assert!(runs[1].sz < runs[0].sz, "the annotation is a rung DOWN from the title — the drop is why it must be baseline-aligned");
+    }
+
+    // ---- the HERO's own source run (Shared Sources, deliverable C) ----------------------------
+    //
+    // The hero is not the focused tile of the shelf beneath it — it is an independent rotating
+    // billboard — so the heading below it attributes something else and this run is the only thing
+    // on the screen that says whose the film is. Same synthetic metric as the heading tests above,
+    // and the same reason for it. Pure: no focus state, no `FOCUS` mutex.
+
+    /// One meta run, plus the BUDGET it was given — which is the half the heading flow has no
+    /// equivalent of, and the half the truncation rule lives in.
+    struct MetaRun {
+        text: String,
+        dx: f32,
+        budget: f32,
+        sz: c_int,
+        bold: c_int,
+        ink: [f32; 4],
+    }
+
+    /// Drive [`meta_source_flow`] with the synthetic metric, eliding to the budget the way
+    /// `draw_meta_source`'s closure does (`text::elide` never returns a run wider than its budget).
+    /// Returns the whole line's advance + every run the flow asked for.
+    fn meta_flow(base_w: f32, source: &str) -> (f32, Vec<MetaRun>) {
+        let mut runs: Vec<MetaRun> = Vec::new();
+        let w = meta_source_flow(base_w, source, |s, dx, budget, sz, bold, ink| {
+            runs.push(MetaRun { text: s.to_string(), dx, budget, sz, bold, ink });
+            width_of(s, sz, bold).min(budget.max(0.0))
+        });
+        (w, runs)
+    }
+
+    /// **The one-source acceptance criterion.** With no source the hero meta line is exactly the
+    /// line it has always been: the flow asks for nothing, adds nothing to its advance, and issues
+    /// no draw call. Absence, not an empty annotation — which is what makes the run free for the
+    /// installs that will never see one.
+    #[test]
+    fn a_hero_from_our_own_server_draws_no_source_run_at_all() {
+        let (w, runs) = meta_flow(420.0, "");
+        assert!(runs.is_empty(), "an empty source must produce no runs, no pad and no dot");
+        assert_eq!(w, 420.0, "…and must not move the line's own end by a pixel");
+    }
+
+    /// A borrowed hero states whose it is, as the LAST run on its own meta line — after a middot,
+    /// one pad either side, in the design's own words ("the person, not the machine").
+    #[test]
+    fn a_borrowed_hero_states_its_owner_as_the_last_run_on_the_line() {
+        let base = 420.0;
+        let (w, runs) = meta_flow(base, "bamx23");
+        assert_eq!(runs.len(), 2, "the separator and the run, and nothing else");
+        assert_eq!(runs[0].text, "\u{b7}");
+        assert_eq!(runs[0].dx, base + SOURCE_PAD, "the dot is one pad past the facts");
+        assert_eq!(runs[1].text, "Shared by bamx23", "the person, not the machine");
+        assert_eq!(
+            runs[1].dx,
+            runs[0].dx + width_of("\u{b7}", theme::size::BODY, 0) + SOURCE_PAD,
+            "the run is one pad past the dot"
+        );
+        assert_eq!(
+            w,
+            base + 2.0 * SOURCE_PAD
+                + width_of("\u{b7}", theme::size::BODY, 0)
+                + width_of("Shared by bamx23", theme::size::BODY, 0),
+            "the line grows by exactly the dot, the run and one pad either side of the dot"
+        );
+    }
+
+    /// **The rung stays, the ink steps down.** The run keeps the line's own `BODY` — it is read
+    /// from across the room — and takes one step of ink, `TEXT_SECONDARY` → `TEXT_TERTIARY`. It is
+    /// deliberately NOT the detail page's `CAPTION`, which is that line's own rung and not a
+    /// property of the run: a rung is a role, and only the ink step travels between the two screens.
+    #[test]
+    fn the_hero_source_run_keeps_the_lines_rung_and_takes_one_step_of_ink() {
+        let (_, runs) = meta_flow(420.0, "bamx23");
+        for r in &runs {
+            assert_eq!((r.sz, r.bold), (theme::size::BODY, 0), "'{}' left the meta line's own rung", r.text);
+            assert_ne!(r.sz, theme::size::CAPTION, "the hero line is BODY — it is not E's line and must not shrink to it");
+        }
+        assert_eq!(runs[0].ink, theme::TEXT_SEPARATOR, "the middot carries the separator token's own .45");
+        assert_eq!(runs[1].ink, theme::TEXT_TERTIARY, "one step under the line's TEXT_SECONDARY, never level with it");
+        assert_ne!(runs[1].ink, theme::TEXT_SECONDARY);
+    }
+
+    /// **The measurement rule: the line never becomes two.** Every run is handed a finite budget
+    /// running to [`HERO_META_R`], so an over-long handle ELIDES where a wrapped block would have
+    /// spilled onto a second line — and the whole line still ends at the bound. The worst case is a
+    /// meta line whose own facts already filled the hero column: even then the run must have real
+    /// room, or the annotation would arrive as a bare ellipsis.
+    #[test]
+    fn an_over_long_handle_truncates_rather_than_wrapping() {
+        let ridiculous = "a-very-long-plex-account-handle-that-nobody-would-ever-choose";
+        for base in [0.0f32, 420.0, HERO_COL_W] {
+            let (w, runs) = meta_flow(base, ridiculous);
+            assert_eq!(runs.len(), 2, "base {base}: a long handle is still ONE run — there is no second line to go to");
+            for r in &runs {
+                assert!(r.budget > 0.0, "base {base}: '{}' was given no room at all ({})", r.text, r.budget);
+                assert!(r.dx + r.budget <= META_FLOW_W + 1e-3, "base {base}: '{}' may elide past the bound", r.text);
+            }
+            assert!(w <= META_FLOW_W + 1e-3, "base {base}: the line ran to {w}, past its {META_FLOW_W} bound");
+        }
+        // …and the room left at that worst case is a real annotation's worth rather than a stub —
+        // a QUARTER of the whole line, which is the guard that a future widening of the hero column
+        // (or a tightening of the bound) cannot quietly starve the run into a bare ellipsis. It is
+        // stated as a share of the line and not in pixels of text because the synthetic metric here
+        // is roughly twice the shipped font's advance; the share is a claim about the geometry,
+        // which is the part the host can actually speak for.
+        let (_, worst) = meta_flow(HERO_COL_W, "bamx23");
+        assert!(
+            worst[1].budget >= 0.25 * META_FLOW_W,
+            "a meta line whose facts fill the column leaves the run only {} of {META_FLOW_W}",
+            worst[1].budget
+        );
+    }
+
+    /// Where the bound IS: inside the corner wedge, and a full fifth of the panel short of the last
+    /// fifth of the frame — the side of the picture the composition is usually about, which the
+    /// wedge leaves alone entirely. Both ends are read from `widgets::hero_scrim_a` (the same closed
+    /// form the hero's legibility contract is graded on) rather than restated here, so a retune of
+    /// the wedge fails this instead of silently stranding the run outside it.
+    #[test]
+    fn the_meta_lines_bound_keeps_the_run_inside_the_hero_wedge() {
+        use crate::ui::widgets::hero_scrim_a;
+        assert!(hero_scrim_a(HERO_META_R, 1.0) > 0.0, "the line ends where the wedge has already given up");
+        let wedge_end = (0..=SCR_W as i32)
+            .map(|x| x as f32)
+            .find(|&x| hero_scrim_a(x, 1.0) <= 0.0)
+            .expect("the wedge must end inside the frame");
+        assert!(
+            HERO_META_R <= wedge_end - 0.2 * SCR_W,
+            "the bound ({HERO_META_R}) must stay a fifth of the panel short of the wedge's end ({wedge_end})"
+        );
+        assert!(HERO_META_R > MARGIN_X + HERO_COL_W, "…and past the text column, or the run has nowhere to go");
     }
 }


### PR DESCRIPTION
Deliverable **C** of the Shared Sources design ruled the conditional in its own list — *"if the hero ever becomes independent of a shelf, it needs E's dim run and the preference comes back."* In this app the hero **is** independent: a rotating billboard built per fetch from Continue Watching plus every recent hub, deduped, capped at 8, turning over on its own 8-second timer. It is nobody's focused tile, the shelf heading beneath it attributes something else, and with a merged pool the front door could open on a stranger's film with nothing on screen saying so.

## What it draws

```
Movie · 2024 · 18 · Shared by bamx23
S1 E4 · Episode title · Shared by bamx23
```

**The rung stays, the ink steps down.** `BODY`, *not* the detail page's `CAPTION` — a rung is a role, and the hero line is BODY because it is read from across the room while E's is CAPTION because it sits under a page of copy. What travels between the two screens is the ink step, secondary → tertiary, after a middot at the separator token's own `.45`. A host test asserts the rung explicitly, because "match E literally" is the plausible wrong answer and it is invisible in a diff.

**The line now has a width budget, which it never had.** This is copy over a photograph, legible only inside the hero's corner wedge — which is gone by four fifths of the frame and leaves the last fifth, the side the composition is usually about, completely alone. `HERO_META_R` ends the line at three fifths, a whole fifth of the panel short of that edge, and every run in the flow is handed a budget running to it. So an over-long handle **elides** where a wrapped block would have spilled: there is no wrap in this flow to reach, only a bound to truncate against, and the line can never become two. The facts ahead of the run keep the hero column exactly as they always have — the handle is last on the line and a fact about where the item came from, so it is the right thing to lose first.

## Own-items-first is an ORDERING, not a filter

`own_items_first` promotes the first owned page to the front and moves nothing else, so `[B,B,O,O,B]` → `[O,B,B,O,B]`: the door opens on your own library and a friend's film arrives one flip in, attributed. Filtering instead would leave a borrowed-only account with **no billboard at all** and would overrule a pin the user made — which is why a pool with nothing of ours in it is left exactly as it is. It needs no switch of its own either: the pool is built from included sources only, so a borrowed hero is always the consequence of a pin.

The pool's entries stop being bare catalog indices and become `HeroSlot` — index plus the handle of its shelf's server. Carried rather than looked up, because this is the one place in the app that lifts items **out of** their shelf order, so an entry that knew only its index would have to scan back to a hub to answer "whose is this" for a fact the build already had in hand.

**With one source none of this exists.** `HubRow::source` is `""` everywhere, so the flow returns before its first run — no pad, no dot, no draw call — and `own_items_first` returns on its first line. Absence, not an empty annotation.

## Two things the flow forced, both real

- `hero_content`'s off-screen cull was measured on the **text column**, and the run is the one thing that draws outside it. Left alone, a flip would take the whole column away while ~400px of that line was still on the panel, and the tail of the meta line would blink out ahead of the item it belongs to.
- `meta_drawn_w` clamps to the column. `TextView::truncates` answers *"were WORDS left unplaced"*, and a single token too wide for the column leaves none — it is ellipsized by a separate safety pass — so the measured string can be wider than anything drawn. Unclamped, the run would start in mid-air past the ellipsis, and an absurd one could hand the flow a negative budget, which `text::elide` reads as "no bound at all".

`SOURCE_PAD` is now one constant for both places this screen states a source: the heading and the hero line are one annotation in two positions, not two spacings.

## Tests

Host **427** (+9: four for the ordering — promotion, no-op, borrowed-only, degenerate ends — and five for the line — absence, composition, the rung/ink step, truncation-not-wrapping at three base widths, and the bound's relation to the wedge, read from `widgets::hero_scrim_a` rather than restated) + lint. `make check` run three times, all green. `make` (ARM) links.

**The two halves have very different verification needs, and that is deliberate.** The ORDERING half is pure list arithmetic and is fully settled here — `own_items_first` is host-tested at every case including the boundary where the owner contributes nothing and a borrowed page may then legitimately lead. The ATTRIBUTION half is typographic and cannot be settled by any host test: nothing below draws a pixel.

## Device verification — deferred to coordinator

**Not verified on device.** No frame of this was ever on a panel; everything below is a recipe, not a result.

### Arm and boot

```sh
tools/tv-session.sh up --screen home                       # (a) baseline: no source
ssh root@<tv> "printf '%s' 'bamx23' > /tmp/plxnative-shared"
tools/tv-session.sh up --screen home --keep                # (b) short handle
ssh root@<tv> "printf '%s' 'a-very-long-plex-account-handle-nobody-would-choose' > /tmp/plxnative-shared"
tools/tv-session.sh up --screen home --keep                # (c) the truncation case
tools/tv-session.sh shot out.png                           # after each; DISPLAY source
```

`/tmp/plxnative-shared=<handle>` is **unit 10's committed trigger, reused — there is no second one**. It stamps one handle onto every item a session loads, which is what a fully-borrowed library looks like, and it stands in only where the real answer is empty, so it can never contradict a source the data layer actually has. `--keep` is required on (b) and (c): `up` glob-clears triggers otherwise. Read once at boot, so it must be armed **before** the launch. One file arms the detail page's run too, which is the point — see the cross-check below.

### Where to look

The hero's **meta line**: the small line directly under the big title/clearLogo and directly above the 3-line synopsis, left column, cap top at **y ≈ 552** for a 3-line synopsis (the column is bottom-anchored on `HERO_TEXT_BOTTOM` 692 and grows up, so a shorter synopsis puts it lower). Not the shelf headings below, and not the title.

### What a CORRECT frame looks like

| # | Frame | Correct |
|---|---|---|
| a | no trigger | `Movie · 2024 · 18` — or `S1 E4 · Episode title`. **Byte for byte today's line**: no trailing dot, no gap, nothing added. This is the whole one-server acceptance criterion. |
| b | `bamx23` | `Movie · 2024 · 18 · Shared by bamx23` on **one line**. The run is the **same size as the facts before it** and visibly **dimmer** than them. The middot before it is dimmer than both. |
| c | long handle | Still **one line**, ending in an **ellipsis** — `… · Shared by a-very-long-plex-acc…` — and ending **well left of the last fifth of the frame** (nothing past x≈1152; the right fifth of the picture stays clear). |

**The three ways this is wrong, in order of likelihood:**

1. **The run is smaller than the facts.** That is unit 10's CAPTION treatment leaking onto this line, and it is the wrong answer here. A rung is a role: the hero line is BODY because it is read from across the room, the detail page's is CAPTION because it sits under a page of copy. **Only the ink step travels.** Correct: same size, one step dimmer (`TEXT_SECONDARY` → `TEXT_TERTIARY`).
2. **The line wraps to two lines** in (c), or the synopsis below it has moved down. It must truncate. A second line here would push the pinned action row into the peeking shelf.
3. **The run runs off into the right of the picture** in (c). It must stop at three fifths of the frame, a full fifth inside the corner wedge's own end — past that there is no scrim under it and it is unreadable over bright artwork.

### Two extra frames worth taking while it is armed

- **Mid-flip.** Wait ~8 s on (b) for the auto-flip and shoot during the slide. The run must travel **with** its column, at the same phase as the title and synopsis. If it blinks out early, or appears on the incoming column before the outgoing one has gone, the cull box or the accessor pairing is wrong (both were bugs found and fixed here, and neither is host-observable).
- **Cross-check against the detail page.** `tools/tv-session.sh up --screen detail=<rk> --keep` with the same trigger armed. The two runs must use the **same words** (`Shared by bamx23` — the person, never a machine name) and differ **only** in rung. Same wording, different size, is correct; different wording is a bug in one of the two.

### What no capture can show

`HubRow::source` is `""` everywhere until the multi-server layer lands, so this is the trigger's behaviour, not the product's. The ordering half in particular is invisible on device with one server — it is settled by the host tests, not by a frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxZ585ehWMnuScciTQ9WgV
