### PR TITLE
auth: discover every server the account can reach, and persist the roster

### DIFF
--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -8,8 +8,9 @@
 //! All network happens on spawned threads; the UI only reads snapshots through the accessors here.
 //! Tokens live in the working [`Session`] and are never logged.
 #![allow(dead_code)]
-use crate::plex::account::{AccountClient, HomeUser};
-use crate::plex::session::{self, ServerRef, Session, UserRef};
+use crate::plex::account::{AccountClient, HomeUser, Resource};
+use crate::plex::probe::{self, Candidate, Outcome, ProbePlan, Scheme};
+use crate::plex::session::{self, ServerRef, Session, SourceRef, UserRef};
 use std::sync::Mutex;
 
 /// Which stage the flow is in — the Login/Profiles screens switch on this each frame.
@@ -190,21 +191,35 @@ pub fn submit_pin(index: usize, pin: &str) {
 
 /// Main-loop hook: when the flow has resolved credentials, return them ONCE (and persist the
 /// session) so the caller installs them on the main thread. `None` on every other frame.
+///
+/// The returned creds are the PRIMARY server's, unchanged. The rest of the roster is registered
+/// here too — every path that resolves credentials passes through this one function (sign-in, a
+/// profile pick, and `cancel`'s resume of the stored session), and a share that is not in the
+/// registry is a share nothing can browse.
 pub fn take_ready() -> Option<ReadyCreds> {
-    with_ctl(|c| {
+    let (sources, creds) = with_ctl(|c| {
         if c.phase == Phase::Ready && c.apply_pending {
             c.apply_pending = false;
             session::save(&c.session);
             session::set_current(Some(c.session.user.clone())); // drives the Home profile chip
-            Some(ReadyCreds {
-                host: c.session.server.address.clone(),
-                port: c.session.server.port as i32,
-                token: c.session.pms_token().to_owned(),
-            })
+            Some((
+                c.session.sources.clone(),
+                ReadyCreds {
+                    host: c.session.server.address.clone(),
+                    port: c.session.server.port as i32,
+                    token: c.session.pms_token().to_owned(),
+                },
+            ))
         } else {
             None
         }
-    })
+    })?;
+    // Outside the CTL lock: registering touches the server registry (and, on a cold slot, reads
+    // the session file for the device id), and nothing here needs the flow state held while it
+    // does. `None` for the primary — the caller's own `plex::install` of these creds is what
+    // retargets `current`, and an owned entry registers first regardless.
+    install_roster(&sources, None);
+    Some(creds)
 }
 
 /// Open the "who's watching" picker: the boot gate (picker-at-start) and the Home profile menu's
@@ -217,6 +232,11 @@ pub fn start_switch() {
     if sess.account_token.is_empty() {
         return set_error("You're signed out — sign in to use profiles.");
     }
+    // The boot picker reaches this before any profile is chosen, so it is the earliest point on
+    // the resumed-session path where the stored roster can go back into the registry. Idempotent,
+    // and it does not touch `current` — a "Change profile" from Home lands here too, by which time
+    // everything is registered already and this is a no-op.
+    install_stored_roster(&sess);
     with_ctl(|c| {
         c.error.clear();
         if c.users.is_empty() {
@@ -315,8 +335,22 @@ fn login_thread() {
         return log("auth: sign-in was cancelled while the pin poll was in flight — token dropped");
     }
     let ac = AccountClient::new(&cid, Some(&token));
-    if !discover_and_store(&ac) {
-        return set_error("No local Plex server found on this network.");
+    // The failure copy is per outcome, and it used to be one line — "No local Plex server found on
+    // this network." — for every one of them. That sentence was the discovery POLICY talking: a
+    // server reached over the internet was a failure by construction, so the message named the LAN.
+    // It now describes what actually happened, and none of the three sends the user to the wrong
+    // place: a token refusal is not a router problem, and an account with no server is not an
+    // outage.
+    match discover_and_store(&ac) {
+        Discovery::Ok => {}
+        Discovery::NoServers => return set_error("This Plex account has no server yet."),
+        // "A Plex server", not "your": `refused` is raised by ANY server's addresses all answering
+        // 401, which includes a friend's share while our own was merely silent. Naming the wrong
+        // machine is the whole failure mode this per-outcome copy exists to avoid.
+        Discovery::Refused => return set_error("A Plex server refused the connection — check its network access settings."),
+        Discovery::Silent => return set_error("Couldn't reach any Plex server — check the connection."),
+        // Silent on purpose: the user pressed BACK and is already on the screen `cancel` resumed.
+        Discovery::Cancelled => return log("auth: sign-in was cancelled while discovery was dialling"),
     }
     // Install the PMS client now (server/owner token) so the who's-watching avatars can proxy
     // through the server's photo transcoder. The per-user token is swapped in on profile pick.
@@ -373,48 +407,454 @@ fn poll_for_token(ac: &AccountClient, id: i64, expires_in: i64) -> Option<String
     None
 }
 
-/// Pick an OWNED server with a `local` connection (offline-capable, numeric address the plain-HTTP
-/// PMS socket can reach), else any server with one, and store it in the working session. A
-/// remote-only server is unusable here — the PMS socket does no DNS/TLS — so we require a local one.
-fn discover_and_store(ac: &AccountClient) -> bool {
+// ---- server discovery ----
+//
+// **Every server the account can reach, not the first one that looks local.** What this replaced
+// filtered both of its passes on `c.local && !c.relay`, kept exactly one server, and threw the rest
+// of the account away. Against a real share that filter is worse than useless: `Connection.local`
+// means "this address is RFC1918", not "you are on that LAN", so it selected the OWNER's
+// `10.9.x.x` — 8 s of timeout from here, and the *worse* outcome is that it succeeds against
+// somebody else's box at that address on our own LAN (`docs/shared-servers.md` §2a).
+//
+// So the shape is: ranked candidates from `plex::probe` (pure policy — it is what drops that
+// address), then dial them in order and **verify identity on the answer** before believing it.
+
+/// How far one server got. Only [`Reach::At`] is a server we can use; the other two are the
+/// distinction `probe.rs`'s module doc refuses to let a caller collapse, because they send the
+/// user to two different places.
+enum Reach {
+    /// This address answered `/identity` **as the server we asked for**.
+    At(Candidate),
+    /// A 401. A TOKEN problem, not a reachability one: the `accessToken` is per (user, server) and
+    /// carries the sharing grant, so every other address of this server answers identically and
+    /// trying them buys nothing. Reporting "can't reach friend-nas" here would send the user to look
+    /// at their friend's router for a problem that lives in `/api/v2/resources`.
+    Refused,
+    /// Nothing answered as this server.
+    No,
+}
+
+/// What discovery concluded. Three outcomes rather than a bool, because "this account owns no
+/// server", "your servers are silent" and "a server answered and refused us" are three different
+/// things to tell a user, and only the middle one is about the network.
+enum Discovery {
+    Ok,
+    /// The user left the flow while this was dialling — nothing was registered, nothing stored,
+    /// and nothing must be SAID either: an error banner would land on a screen they had already
+    /// moved on from.
+    Cancelled,
+    /// `/api/v2/resources` named no server at all. NOT the case where it could not be fetched —
+    /// that is [`Discovery::Silent`], because a request that never arrived says nothing about what
+    /// the account owns.
+    NoServers,
+    /// Servers exist; none of them answered (or plex.tv itself did not).
+    Silent,
+    /// At least one answered **401**, and none was reachable. Something in front of that server
+    /// refuses unauthenticated requests — an auth proxy, or `allowedNetworks` excluding this
+    /// subnet. It is not a network fault and not a dead server, so it must not be worded as one.
+    Refused,
+}
+
+/// The probe path. **Unauthenticated on purpose** — `/identity` answers 200 to anybody, which
+/// makes it useless as a token test and perfect as a reachability + identity one.
+///
+/// The token is deliberately NOT sent. A probe can land on a *different machine* (that is rule 1
+/// of `probe.rs`, and the reason identity is verified at all), and a request that carried the
+/// per-(user, server) token would hand that stranger a live credential before we had any reason to
+/// believe who they are.
+///
+/// **So discovery does not, and cannot, prove the token works.** A per-(user, server) grant revoked
+/// between the `/api/v2/resources` fetch and now still probes as [`Outcome::Reachable`] here — the
+/// server really is reachable; it is the credential that is dead, and this request never shows it
+/// one. That 401 surfaces on the first AUTHENTICATED request instead, where the answer is to refetch
+/// `/api/v2/resources` (`probe.rs`'s module doc) rather than to look for a network fault. The
+/// [`Outcome::Unauthorized`] arm below is not dead code for that: a PMS behind an auth proxy, or one
+/// whose `allowedNetworks` refuses this subnet, answers 401 to the probe itself, and *that* must not
+/// be reported as an unreachable address.
+const IDENTITY: &str = "/identity";
+
+/// Can this app's transport dial that candidate **today**? `stream.rs` speaks plain HTTP to a
+/// dotted quad: no TLS, and no name resolution of any kind (`stream.rs`'s `http_open` builds the
+/// `sockaddr_in` by hand from four decimal octets). An https `plex.direct` origin and the owner's
+/// custom hostname are therefore not "unreachable" — they are unspoken, and saying otherwise would
+/// blame a server for a gap in this client. They come back when the curl control plane lands
+/// (`docs/shared-servers.md` §5 step 6), which is why `probe::candidates` already emits them.
+fn dialable(c: &Candidate) -> bool {
+    c.scheme == Scheme::Http && is_ipv4_literal(&c.address)
+}
+
+/// Four decimal octets and nothing else — the exact address shape `stream.rs` can turn into a
+/// `sockaddr_in`. Anything else (a hostname, a v6 literal, a five-part typo) would be handed to
+/// `http_open` only to be rejected there after a `CString` round trip.
+fn is_ipv4_literal(a: &str) -> bool {
+    let mut parts = 0;
+    for p in a.split('.') {
+        if p.is_empty() || p.len() > 3 || !p.bytes().all(|b| b.is_ascii_digit()) || p.parse::<u8>().is_err() {
+            return false;
+        }
+        parts += 1;
+    }
+    parts == 4
+}
+
+/// The `machineIdentifier` in an `/identity` body, read out of **either** encoding.
+///
+/// PMS answers JSON only for an explicit `Accept: application/json` and XML for anything else
+/// (`plex/CLAUDE.md`), and a probe is exactly the request most likely to meet a proxy, a cache or
+/// an older build that ignores the header — so the one field that decides whether we trust the
+/// connection is scanned for rather than deserialized. The two forms differ only in the
+/// punctuation between the name and the value: `"machineIdentifier":"abc"` and
+/// `machineIdentifier="abc"`.
+fn machine_id_in(body: &[u8]) -> Option<String> {
+    const NAME: &[u8] = b"machineIdentifier";
+    let after = body.windows(NAME.len()).position(|w| w == NAME)? + NAME.len();
+    let rest = &body[after..];
+    let start = rest.iter().position(|b| !matches!(b, b'"' | b':' | b'=' | b' ' | b'\t' | b'\r' | b'\n'))?;
+    let rest = &rest[start..];
+    let end = rest
+        .iter()
+        .position(|b| matches!(b, b'"' | b'\'' | b'<' | b',' | b'}' | b' '))
+        .unwrap_or(rest.len());
+    let v = &rest[..end];
+    (!v.is_empty()).then(|| String::from_utf8_lossy(v).into_owned())
+}
+
+/// Turn one probe response into the outcome the caller must not collapse. Pure, so the acceptance
+/// policy is gradeable on the dev Mac — which is the only tier that can grade it, since the
+/// failures it prevents are "a stranger's server answered" and "a token problem reported as a dead
+/// router".
+fn classify(status: i32, body: &[u8], want_machine_id: &str) -> Outcome {
+    if status == 401 {
+        // 401 ONLY. PMS refuses a credential with 401; a 403 is an endpoint saying "not for you"
+        // (the owner-only surfaces), which is not something re-fetching `/resources` can fix.
+        return Outcome::Unauthorized;
+    }
+    if !(200..300).contains(&status) {
+        return Outcome::Unreachable;
+    }
+    if want_machine_id.is_empty() {
+        // Nothing to verify against, so nothing is verified. plex.tv sent a resource with no
+        // `clientIdentifier`; accepting whatever answered would be accepting an unnamed machine.
+        return Outcome::WrongServer;
+    }
+    match machine_id_in(body) {
+        Some(id) if id == want_machine_id => Outcome::Reachable,
+        _ => Outcome::WrongServer,
+    }
+}
+
+/// One unauthenticated `GET http://host:port/identity`, as (status, body).
+///
+/// Uses the raw stream primitives rather than `stream::http_get` because the STATUS is half the
+/// answer: `http_get` folds every non-2xx into `None`, which is precisely the collapse of 401 into
+/// "unreachable" that this module exists to avoid. `http_open` already closed the socket on a
+/// non-2xx (and `http_close` is a no-op the second time, by `take_fd`'s swap), so the status
+/// survives on the stream while the body does not.
+fn get_identity(host: &str, port: i32) -> (i32, Vec<u8>) {
+    let (Ok(h), Ok(p)) = (std::ffi::CString::new(host), std::ffi::CString::new(IDENTITY)) else {
+        return (0, Vec::new());
+    };
+    let accept = c"Accept: application/json\r\n";
+    let mut hs = crate::stream::http_stream_boxed();
+    let opened = crate::stream::http_open(&mut *hs, h.as_ptr(), port, p.as_ptr(), accept.as_ptr(), "GET");
+    let status = crate::stream::hs_status(&*hs);
+    let mut body = Vec::new();
+    if opened == 0 {
+        let mut chunk = vec![0u8; 8192];
+        loop {
+            let n = crate::stream::http_read(&mut *hs, chunk.as_mut_ptr(), chunk.len() as i32);
+            if n <= 0 {
+                break;
+            }
+            body.extend_from_slice(&chunk[..n as usize]);
+            // `/identity` is one empty MediaContainer. Anything past this is not an answer to the
+            // question, and a probe must not be a way to make us read an unbounded body.
+            if body.len() >= 64 * 1024 {
+                break;
+            }
+        }
+    }
+    crate::stream::http_close(&mut *hs);
+    (status, body)
+}
+
+/// Dial one server's candidates in rank order, stopping at the first that answers **as it**.
+///
+/// `dial` is injected so the whole acceptance policy — identity verified before a connection is
+/// accepted, a wrong machine discarded rather than retried, a 401 ending the server instead of the
+/// candidate — is host-testable without a socket.
+///
+/// Sequential, not parallel. `stream.rs` bounds a handshake at 2 s (`CONNECT_TIMEOUT_MS`), the
+/// dialable list is short (policy has already dropped the owner's LAN address and this client
+/// cannot speak to the https/hostname ones), and this runs on the login worker behind a spinner —
+/// so racing would buy a couple of seconds at the price of N threads that each have to capture
+/// their inputs at the spawn site. It is the trade `docs/shared-servers.md` §5 step 4 leaves open.
+///
+/// **A 401 does not end the server, it ends the candidate.** The probe is unauthenticated, so a 401
+/// is not this server refusing our credential — it is whatever is listening at that address refusing
+/// an anonymous request, and that need not be the server at all. Abandoning the whole server on one
+/// would mean this: DHCP moves the PMS, a NAS answers 401 at its old address, and discovery drops
+/// the user's own server without trying the second address plex.tv advertised for it. So it is
+/// carried like [`Outcome::WrongServer`] — next candidate — and only reported as
+/// [`Reach::Refused`] when EVERY address that could be dialled answered 401, which is the shape
+/// that really does mean "reaching this server is not the problem".
+fn probe_server(plan: &ProbePlan, dial: &dyn Fn(&str, i32) -> (i32, Vec<u8>)) -> Reach {
+    let (mut tried, mut refusals) = (0, 0);
+    for c in plan.candidates.iter().filter(|c| dialable(c)) {
+        tried += 1;
+        let (status, body) = dial(&c.address, c.port as i32);
+        match classify(status, &body, &plan.machine_id) {
+            Outcome::Reachable => return Reach::At(c.clone()),
+            Outcome::Unauthorized => {
+                refusals += 1;
+                log(&format!("auth: '{}' — {}:{} refused an unauthenticated request (401)", plan.name, c.address, c.port));
+            }
+            Outcome::WrongServer => {
+                // Rule 1, live: something answered and it is not this server. Discarded, never
+                // retried — and never registered, which is the point of verifying at all.
+                log(&format!("auth: '{}' — {}:{} answered as a DIFFERENT machine", plan.name, c.address, c.port));
+            }
+            Outcome::Unreachable => {}
+        }
+    }
+    let skipped = plan.candidates.len() - tried;
+    log(&format!("auth: '{}' did not answer ({tried} address(es) tried, {skipped} not dialable)", plan.name));
+    if tried > 0 && refusals == tried {
+        Reach::Refused
+    } else {
+        Reach::No
+    }
+}
+
+/// Has the login flow moved on from [`Phase::Discovering`] — i.e. is this worker no longer the live
+/// flow? [`cancel`] is a phase flip and nothing more, so this is the only way a worker holding a
+/// socket can find out that BACK was pressed and the stored session has already been resumed.
+fn flow_left_discovery() -> bool {
+    with_ctl(|c| c.phase != Phase::Discovering)
+}
+
+/// What probing a whole `/api/v2/resources` response came to.
+enum Resolved {
+    /// The response named no server at all — nothing was dialled, and this is a fact about the
+    /// account rather than about the network.
+    NoServers,
+    /// Servers were probed and none was accepted. `refused` distinguishes "a server's every
+    /// dialable address answered 401" from "silence" — two different things to tell the user.
+    None { refused: bool },
+    /// The flow moved on (BACK) while this was dialling. Not an outcome to report: nothing may be
+    /// registered, stored or said, because the user is already somewhere else.
+    Cancelled,
+    /// The roster, **ours first**, each entry carrying the address that actually answered.
+    Reached(Vec<SourceRef>),
+}
+
+/// The whole of discovery except the two impure edges — fetching `/resources` and holding a socket.
+///
+/// Everything that decides what the app ends up talking to lives here: which servers are tried and
+/// in what order, which of a server's addresses is accepted, and what is written down about it. It
+/// takes the response and a `dial`, so a full sign-in against a two-server account is a host test
+/// rather than a screenshot — which matters because this function is the gate on the whole feature:
+/// register the wrong connection and no other unit's work is reachable, however correct it is.
+///
+/// `abort` is polled between servers. Discovery is no longer a filter over a response — it holds
+/// sockets, and `stream.rs` will wait 2 s on a handshake and 15 s on a peer that connects and then
+/// says nothing. That is a long time for the user to be looking at a spinner they can leave, so the
+/// worker has to be able to notice that it is no longer the live flow.
+fn resolve_roster(
+    resources: &[Resource],
+    dial: &dyn Fn(&str, i32) -> (i32, Vec<u8>),
+    abort: &dyn Fn() -> bool,
+) -> Resolved {
+    let mut servers: Vec<&Resource> = resources.iter().filter(|r| r.is_server()).collect();
+    if servers.is_empty() {
+        return Resolved::NoServers;
+    }
+    // Ours first — it is what becomes `current`, what Home is built from, and the one whose silence
+    // the user can actually do something about. `sort_by_key` is stable, so plex.tv's own order
+    // survives inside each group.
+    servers.sort_by_key(|r| !r.owned);
+
+    let mut found: Vec<SourceRef> = Vec::new();
+    let mut refused = false;
+    for r in servers {
+        if abort() {
+            return Resolved::Cancelled;
+        }
+        let plan = probe::plan(r);
+        match probe_server(&plan, dial) {
+            Reach::At(c) => {
+                let s = SourceRef {
+                    machine_id: plan.machine_id.clone(),
+                    name: plan.name.clone(),
+                    shared_by: plan.source_title.clone().unwrap_or_default(),
+                    owned: plan.owned,
+                    // The address that ANSWERED, never the first advertised — and it got here only
+                    // by being dialable, which is what keeps a v6 literal or a hostname out of the
+                    // session file.
+                    address: c.address,
+                    port: c.port,
+                    // That server's OWN grant. Our own server's token gets a 401 from a share, so
+                    // there is no such thing as one token for the roster.
+                    token: plan.token.clone(),
+                };
+                log(&format!("auth: reached {}", s.describe()));
+                found.push(s);
+            }
+            Reach::Refused => refused = true,
+            Reach::No => {}
+        }
+    }
+    if found.is_empty() {
+        Resolved::None { refused }
+    } else {
+        Resolved::Reached(found)
+    }
+}
+
+/// Discover **every** server this identity can use — ours and each share — and store the roster.
+///
+/// Each resource that `provides` a server is turned into ranked candidates by `plex::probe`, dialled
+/// in order, and accepted only when the answer's `machineIdentifier` matches. Each one that answers
+/// is registered with the [server registry](crate::plex::register) under its **real machine id** and
+/// its **own** per-(user, server) `accessToken` — a share is a separate authority and answers 401 to
+/// our own server's token. Our own server stays `current`: a share is browsable, never the default.
+///
+/// The primary [`ServerRef`] is written exactly as before, so a single-server account produces the
+/// same session file it always did (plus a one-entry roster beside it).
+fn discover_and_store(ac: &AccountClient) -> Discovery {
     let resources = match ac.resources() {
         Some(r) => r,
         None => {
+            // No response, or one that would not deserialize: plex.tv is unreachable from here.
+            // NOT `NoServers` — that copy tells the user their account owns no server, which is a
+            // statement about their account made on the strength of never having heard from it.
             log("auth: resources request FAILED (no response/deser)");
-            return false;
+            return Discovery::Silent;
         }
     };
-    let servers = resources.iter().filter(|r| r.is_server()).count();
-    log(&format!("auth: resources n={} servers={}", resources.len(), servers));
-    let find = |owned_only: bool| {
-        resources
-            .iter()
-            .filter(|r| r.is_server() && (!owned_only || r.owned))
-            .find_map(|r| {
-                r.connections
-                    .iter()
-                    .find(|c| c.local && !c.relay && !c.address.is_empty())
-                    .map(|c| (r, c))
-            })
+    log(&format!(
+        "auth: resources n={} servers={}",
+        resources.len(),
+        resources.iter().filter(|r| r.is_server()).count()
+    ));
+    let found = match resolve_roster(&resources, &get_identity, &flow_left_discovery) {
+        Resolved::NoServers => return Discovery::NoServers,
+        Resolved::None { refused: true } => return Discovery::Refused,
+        Resolved::None { refused: false } => return Discovery::Silent,
+        Resolved::Cancelled => return Discovery::Cancelled,
+        Resolved::Reached(f) => f,
     };
-    let (r, conn) = match find(true).or_else(|| find(false)) {
-        Some(x) => x,
-        None => {
-            log("auth: no server with a local connection (remote-only can't be reached)");
-            return false;
-        }
+
+    // LAST CHANCE TO STOP, and the one that matters most: everything below is global. The guard
+    // above `discover_and_store` is checked before any of this runs, and dialling can now take
+    // seconds — long enough for BACK to have resumed the stored session, installed it and routed
+    // the user to Home. Registering here would then retarget `client()` out from under that Home,
+    // and the session write would clobber the session `cancel` had just restored.
+    if flow_left_discovery() {
+        return Discovery::Cancelled;
+    }
+
+    let primary = primary_index(&found);
+    log(&format!("auth: {} server(s) reached, primary '{}'", found.len(), found[primary].name));
+    install_roster(&found, Some(primary));
+    let p = &found[primary];
+    let server = ServerRef {
+        name: p.name.clone(),
+        machine_id: p.machine_id.clone(),
+        address: p.address.clone(),
+        port: if p.port != 0 { p.port } else { 32400 },
+        token: p.token.clone(),
     };
-    log(&format!("auth: chose server '{}' {}:{}", r.name, conn.address, conn.port));
     with_ctl(|c| {
-        c.session.server = ServerRef {
-            name: r.name.clone(),
-            machine_id: r.client_identifier.clone(),
-            address: conn.address.clone(),
-            port: if conn.port != 0 { conn.port } else { 32400 },
-            token: r.access_token.clone(),
-        };
+        c.session.server = server;
+        c.session.sources = found;
     });
-    true
+    Discovery::Ok
+}
+
+/// Register a roster with the [server registry](crate::plex::register), optionally naming which
+/// entry is the current server.
+///
+/// The registry is keyed on `machineIdentifier`, so this is idempotent: re-running discovery
+/// re-points a server that moved rather than adding a second slot for it, and a re-registration at
+/// the same address just swaps the token in place — which is what the ~30 call sites holding a
+/// `&'static Client` rely on.
+///
+/// Owned entries are registered FIRST even when `primary` is `None` — see [`registration_order`].
+fn install_roster(sources: &[SourceRef], primary: Option<usize>) -> usize {
+    let order = registration_order(sources);
+    for &i in &order {
+        let s = &sources[i];
+        let id = crate::plex::register(&s.machine_id, &s.address, s.port as i32, &s.token);
+        if primary == Some(i) {
+            crate::plex::set_current(id);
+        }
+    }
+    order.len()
+}
+
+/// Which roster entries to register, and in what order: the ones that can actually be dialled,
+/// **ours first**.
+///
+/// The order is load-bearing, not tidiness. The registry makes the FIRST registration current when
+/// nothing is current yet (`servers.rs`), which is exactly the state a boot is in — so a roster
+/// that happens to list a share first would silently come up pointed at the friend's server, and
+/// Home would be built from their library. Stable, so plex.tv's own order survives inside each
+/// group.
+fn registration_order(sources: &[SourceRef]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..sources.len()).filter(|&i| sources[i].usable()).collect();
+    order.sort_by_key(|&i| !sources[i].owned);
+    order
+}
+
+/// Which reached server is the primary: ours if it answered, else the first that did. A friend's
+/// library is a better app than "no server found" when our own box is off.
+fn primary_index(sources: &[SourceRef]) -> usize {
+    sources.iter().position(|s| s.owned).unwrap_or(0)
+}
+
+/// Register the persisted roster — the BOOT twin of discovery, for the path that resumes a stored
+/// session instead of signing in. Only the primary server comes back through
+/// [`take_ready`]/`plex::install`; without this the shares stay unregistered until the next
+/// sign-in, and a boot that resumed a session could browse only our own server.
+///
+/// Leaves `current` alone (an owned entry sorts first, so the registry's own "first registration
+/// wins" already points at ours); the caller's `plex::install` of the primary is what retargets.
+///
+/// **Called from [`start_switch`], which covers the boot picker and every later "Change profile".
+/// The one path it does NOT cover is `app.rs`'s straight-to-Home boot** — a stored session with a
+/// single Plex Home user, or any automated run — which installs the primary itself and never
+/// enters this module. That boot needs one line beside its `install_pms`:
+/// `crate::auth::install_stored_roster(&session);`.
+pub fn install_stored_roster(sess: &Session) -> usize {
+    let n = install_roster(&sess.sources, None);
+    if n > 0 {
+        log(&format!("auth: roster restored — {n} server(s) registered"));
+    }
+    n
+}
+
+/// Re-key a stored roster to a newly switched profile.
+///
+/// `accessToken` is per **(user, server)**, so switching profile invalidates every stored token at
+/// once, not only the primary's — a share left on the previous profile's token answers 401 to
+/// everything. The switch already fetches `/api/v2/resources` as the new user to find the primary's
+/// token, so this re-keys the whole roster from that same response: no extra round trip.
+///
+/// A source the response no longer names is DROPPED — that profile has not been granted it. A brand
+/// new share is not added here: it has no probed address yet, and inventing one is what discovery
+/// is for.
+/// An entry with no machine id is dropped too: it cannot be identified, so it cannot be re-keyed,
+/// and an empty id must never be allowed to match a resource that also happens to have none.
+fn retoken(sources: &[SourceRef], resources: &[Resource]) -> Vec<SourceRef> {
+    sources
+        .iter()
+        .filter(|s| !s.machine_id.is_empty())
+        .filter_map(|s| {
+            let r = resources.iter().find(|r| r.is_server() && r.client_identifier == s.machine_id)?;
+            (!r.access_token.is_empty()).then(|| SourceRef { token: r.access_token.clone(), ..s.clone() })
+        })
+        .collect()
 }
 
 fn switch_thread(index: usize, pin: Option<String>) {
@@ -466,18 +906,39 @@ fn switch_thread(index: usize, pin: Option<String>) {
         // managed users (the admin's happens to double as one). Re-discover with the switched user's
         // token to get THIS user's per-user server access token (the /resources `accessToken` the PMS
         // accepts), scoped to what that profile is allowed to see.
-        let mid = with_ctl(|c| c.session.server.machine_id.clone());
-        let stok = AccountClient::new(&cid, Some(&u.auth_token))
-            .resources()
-            .and_then(|rs| {
-                rs.into_iter()
-                    .find(|r| r.is_server() && (mid.is_empty() || r.client_identifier == mid))
-                    .map(|r| r.access_token)
-            })
+        let (mid, roster) = with_ctl(|c| (c.session.server.machine_id.clone(), c.session.sources.clone()));
+        let resources = AccountClient::new(&cid, Some(&u.auth_token)).resources().unwrap_or_default();
+        // The fallback when we have no machine id used to take the FIRST server in the response,
+        // which is only safe while one server exists: plex.tv listed the SHARE first in the
+        // measured capture, so an empty `session.server.machine_id` would persist a friend's
+        // accessToken as this profile's primary token — and 401 everything. Ours first, then
+        // anything, and only the exact machine when we know it.
+        let by_id = |r: &&Resource| r.is_server() && !mid.is_empty() && r.client_identifier == mid;
+        let stok = resources
+            .iter()
+            .find(by_id)
+            .or_else(|| mid.is_empty().then(|| resources.iter().find(|r| r.is_server() && r.owned)).flatten())
+            .or_else(|| mid.is_empty().then(|| resources.iter().find(|r| r.is_server())).flatten())
+            .map(|r| r.access_token.clone())
             .filter(|t| !t.is_empty());
+        // The per-(user, server) token is per server, so EVERY entry of the roster has just gone
+        // stale, not only the primary's — a share left on the previous profile's token answers 401
+        // to everything. This response is the one already being fetched, so re-keying costs nothing.
+        //
+        // COMPUTED here, APPLIED only on the success branch below. `retoken` drops what the new
+        // profile was not granted, and a switch that then fails leaves the user on the picker with
+        // their old profile still signed in — persisting a roster re-keyed for a profile we did not
+        // switch to would delete their shares from disk the next time anything saved the session.
+        // Guarded on the response naming at least one server, so a failed fetch cannot read as
+        // "this profile has been un-shared everything" either.
+        let rekeyed = resources.iter().any(|r| r.is_server()).then(|| retoken(&roster, &resources));
         match stok {
             Some(token) => {
                 log(&format!("auth: switch '{}' -> ok (per-user server token)", tile.title));
+                if let Some(next) = rekeyed {
+                    with_ctl(|c| c.session.sources = next.clone());
+                    install_roster(&next, None);
+                }
                 with_ctl(|c| {
                     c.session.user = UserRef {
                         id: u.id,
@@ -518,4 +979,426 @@ fn set_error(msg: &str) {
         c.error = msg.to_owned();
         c.phase = Phase::Error;
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn resource(json: &str) -> Resource {
+        serde_json::from_str(json).expect("fixture parses")
+    }
+
+    /// A share with FOUR advertised addresses, which between them cover every case the probe loop
+    /// has to get right: the owner's LAN address (policy drops it), a hostname this transport
+    /// cannot resolve, and two public IPv4s so "the first one answered as somebody else" has a
+    /// second one to fall through to. Shaped on the live capture of 2026-08-11
+    /// (`docs/shared-servers.md` §2); the addresses are stand-ins, the arrangement is not.
+    fn a_share() -> Resource {
+        resource(
+            r#"{"name":"friend-nas","clientIdentifier":"bbbb2222","provides":"server","owned":false,
+                "sourceTitle":"afriend","publicAddressMatches":false,"httpsRequired":false,
+                "accessToken":"tok-share","connections":[
+                  {"protocol":"https","address":"10.9.9.7","port":32400,
+                   "uri":"https://10-9-9-7.h.plex.direct:32400","local":true,"relay":false,"IPv6":false},
+                  {"protocol":"https","address":"media.example.internal","port":31234,
+                   "uri":"https://media.example.internal:31234","local":false,"relay":false,"IPv6":false},
+                  {"protocol":"https","address":"198.51.100.7","port":31234,
+                   "uri":"https://198-51-100-7.h.plex.direct:31234","local":false,"relay":false,"IPv6":false},
+                  {"protocol":"https","address":"203.0.113.9","port":31234,
+                   "uri":"https://203-0-113-9.h.plex.direct:31234","local":false,"relay":false,"IPv6":false}]}"#,
+        )
+    }
+
+    /// A JSON `/identity` body naming `mid` — what a PMS answers a probe with.
+    fn identity_json(mid: &str) -> Vec<u8> {
+        format!(r#"{{"MediaContainer":{{"size":0,"machineIdentifier":"{mid}","version":"1.43.3"}}}}"#).into_bytes()
+    }
+
+    /// A recording dial. Returns whatever the script says for an address, and remembers the order
+    /// it was asked — which is how "it stopped" and "it never tried that one" become assertions.
+    struct Dialled {
+        seen: RefCell<Vec<String>>,
+        answers: Vec<(&'static str, i32, Vec<u8>)>,
+    }
+    impl Dialled {
+        fn new(answers: Vec<(&'static str, i32, Vec<u8>)>) -> Dialled {
+            Dialled { seen: RefCell::new(Vec::new()), answers }
+        }
+        fn dial(&self, host: &str, port: i32) -> (i32, Vec<u8>) {
+            self.seen.borrow_mut().push(format!("{host}:{port}"));
+            match self.answers.iter().find(|(h, _, _)| *h == host) {
+                Some((_, s, b)) => (*s, b.clone()),
+                None => (0, Vec::new()), // nothing answered at that address
+            }
+        }
+        fn seen(&self) -> Vec<String> {
+            self.seen.borrow().clone()
+        }
+    }
+
+    /// **Identity is verified before a connection is accepted.** A candidate that answers is not
+    /// the server we asked for: rule 1 of `probe.rs` is a live account of how a stranger's box on
+    /// our own LAN answers a probe, and accepting it would register their machine under our
+    /// friend's name and browse it.
+    ///
+    /// The wrong machine is discarded and the NEXT candidate is tried — a mismatch is a fact about
+    /// that address, not about the server.
+    #[test]
+    fn a_response_from_the_wrong_machine_is_rejected_and_the_next_address_is_tried() {
+        let plan = probe::plan(&a_share());
+        let d = Dialled::new(vec![
+            ("198.51.100.7", 200, identity_json("zzzz9999")), // someone else entirely
+            ("203.0.113.9", 200, identity_json("bbbb2222")),  // the server we asked for
+        ]);
+
+        match probe_server(&plan, &|h, p| d.dial(h, p)) {
+            Reach::At(c) => assert_eq!((c.address.as_str(), c.port), ("203.0.113.9", 31234)),
+            _ => panic!("the second address answers as the right machine: {:?}", d.seen()),
+        }
+        assert_eq!(d.seen(), vec!["198.51.100.7:31234", "203.0.113.9:31234"]);
+
+        // …and the same body from the wrong machine is never enough on its own
+        assert_eq!(classify(200, &identity_json("zzzz9999"), "bbbb2222"), Outcome::WrongServer);
+        assert_eq!(classify(200, &identity_json("bbbb2222"), "bbbb2222"), Outcome::Reachable);
+        // a 200 that says nothing we can check is not an acceptance either
+        assert_eq!(classify(200, b"<html>router login</html>", "bbbb2222"), Outcome::WrongServer);
+        // nor is a resource plex.tv sent without an identity to verify against
+        assert_eq!(classify(200, &identity_json("bbbb2222"), ""), Outcome::WrongServer);
+    }
+
+    /// **A 401 is its own state, never folded into "unreachable" — but it ends the CANDIDATE, not
+    /// the server.** The probe is unauthenticated, so a 401 is not this server refusing our
+    /// credential; it is whatever is listening refusing an anonymous request, and that need not be
+    /// the server at all. The scenario that decides it: DHCP moves the PMS, a NAS answers 401 at its
+    /// old address, and abandoning the server there would drop the user's OWN server without ever
+    /// trying the second address plex.tv advertised for it.
+    #[test]
+    fn a_401_moves_to_the_next_address_and_only_a_clean_sweep_is_a_refusal() {
+        assert_eq!(classify(401, b"", "bbbb2222"), Outcome::Unauthorized);
+        // and 401 is the only status that means it: an endpoint refusal, a dead gateway and no
+        // answer at all are all just "try the next address"
+        for s in [403, 404, 500, 502, 0] {
+            assert_eq!(classify(s, b"", "bbbb2222"), Outcome::Unreachable, "status {s}");
+        }
+
+        // one address 401s, the next answers properly → the server is REACHED, not abandoned
+        let plan = probe::plan(&a_share());
+        let d = Dialled::new(vec![("198.51.100.7", 401, Vec::new()), ("203.0.113.9", 200, identity_json("bbbb2222"))]);
+        match probe_server(&plan, &|h, p| d.dial(h, p)) {
+            Reach::At(c) => assert_eq!(c.address, "203.0.113.9"),
+            _ => panic!("a 401 on one address must not cost the server: {:?}", d.seen()),
+        }
+        assert_eq!(d.seen().len(), 2, "the 401 did not stop the sweep");
+
+        // every dialable address 401s → THAT is a refusal, and it is not "unreachable"
+        let all = Dialled::new(vec![("198.51.100.7", 401, Vec::new()), ("203.0.113.9", 401, Vec::new())]);
+        assert!(matches!(probe_server(&plan, &|h, p| all.dial(h, p)), Reach::Refused));
+
+        // a 401 mixed with silence is NOT a refusal — the silent address is the unexplained one,
+        // and reporting "refused" would send the user to the wrong setting entirely
+        let mixed = Dialled::new(vec![("198.51.100.7", 401, Vec::new())]);
+        assert!(matches!(probe_server(&plan, &|h, p| mixed.dial(h, p)), Reach::No));
+    }
+
+    /// BACK during discovery must leave the process alone. `cancel` is a phase flip, so by the time
+    /// a dial returns the stored session may already be installed and the user on Home — and
+    /// everything discovery does next is global: it registers servers, retargets `client()`, and
+    /// overwrites the session. It gets to do none of that.
+    #[test]
+    fn a_flow_that_moved_on_mid_dial_registers_nothing_and_stores_nothing() {
+        let d = Dialled::new(vec![
+            ("192.168.0.10", 200, identity_json("aaaa1111")),
+            ("203.0.113.9", 200, identity_json("bbbb2222")),
+        ]);
+        let out = resolve_roster(&a_two_server_account(), &|h, p| d.dial(h, p), &|| true);
+        assert!(matches!(out, Resolved::Cancelled), "cancelled before anything was dialled");
+        assert!(d.seen().is_empty(), "not one socket after the flow moved on: {:?}", d.seen());
+
+        // and the abort is polled BETWEEN servers, so a cancel landing after the first still stops
+        let hits = std::cell::Cell::new(0);
+        let after_one = || {
+            hits.set(hits.get() + 1);
+            hits.get() > 1
+        };
+        let d2 = Dialled::new(vec![
+            ("192.168.0.10", 200, identity_json("aaaa1111")),
+            ("203.0.113.9", 200, identity_json("bbbb2222")),
+        ]);
+        assert!(matches!(
+            resolve_roster(&a_two_server_account(), &|h, p| d2.dial(h, p), &after_one),
+            Resolved::Cancelled
+        ));
+        assert_eq!(d2.seen(), vec!["192.168.0.10:32400"], "the second server is never dialled");
+    }
+
+    /// The 8-second trap, and the half of it the transport adds. Policy has already dropped the
+    /// share's `local` address (the OWNER's LAN); this asserts the probe loop never dials it — and
+    /// never dials the two candidates this client cannot speak to at all, which are unspoken rather
+    /// than unreachable and must not be counted as the server failing.
+    #[test]
+    fn only_addresses_this_transport_can_dial_are_ever_probed() {
+        let plan = probe::plan(&a_share());
+        assert_eq!(plan.candidates.len(), 6, "policy kept three connections, two candidates each");
+
+        let d = Dialled::new(vec![("203.0.113.9", 200, identity_json("bbbb2222"))]);
+        assert!(matches!(probe_server(&plan, &|h, p| d.dial(h, p)), Reach::At(_)));
+        let seen = d.seen();
+        assert!(!seen.iter().any(|s| s.starts_with("10.9.x.x")), "the owner's LAN address: {seen:?}");
+        assert!(!seen.iter().any(|s| s.contains("example.internal")), "no DNS in this transport: {seen:?}");
+        assert!(!seen.iter().any(|s| s.contains("plex.direct")), "no TLS in this transport: {seen:?}");
+
+        // the rule itself, stated on the candidates
+        let http_v4 = |a: &str| Candidate {
+            url: format!("http://{a}:32400"),
+            scheme: Scheme::Http,
+            location: probe::Location::Remote,
+            address: a.into(),
+            port: 32400,
+            ipv6: false,
+        };
+        assert!(dialable(&http_v4("203.0.113.9")));
+        assert!(!dialable(&Candidate { scheme: Scheme::Https, ..http_v4("203.0.113.9") }));
+        assert!(!dialable(&http_v4("media.example.internal")));
+        assert!(!dialable(&http_v4("2001:db8::1")));
+        assert!(!dialable(&http_v4("203.0.113")), "three octets is not an address");
+        assert!(!dialable(&http_v4("203.0.113.999")), "999 is not an octet");
+    }
+
+    /// **The address that reaches the session file is one this transport can dial — never an IPv6
+    /// literal, never a hostname.** This is the property that replaced `choose_local_connection`'s
+    /// v6 guard: the foundation's `includeIPv6=1` made plex.tv offer v6 connections, and the chooser
+    /// this file used to end in took the FIRST `local` match and PERSISTED it, so one v6 address
+    /// wrote an undialable server to disk and broke every later boot, not just that one.
+    ///
+    /// Here the guard is structural rather than a filter that can be forgotten: nothing but a
+    /// `dialable` candidate is ever dialled, and only a candidate that ANSWERED becomes a
+    /// `SourceRef`. So an address can only be persisted after it has been connected to.
+    #[test]
+    fn only_an_address_this_transport_can_dial_is_ever_chosen_and_stored() {
+        // our own server, v6 first — and the second v6 lies about its flag, which is why the shape
+        // of the address is what decides rather than `IPv6`
+        let res = resource(
+            r#"{"name":"Mac mini","clientIdentifier":"aaaa1111","provides":"server","owned":true,
+                "publicAddressMatches":false,"httpsRequired":false,"accessToken":"tok-own",
+                "connections":[
+                  {"protocol":"https","address":"2001:db8::1","port":32400,
+                   "uri":"https://2001-db8--1.h.plex.direct:32400","local":true,"relay":false,"IPv6":true},
+                  {"protocol":"https","address":"fd00::5","port":32400,"uri":"","local":true,"relay":false,"IPv6":false},
+                  {"protocol":"https","address":"192.168.0.10","port":32400,
+                   "uri":"https://192-168-0-10.h.plex.direct:32400","local":true,"relay":false,"IPv6":false}]}"#,
+        );
+        let plan = probe::plan(&res);
+        let d = Dialled::new(vec![
+            // every one of them answers, correctly — so nothing but the ORDER and the dialable
+            // filter can keep the v6 addresses out
+            ("2001:db8::1", 200, identity_json("aaaa1111")),
+            ("fd00::5", 200, identity_json("aaaa1111")),
+            ("192.168.0.10", 200, identity_json("aaaa1111")),
+        ]);
+
+        match probe_server(&plan, &|h, p| d.dial(h, p)) {
+            Reach::At(c) => assert_eq!(c.address, "192.168.0.10", "a v6 literal is not dialable here"),
+            _ => panic!("the LAN IPv4 answers: {:?}", d.seen()),
+        }
+        assert_eq!(d.seen(), vec!["192.168.0.10:32400"], "the v6 addresses are never even tried");
+        // …and the flag being false does not make a colon-bearing address dialable
+        assert!(!is_ipv4_literal("fd00::5") && !is_ipv4_literal("2001:db8::1"));
+    }
+
+    /// The one field that decides whether we trust a connection is scanned for, not deserialized:
+    /// PMS answers XML unless an explicit JSON Accept survives to it, and a probe is the request
+    /// most likely to meet a proxy that rewrites headers.
+    #[test]
+    fn the_machine_identifier_is_read_from_json_and_from_xml_alike() {
+        assert_eq!(machine_id_in(&identity_json("abc123")).as_deref(), Some("abc123"));
+        assert_eq!(
+            machine_id_in(br#"<MediaContainer size="0" machineIdentifier="abc123" version="1.43.3"/>"#).as_deref(),
+            Some("abc123")
+        );
+        assert_eq!(machine_id_in(br#"{"MediaContainer":{"machineIdentifier" : "abc123"}}"#).as_deref(), Some("abc123"));
+        // an empty value is no value — it must not read as "the next field"
+        assert_eq!(machine_id_in(br#"{"machineIdentifier":"","size":0}"#), None);
+        assert_eq!(machine_id_in(b"nothing here"), None);
+        assert_eq!(machine_id_in(b""), None);
+    }
+
+    /// The account this feature exists for, as `/api/v2/resources` really returns it: OUR server
+    /// (owned, LAN + public + relay) and the SHARE (not owned, the owner's 10.9.x.x LAN, an internal
+    /// hostname, and one public IPv4). Shaped on the live capture of 2026-08-11
+    /// (`docs/shared-servers.md` §2) — the addresses are stand-ins, the arrangement is not, and the
+    /// share is listed FIRST because plex.tv's order is not ours to rely on.
+    fn a_two_server_account() -> Vec<Resource> {
+        serde_json::from_str(
+            r#"[
+              {"name":"friend-nas","clientIdentifier":"bbbb2222","provides":"server","owned":false,
+               "sourceTitle":"afriend","ownerId":987654,"publicAddressMatches":false,
+               "httpsRequired":false,"accessToken":"tok-share","connections":[
+                 {"protocol":"https","address":"10.9.9.7","port":32400,
+                  "uri":"https://10-9-9-7.h.plex.direct:32400","local":true,"relay":false,"IPv6":false},
+                 {"protocol":"https","address":"media.example.internal","port":31234,
+                  "uri":"https://media.example.internal:31234","local":false,"relay":false,"IPv6":false},
+                 {"protocol":"https","address":"203.0.113.9","port":31234,
+                  "uri":"https://203-0-113-9.h.plex.direct:31234","local":false,"relay":false,"IPv6":false}]},
+              {"name":"Mac mini","clientIdentifier":"aaaa1111","provides":"server","owned":true,
+               "sourceTitle":null,"ownerId":null,"publicAddressMatches":false,"httpsRequired":false,
+               "accessToken":"tok-own","connections":[
+                 {"protocol":"https","address":"2001:db8::1","port":32400,
+                  "uri":"https://2001-db8--1.h.plex.direct:32400","local":true,"relay":false,"IPv6":true},
+                 {"protocol":"https","address":"192.168.0.10","port":32400,
+                  "uri":"https://192-168-0-10.h.plex.direct:32400","local":true,"relay":false,"IPv6":false},
+                 {"protocol":"https","address":"plex-relay.example.net","port":8443,
+                  "uri":"https://plex-relay.example.net:8443","local":false,"relay":true,"IPv6":false}]},
+              {"name":"someone's iPad","clientIdentifier":"cccc3333","provides":"player,controller",
+               "accessToken":"tok-pad","connections":[]}
+            ]"#,
+        )
+        .expect("fixture parses")
+    }
+
+    /// **What a real sign-in must produce.** The whole of discovery over the measured two-server
+    /// account, with only the socket faked: this is the assertion that stands in for a device run,
+    /// because everything downstream — Home, the library grid, playback — talks to whatever this
+    /// function decided.
+    ///
+    /// Two servers, OURS FIRST (plex.tv listed the share first), each settled on the one address
+    /// that answers from this TV: our LAN IPv4, and the share's PUBLIC IPv4 rather than the owner's
+    /// 10.9.x.x LAN. Each carries its own grant, and the non-server resource is not in the roster.
+    #[test]
+    fn a_sign_in_to_a_two_server_account_settles_on_one_address_each_ours_first() {
+        let d = Dialled::new(vec![
+            ("192.168.0.10", 200, identity_json("aaaa1111")),
+            ("203.0.113.9", 200, identity_json("bbbb2222")),
+        ]);
+        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &|h, p| d.dial(h, p), &|| false) else {
+            panic!("both servers answer: {:?}", d.seen())
+        };
+
+        assert_eq!(roster.len(), 2, "a player resource is not a server");
+        assert_eq!(primary_index(&roster), 0, "ours is the primary and becomes `current`");
+
+        let own = &roster[0];
+        assert!(own.owned && own.machine_id == "aaaa1111");
+        assert_eq!((own.address.as_str(), own.port), ("192.168.0.10", 32400), "the LAN v4, not the v6");
+        assert_eq!(own.token, "tok-own");
+        assert!(own.shared_by.is_empty(), "an owned server has no owner to name");
+
+        let share = &roster[1];
+        assert!(!share.owned && share.machine_id == "bbbb2222");
+        assert_eq!(
+            (share.address.as_str(), share.port),
+            ("203.0.113.9", 31234),
+            "the owner's 10.9.x.x LAN is not ours to dial, and their hostname does not resolve"
+        );
+        assert_eq!(share.token, "tok-share", "a share is a separate authority: OUR token gets a 401");
+        assert_eq!(share.shared_by, "afriend");
+        assert!(roster.iter().all(|s| s.usable()), "every entry is dialable, so every one registers");
+
+        // Exactly two dials: the relay is never tried (a 2 Mbit/s https-only tunnel), nor the
+        // owner's LAN, nor the internal hostname, nor the v6 literal — none of which this transport
+        // can speak to. And OURS is probed first, though plex.tv listed the share first.
+        assert_eq!(d.seen(), vec!["192.168.0.10:32400", "203.0.113.9:31234"]);
+    }
+
+    /// The three ways discovery can come to nothing are three different things to say, and the one
+    /// that used to be said for all of them ("No local Plex server found on this network") was the
+    /// old policy talking rather than a description of what happened.
+    #[test]
+    fn the_three_empty_outcomes_are_distinguished() {
+        let players = serde_json::from_str::<Vec<Resource>>(
+            r#"[{"name":"iPad","clientIdentifier":"cccc3333","provides":"player","connections":[]}]"#,
+        )
+        .unwrap();
+        assert!(matches!(resolve_roster(&players, &|_, _| (0, Vec::new()), &|| false), Resolved::NoServers));
+
+        // servers that simply do not answer
+        let silent = Dialled::new(vec![]);
+        assert!(matches!(
+            resolve_roster(&a_two_server_account(), &|h, p| silent.dial(h, p), &|| false),
+            Resolved::None { refused: false }
+        ));
+
+        // …and one that answers 401: something in front of it refuses unauthenticated requests,
+        // which is not a network fault and must not be worded as one
+        let refused = Dialled::new(vec![("192.168.0.10", 401, Vec::new()), ("203.0.113.9", 401, Vec::new())]);
+        assert!(matches!(
+            resolve_roster(&a_two_server_account(), &|h, p| refused.dial(h, p), &|| false),
+            Resolved::None { refused: true }
+        ));
+
+        // a share that answers while OUR server is off still signs in — a friend's library beats
+        // "no server found" — and it becomes the primary because it is the only thing there is
+        let one = Dialled::new(vec![("203.0.113.9", 200, identity_json("bbbb2222"))]);
+        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &|h, p| one.dial(h, p), &|| false) else {
+            panic!("the share answered")
+        };
+        assert_eq!(roster.len(), 1);
+        assert_eq!(primary_index(&roster), 0);
+        assert!(!roster[0].owned, "the primary is a share here, and that is the point");
+    }
+
+    fn source(machine_id: &str, owned: bool, token: &str) -> SourceRef {
+        SourceRef {
+            machine_id: machine_id.into(),
+            name: machine_id.into(),
+            shared_by: if owned { String::new() } else { "afriend".into() },
+            owned,
+            address: "10.0.0.1".into(),
+            port: 32400,
+            token: token.into(),
+        }
+    }
+
+    /// Our own server registers first and is the primary, whatever order plex.tv listed the account
+    /// in — because the registry makes the first registration `current` when nothing is yet, so the
+    /// ordering is what stops a boot coming up pointed at a friend's server and building Home from
+    /// their library.
+    #[test]
+    fn our_own_server_leads_the_roster_however_plex_tv_ordered_it() {
+        let roster = vec![source("share-1", false, "t1"), source("ours", true, "t2"), source("share-2", false, "t3")];
+        assert_eq!(registration_order(&roster), vec![1, 0, 2], "ours first, then plex.tv's own order");
+        assert_eq!(primary_index(&roster), 1);
+
+        // an entry with no credential (or no address) cannot be dialled, so it is not registered —
+        // registering it would put a `Client` in the table that 401s everything asked of it
+        let mut half = roster.clone();
+        half[0].token.clear();
+        half[2].address.clear();
+        assert_eq!(registration_order(&half), vec![1]);
+
+        // a shares-only roster (our own box is off) still yields a primary rather than nothing:
+        // a friend's library is a better app than "no server found"
+        let shares = vec![source("share-1", false, "t1"), source("share-2", false, "t3")];
+        assert_eq!(primary_index(&shares), 0);
+        assert_eq!(registration_order(&shares), vec![0, 1]);
+    }
+
+    /// A profile switch re-keys the WHOLE roster, not just the primary. `accessToken` is per
+    /// (user, server), so the other profile's token on a share is a 401 waiting to happen — and a
+    /// server this profile has not been granted leaves the roster rather than lingering with a
+    /// credential that no longer works.
+    #[test]
+    fn switching_profile_re_keys_every_source_and_drops_the_ones_not_granted() {
+        let roster =
+            vec![source("ours", true, "old-own"), source("share-1", false, "old-share"), source("gone", false, "old-gone")];
+        let rs = vec![
+            resource(r#"{"clientIdentifier":"ours","provides":"server","owned":true,"accessToken":"new-own"}"#),
+            resource(r#"{"clientIdentifier":"share-1","provides":"server","owned":false,"accessToken":"new-share"}"#),
+        ];
+
+        let next = retoken(&roster, &rs);
+        assert_eq!(next.len(), 2, "the un-granted server is gone, not left on a stale token");
+        assert_eq!(next[0].token, "new-own");
+        assert_eq!((next[1].machine_id.as_str(), next[1].token.as_str()), ("share-1", "new-share"));
+        assert_eq!(next[1].shared_by, "afriend", "everything but the token is carried over");
+        assert_eq!(next[1].address, "10.0.0.1", "including the address discovery probed");
+
+        // a resource that came back WITHOUT a token for this profile is not a re-key either
+        let empty = vec![resource(r#"{"clientIdentifier":"ours","provides":"server","accessToken":""}"#)];
+        assert!(retoken(&roster, &empty).is_empty());
+        // and an entry with no identity cannot be re-keyed, and must never match by emptiness
+        let anon = vec![source("", false, "old")];
+        assert!(retoken(&anon, &[resource(r#"{"provides":"server","accessToken":"x"}"#)]).is_empty());
+    }
 }

--- a/rust-modules/src/plex/probe.rs
+++ b/rust-modules/src/plex/probe.rs
@@ -20,7 +20,10 @@
 //! 2. **No plain-HTTP candidate when the owner set `httpsRequired`.** It is their setting; a plain
 //!    request to such a server is a refusal, not a connection.
 //! 3. **Rank local → remote → relay.** The order every Plex client with an order uses. Relay is a
-//!    2 Mbit/s tunnel the server transcodes down to fit: a last resort, never a preference.
+//!    2 Mbit/s tunnel the server transcodes down to fit: a last resort, never a preference. Inside a
+//!    tier, an address this client can actually dial comes first: IPv4 before IPv6, and a numeric
+//!    literal before a HOSTNAME (see [`is_numeric_address`] — the transport has no resolver at all,
+//!    and the measured share lists an unresolvable internal name ahead of the address that answers).
 //!
 //! ## What a real prober must still do (this module cannot)
 //!
@@ -158,6 +161,29 @@ fn host_for_url(address: &str) -> String {
     }
 }
 
+/// Is this address a NUMERIC literal (v4 or v6) rather than a name that needs resolving?
+///
+/// The fourth ranking axis, and it exists for the same reason `Scheme` is ranked at all: this app's
+/// transport has **no name resolution of any kind** — `stream.rs`'s `http_open` builds a
+/// `sockaddr_in` from four decimal octets and there is no `getaddrinfo` in the file — so a hostname
+/// candidate cannot be dialled however well it ranks. It is not hypothetical: the share measured on
+/// 2026-08-11 advertises a custom internal hostname that does not resolve from here at all, and it
+/// is listed BEFORE the public IPv4 that answers. Ranking it above a numeric address spends the
+/// first probe slot on a name that cannot resolve.
+///
+/// A hostname is not DROPPED, because it is the only form that can ever carry TLS validation (an
+/// https `plex.direct` origin is a name by construction) — it is merely ranked behind the addresses
+/// that can be dialled today, which is exactly the treatment IPv6 already gets.
+/// Judged on the CONNECTION's `address`, which is what the current transport dials — not on the
+/// host inside an advertised `uri`. For an https candidate those differ (the `uri` host is always a
+/// `plex.direct` NAME, whatever the address is), so this ranks such a candidate by the address it
+/// stands for. That is the right axis while https cannot be dialled at all; a TLS transport that
+/// ranks by URL host would want its own key here.
+fn is_numeric_address(a: &str) -> bool {
+    a.contains(':') // a v6 literal — colons cannot appear in a hostname
+        || (a.split('.').count() == 4 && a.split('.').all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())))
+}
+
 /// Every address of `res` that policy allows, best first.
 ///
 /// Each surviving connection yields its advertised `uri` (verbatim — the `plex.direct` hostname's
@@ -198,8 +224,8 @@ pub fn candidates(res: &Resource) -> Vec<Candidate> {
         }
     }
     // Stable, so plex.tv's own order survives inside a tier — it is the only tiebreak left once
-    // location, scheme and address family have spoken, and it is not ours to reorder.
-    out.sort_by_key(|c| (c.location, c.scheme, c.ipv6));
+    // location, scheme, address family and resolvability have spoken, and it is not ours to reorder.
+    out.sort_by_key(|c| (c.location, c.scheme, c.ipv6, !is_numeric_address(&c.address)));
     out
 }
 
@@ -286,6 +312,29 @@ mod tests {
         assert!(cs.iter().all(|c| c.location == Location::Remote), "a share has no local tier here");
         // and http outranks https for now, because https is the one this app cannot dial yet
         assert_eq!(cs[0].scheme, Scheme::Http);
+    }
+
+    /// **A hostname ranks behind a numeric address**, and the share is the live case: plex.tv lists
+    /// the owner's internal name (`media.example.internal`, which does not resolve from here)
+    /// BEFORE the public IPv4 that answered in 115 ms. This client's transport has no resolver at
+    /// all, so ranking the name first spends the first probe slot proving that.
+    ///
+    /// It is ranked, not dropped — a name is the only thing TLS can validate, so it has to survive
+    /// for the curl transport to use later.
+    #[test]
+    fn a_hostname_ranks_behind_an_address_that_can_actually_be_dialled() {
+        let cs = candidates(&shared_server());
+        let http: Vec<&Candidate> = cs.iter().filter(|c| c.scheme == Scheme::Http).collect();
+
+        assert_eq!(http[0].address, "203.0.113.9", "the numeric address leads its tier: {cs:#?}");
+        assert_eq!(http[1].address, "media.example.internal", "the name is kept, just not first");
+        assert!(
+            cs.iter().any(|c| c.address == "media.example.internal" && c.scheme == Scheme::Https),
+            "and its https uri survives for the TLS transport: {cs:#?}"
+        );
+
+        assert!(is_numeric_address("203.0.113.9") && is_numeric_address("2001:db8::1"));
+        assert!(!is_numeric_address("media.example.internal"));
     }
 
     /// A friend on our own LAN (Plex Home, or a share while visiting) is the case rule 1 must not

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -3,7 +3,21 @@
 //! and the profile's token are written here, so every later boot connects straight to the LAN
 //! server over plain HTTP with no internet needed. Lives in the writable app dir (device-only;
 //! never in the repo). The token fields are secrets — this file's contents are never logged.
-use serde::{Deserialize, Serialize};
+//!
+//! ## One server, and then the ROSTER
+//!
+//! [`Session::server`] is still the primary — the one address `can_go_local` runs on and the one
+//! `app.rs` boots against — and it is untouched. Beside it, [`Session::sources`] records **every**
+//! server discovery reached, ours and every share, each with its own address and its own
+//! per-(user, server) token, because a shared server is a separate authority that answers 401 to
+//! anybody else's credential (`docs/shared-servers.md` §2b). A single-server account writes one
+//! entry there and behaves exactly as it always has.
+//!
+//! **Nothing here carries a timestamp**, deliberately: this TV's wall clock runs ~3 h skewed
+//! (root `CLAUDE.md`), so a stored "last seen" would be a number that cannot be compared with
+//! anything and would invite an expiry rule built on it.
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Mutex;
 
 /// The signed-in profile, in-memory for the UI (the Home profile chip reads this). Set by the boot
@@ -58,26 +72,55 @@ pub struct Session {
     pub user: UserRef,
     /// The Plex Home roster as of the last successful fetch — lets the who's-watching picker
     /// render instantly on every boot (and offline) instead of waiting on a plex.tv round-trip.
-    #[serde(default)]
+    ///
+    /// Soft-parsed for the same reason [`Session::sources`] is: one managed user whose stored
+    /// `thumb` came back as a JSON `null` would otherwise fail the whole `Session` and sign the
+    /// device out on every boot, to fix an avatar.
+    #[serde(default, deserialize_with = "de_soft_vec")]
     pub home_users: Vec<HomeUserRef>,
+    /// **Every server this identity can browse**, as of the last successful discovery — ours and
+    /// each share, best-address-first per entry. Additive: [`Session::server`] stays the primary,
+    /// and this list holds it too (as the `owned` entry) so a reader needs only one surface.
+    ///
+    /// Soft-parsed (see [`de_soft_vec`]) — a corrupt or unreadable entry costs that entry, never
+    /// the `Session`, because failing the whole file here is a silent sign-out at every boot for
+    /// a feature nobody has used yet.
+    #[serde(default, deserialize_with = "de_soft_vec")]
+    pub sources: Vec<SourceRef>,
+    /// Which libraries the user chose to see **on Home**. Browsing is governed by the grant, not
+    /// by this: pinning is the only *setting* of the three states a source has (granted / pinned /
+    /// reachable — `docs/shared-servers.md` §6).
+    ///
+    /// **Empty means "never chosen", not "none pinned"** — the same trap `home_users` documents.
+    /// A reader that finds it empty must fall back to its own default (our own server's
+    /// libraries), never draw an empty Home.
+    #[serde(default, deserialize_with = "de_soft_vec")]
+    pub pinned: Vec<PinnedLib>,
 }
 
 /// One persisted who's-watching tile (avatar + PIN flag; no tokens live here).
+///
+/// `#[serde(default)]` on the CONTAINER, so a missing field costs that field. Per-field it covered
+/// only the two flags, which meant a tile written by a build that did not have `thumb` yet — or one
+/// hand-edited on the TV — failed the whole `Session`, i.e. signed the device out. The same
+/// reasoning applies to every struct in this file: it is a file we read on the boot path, and the
+/// cost of one unexpected shape must never be the credentials.
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)]
 pub struct HomeUserRef {
     pub uuid: String,
     pub title: String,
     pub thumb: String,
-    #[serde(default)]
     pub protected: bool,
-    #[serde(default)]
     pub admin: bool,
 }
 
-/// The chosen server's LAN coordinates. `address`:`port` is reached over plain HTTP by the existing
-/// PMS socket (offline-capable); `token` is the owner's server access token (fallback when no
-/// managed-user token is set).
+/// The PRIMARY server's coordinates — the one `can_go_local` boots on. `address`:`port` is reached
+/// over plain HTTP by the existing PMS socket (offline-capable); `token` is that server's access
+/// token (fallback when no managed-user token is set). Every server, including this one, is also
+/// in [`Session::sources`].
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)] // a missing field costs that field, never the session — see [`HomeUserRef`]
 pub struct ServerRef {
     pub name: String,
     pub machine_id: String,
@@ -86,15 +129,96 @@ pub struct ServerRef {
     pub token: String,
 }
 
+/// One server this identity can browse — our own or a friend's share. What discovery resolved:
+/// the identity to key it on, the address that actually **answered**, and the credential that
+/// server accepts.
+///
+/// Deliberately NOT `Debug`: `token` is a live per-(user, server) PMS access token, and a derived
+/// `Debug` is exactly how a secret reaches a log by accident (`dev::DevServer` says the same).
+/// [`SourceRef::describe`] is the only formatter, and it prints everything but the token.
+#[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct SourceRef {
+    /// `machineIdentifier` — the ONLY stable identity, and the registry key. An address moves
+    /// (LAN ↔ remote, DHCP, relay); this does not.
+    pub machine_id: String,
+    /// The machine name ("friend-nas"). Settings surfaces only — a person is named by `shared_by`.
+    pub name: String,
+    /// The OWNER's plex.tv handle (`sourceTitle`), empty on our own server. The one string the
+    /// browsing UI ever says about a share: "Shared by afriend".
+    pub shared_by: String,
+    /// False ⇒ shared with us. A preference (ours sorts first, ours is `current`), never a wall.
+    pub owned: bool,
+    /// The address that answered `/identity` with the right `machineIdentifier` — not the first
+    /// one advertised. A share's `local` address is the OWNER's LAN and is never this.
+    pub address: String,
+    pub port: i64,
+    /// This identity's per-(user, server) `accessToken` for THIS server. A secret — never logged.
+    /// Our own server's token gets a 401 from a share, which is why one token cannot serve both.
+    pub token: String,
+}
+
+impl SourceRef {
+    /// Everything about this source except the token, for the event log. The machine id is left
+    /// out entirely — it is a permanent household fingerprint (`ui::stats`), and the event log is
+    /// the file we ask users to send us.
+    pub fn describe(&self) -> String {
+        let who = if self.owned { "ours".to_string() } else { format!("shared by {}", self.shared_by) };
+        format!("{:?} {}:{} ({who})", self.name, self.address, self.port)
+    }
+    /// Enough to dial: an address, a port, and the credential that server accepts.
+    pub fn usable(&self) -> bool {
+        !self.address.is_empty() && self.port > 0 && !self.token.is_empty()
+    }
+}
+
+/// One library the user pinned to Home, named the only way a library CAN be named across two
+/// servers: the server's machine id plus that server's own section key. Section keys are
+/// server-local integers starting at 1 — both servers in the measured pair have a section `1`
+/// (`docs/shared-servers.md` §2), so a bare key identifies nothing.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(default)]
+pub struct PinnedLib {
+    pub machine_id: String,
+    pub key: i64,
+}
+
 /// The last-selected Plex Home user. `token` is the per-user token PMS scopes watch state by — it
 /// keeps working against the LAN server offline once cached here.
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)] // a missing field costs that field, never the session — see [`HomeUserRef`]
 pub struct UserRef {
     pub id: i64,
     pub uuid: String,
     pub title: String,
     pub thumb: String,
     pub token: String,
+}
+
+/// A list that degrades **element by element** instead of taking the whole [`Session`] with it.
+///
+/// `#[serde(default)]` covers a field that is ABSENT. It does not cover one that is present and
+/// the wrong shape — a `null`, a string where an array belongs, one entry whose `port` was
+/// hand-edited to `"32400"` — and any of those fails the enclosing struct. For a `Session` that
+/// failure is not "the roster is empty": [`peek`] then finds no candidate that parses, `load`
+/// mints a fresh `client_id`, and the user is signed out and re-scanning a QR code on every boot,
+/// for a stale list nothing had read yet.
+///
+/// So: decode to a `Value` (which for JSON can only fail on input the whole file would fail on),
+/// keep the entries that are the right shape, and drop the ones that are not.
+fn de_soft_vec<'de, D, T>(d: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    let Ok(v) = serde_json::Value::deserialize(d) else { return Ok(Vec::new()) };
+    Ok(match v {
+        serde_json::Value::Array(items) => {
+            items.into_iter().filter_map(|it| serde_json::from_value::<T>(it).ok()).collect()
+        }
+        // a null, an object, a string: not a list, so there is no list. Not an error.
+        _ => Vec::new(),
+    })
 }
 
 impl Session {
@@ -104,12 +228,36 @@ impl Session {
     }
     /// The token PMS calls use: the switched managed-user token if we have one, else the server
     /// access token (owner).
+    ///
+    /// **This is the PRIMARY server's token and no other's.** A share is a separate authority and
+    /// answers 401 to it; its own credential is [`SourceRef::token`], keyed by machine id.
     pub fn pms_token(&self) -> &str {
         if !self.user.token.is_empty() {
             &self.user.token
         } else {
             &self.server.token
         }
+    }
+
+    /// One source by `machineIdentifier` — the only key that identifies a server.
+    pub fn source(&self, machine_id: &str) -> Option<&SourceRef> {
+        if machine_id.is_empty() {
+            return None; // an unknown id must not match the entries that have none either
+        }
+        self.sources.iter().find(|s| s.machine_id == machine_id)
+    }
+    /// Our own server's entry in the roster, if discovery reached one.
+    pub fn owned_source(&self) -> Option<&SourceRef> {
+        self.sources.iter().find(|s| s.owned)
+    }
+    /// The shares — every source that is not ours, in discovery order.
+    pub fn shared_sources(&self) -> impl Iterator<Item = &SourceRef> {
+        self.sources.iter().filter(|s| !s.owned)
+    }
+    /// Has the user pinned this library to Home? See [`Session::pinned`] on why an EMPTY list is
+    /// "never chosen" and must not be read as "nothing is pinned".
+    pub fn is_pinned(&self, machine_id: &str, key: i64) -> bool {
+        self.pinned.iter().any(|p| p.machine_id == machine_id && p.key == key)
     }
 }
 
@@ -263,5 +411,126 @@ impl Session {
             can_switch: !self.account_token.is_empty(),
             name,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The file a signed-in device holds today, once discovery has reached two servers. Written
+    /// as literal JSON rather than by serialising a `Session`, because the thing under test is
+    /// what happens when the bytes on disk are not what this build expects.
+    fn two_server_json() -> &'static str {
+        r#"{"client_id":"cid-1","account_token":"acct",
+            "server":{"name":"Mac mini","machine_id":"aaaa1111","address":"192.168.0.10",
+                      "port":32400,"token":"tok-own"},
+            "user":{"id":7,"uuid":"u-7","title":"Gleb","thumb":"","token":"tok-user"},
+            "home_users":[{"uuid":"u-7","title":"Gleb","thumb":"","protected":false,"admin":true}],
+            "sources":[
+              {"machine_id":"aaaa1111","name":"Mac mini","shared_by":"","owned":true,
+               "address":"192.168.0.10","port":32400,"token":"tok-own"},
+              {"machine_id":"bbbb2222","name":"friend-nas","shared_by":"afriend","owned":false,
+               "address":"203.0.113.9","port":31234,"token":"tok-share"}],
+            "pinned":[{"machine_id":"bbbb2222","key":1}]}"#
+    }
+
+    /// The roster survives a write/read cycle intact — including the two facts that make a share
+    /// usable at all: its OWN address (never the owner's LAN one) and its OWN token.
+    #[test]
+    fn the_roster_round_trips_through_the_session_file_format() {
+        let s: Session = serde_json::from_str(two_server_json()).expect("a normal session parses");
+        let s: Session = serde_json::from_slice(&serde_json::to_vec(&s).unwrap()).expect("re-read");
+
+        assert_eq!(s.sources.len(), 2);
+        let own = s.owned_source().expect("our own server is in the roster");
+        assert_eq!((own.machine_id.as_str(), own.address.as_str()), ("aaaa1111", "192.168.0.10"));
+        assert!(own.shared_by.is_empty(), "an owned server has no owner to name");
+
+        let share = s.source("bbbb2222").expect("keyed by machineIdentifier, not by index");
+        assert_eq!((share.address.as_str(), share.port), ("203.0.113.9", 31234));
+        assert_eq!(share.token, "tok-share", "the sharing grant, not the account token");
+        assert_eq!(share.shared_by, "afriend");
+        assert!(!share.owned && share.usable());
+        assert_eq!(s.shared_sources().count(), 1);
+
+        assert!(s.is_pinned("bbbb2222", 1));
+        // section keys are server-local: both servers have a section 1, so the key alone matches
+        // nothing on its own
+        assert!(!s.is_pinned("aaaa1111", 1), "a pin names a server AND a key");
+        assert!(s.source("").is_none() && s.source("nope").is_none());
+
+        // and the token is not printable by accident — `describe` is the only formatter there is
+        assert!(!share.describe().contains("tok-share"), "{}", share.describe());
+        assert!(share.describe().contains("afriend") && share.describe().contains("203.0.113.9"));
+    }
+
+    /// **The sign-out bug this list is shaped to avoid.** A `sources` array that is corrupt, the
+    /// wrong type, or absent entirely must cost the roster and nothing else — `#[serde(default)]`
+    /// alone does not do that, because it covers an ABSENT field and not a present, malformed one,
+    /// and the failure mode is not "an empty roster" but a `Session` that will not parse: no
+    /// account token, no server, a freshly minted client id, and a QR code to scan on every boot.
+    #[test]
+    fn a_corrupt_or_absent_roster_never_costs_the_session() {
+        // one entry with a hand-mangled port, beside a perfectly good one
+        let mixed = r#"{"client_id":"cid-1","account_token":"acct",
+            "server":{"name":"m","machine_id":"aaaa1111","address":"192.168.0.10","port":32400,"token":"t"},
+            "sources":[{"machine_id":"aaaa1111","port":{"oops":true}},
+                       {"machine_id":"bbbb2222","name":"friend-nas","owned":false,
+                        "address":"203.0.113.9","port":31234,"token":"tok-share"}],
+            "pinned":"not a list"}"#;
+        let s: Session = serde_json::from_str(mixed).expect("a bad entry must not fail the file");
+        assert_eq!(s.account_token, "acct", "the credentials are still here");
+        assert!(s.can_go_local(), "and the device can still stream");
+        assert_eq!(s.sources.len(), 1, "the malformed entry dropped, the good one landed");
+        assert_eq!(s.sources[0].machine_id, "bbbb2222");
+        assert!(s.pinned.is_empty(), "a string where a list belongs is no list, not an error");
+
+        // the whole field as an explicit null, and the whole field missing (every session file
+        // written before this landed) — both are simply a session with no roster yet
+        for json in [
+            r#"{"client_id":"c","server":{"address":"192.168.0.10","port":32400,"token":"t"},"sources":null}"#,
+            r#"{"client_id":"c","server":{"address":"192.168.0.10","port":32400,"token":"t"}}"#,
+        ] {
+            let s: Session = serde_json::from_str(json).expect("null and absent both parse");
+            assert!(s.sources.is_empty() && s.pinned.is_empty());
+            assert!(s.can_go_local(), "the primary server is what boot runs on, roster or not");
+        }
+    }
+
+    /// One server must behave exactly as it did before the roster existed: the primary
+    /// `server`/`user` pair is what `can_go_local` and `pms_token` read, and the roster is a
+    /// record beside it, never a second source of truth that could disagree.
+    #[test]
+    fn a_single_server_session_behaves_as_it_always_has() {
+        let mut s: Session = serde_json::from_str(
+            r#"{"client_id":"cid-1","account_token":"acct",
+                "server":{"name":"Mac mini","machine_id":"aaaa1111","address":"192.168.0.10",
+                          "port":32400,"token":"tok-own"},
+                "sources":[{"machine_id":"aaaa1111","name":"Mac mini","owned":true,
+                            "address":"192.168.0.10","port":32400,"token":"tok-own"}]}"#,
+        )
+        .unwrap();
+        assert!(s.can_go_local());
+        assert_eq!(s.pms_token(), "tok-own", "no managed user picked yet → the server token");
+        s.user.token = "tok-user".into();
+        assert_eq!(s.pms_token(), "tok-user", "a switched profile's token wins, as before");
+        // the roster agrees with the primary rather than competing with it
+        assert_eq!(s.owned_source().map(|x| x.address.as_str()), Some(s.server.address.as_str()));
+        assert_eq!(s.shared_sources().count(), 0);
+        assert!(s.account(None).signed_in && s.account(None).can_switch);
+    }
+
+    /// The roster's own leniency must not weaken the roster the picker draws from: a managed user
+    /// whose stored `thumb` is a `null` costs that user, not the session.
+    #[test]
+    fn a_malformed_home_user_costs_that_tile_and_not_the_session() {
+        let s: Session = serde_json::from_str(
+            r#"{"client_id":"c","home_users":[{"uuid":"a","title":"A","thumb":null},
+                                              {"uuid":"b","title":"B","thumb":"","admin":true}]}"#,
+        )
+        .expect("one bad tile must not fail the file");
+        assert_eq!(s.home_users.len(), 1);
+        assert_eq!(s.account(None).name.as_deref(), Some("B"));
     }
 }


### PR DESCRIPTION
Unit: **Discovery & roster** — the gate on the whole shared-servers feature. If this picks the wrong
connection, no other unit's work is reachable however correct it is.

## What changed

`auth.rs`'s `discover_and_store` kept exactly ONE server and threw the rest of the account away:
both of its passes filtered on `c.local && !c.relay`. Against a real share that is worse than
useless — `Connection.local` means "this address is RFC1918", not "you are on that LAN" — so it
selected the *owner's* `<owner-lan-ip>`: 8 s of timeout from here, and the worse outcome is that it
succeeds, against whatever else sits at that address on our own LAN.

It is now real discovery:

- **Every** resource that `provides` a server, ours and each share, is turned into ranked candidates
  by `plex::probe` and dialled in order.
- The probe is `GET /identity`, **unauthenticated on purpose** and with the token deliberately not
  sent: a probe can land on a machine that is not the one we asked for, and that machine must never
  be handed a live credential.
- The answer is **verified** — its `machineIdentifier` must equal the resource's `clientIdentifier`
  before the connection is accepted. Anything else is discarded and the next address tried.
- **401 is its own state**, never "unreachable" — but it ends the **candidate**, not the server.
  Because the probe is unauthenticated, a 401 is not that server refusing our credential; it is
  whatever is listening refusing an anonymous request, and that need not be the server at all. Only
  a clean sweep — every dialable address refusing — is reported as a refusal.
- **BACK during discovery stops it.** Dialling holds sockets (2 s a handshake, 15 s on a peer that
  connects then says nothing), so the worker can outlive the screen. `cancel` is only a phase flip,
  so discovery polls for it between servers and again immediately before it touches anything global
  — registering would retarget `client()` out from under the Home the user had gone back to, and the
  session write would clobber the session `cancel` had just restored.
- Everything that answered is `register`ed with its **real machine id** and its **own**
  per-(user, server) token. Our own server stays `current`.
- The roster is persisted in `session.rs` as `sources` (+ a `pinned` list for Home), beside the
  primary `ServerRef`, which is written exactly as before.

Single-server behaviour is unchanged by construction: the same `ServerRef` is written, plus a
one-entry roster nothing is obliged to read.

## Notable decisions

- **Sequential probing, not parallel.** `stream.rs` bounds a handshake at 2 s, the dialable list is
  short (policy has already dropped the owner's LAN address, and this client cannot speak to the
  https/hostname candidates), and it runs on the login worker behind a spinner. Racing would buy a
  couple of seconds for N threads that each have to capture at the spawn site.
- **Discovery does not, and cannot, prove the token works** — `/identity` answers 200 to anybody. A
  grant revoked since the `/resources` fetch still probes as reachable and surfaces on the first
  authenticated request. That limit is stated where the probe path is defined rather than papered
  over; an authenticated second probe was considered and rejected because a transient failure
  between two requests would then drop a good server from the roster.
- **The failure copy is now per outcome, not one line.** "No local Plex server found on this network."
  was the old *policy* talking — a server reached over the internet was a failure by construction,
  so the message named the LAN.
- **A profile switch re-keys the whole roster** from the `/resources` response it already fetches
  (`accessToken` is per (user, server), so a share left on the previous profile's token 401s
  everything). Computed before the switch is known to have worked, applied only on success —
  persisting a roster re-keyed for a profile we did not switch to would delete the user's shares
  from disk.

## The two items the coordinator forwarded

**1. Unit 14's IPv6 fix (`choose_local_connection`, PR #25).** This PR deletes that chooser — it is
the legacy selector being replaced — and makes its property **structural instead of a filter that
can be forgotten**: nothing but a *dialable* candidate (plain HTTP to four decimal octets, all
`stream.rs` can build a `sockaddr_in` from) is ever dialled, and only a candidate that **answered**
becomes a stored source. An address can therefore only be persisted after it has been connected to.
Carried over with its own test — `only_an_address_this_transport_can_dial_is_ever_chosen_and_stored`
— including unit 14's sharpest case: an address bearing colons whose `IPv6` flag lies and says
`false`.

*Merge note:* if #25 lands first, resolve by **deleting `choose_local_connection` and its two
tests**; the property they pin is asserted by the test named above.

**2. `probe.rs` had no numeric-vs-hostname tiebreak.** Added as the fourth ranking axis: inside a
tier, a numeric literal outranks a **hostname**. The transport has no resolver at all, and this
account's share lists an internal name that does not resolve ahead of the public address that
answers in 115 ms. Ranked, not dropped — a name is the only thing TLS can ever validate.
Test: `a_hostname_ranks_behind_an_address_that_can_actually_be_dialled`.

## Also hardened while the file was open

Every struct in `session.rs` takes `#[serde(default)]` on the **container**, and the three list
fields decode element by element. `#[serde(default)]` covers a field that is ABSENT, not one present
and the wrong shape — and for this file the cost of that difference is not an empty roster, it is a
`Session` that will not parse: a silent sign-out and a QR code to scan on every boot. `ServerRef`
had no per-field defaults at all, so a session file missing one field already failed the whole parse.

## Tests

`make check` green **3/3 runs**, 433 passing (was 428 at the base). `make` (ARM cross-build) links.
`code-review` run **twice**; every finding in this unit's files fixed. From pass 1: a roster wiped
by a *failed* profile switch, and a plex.tv fetch failure reported as "this account has no server".
From pass 2, both of which changed behaviour rather than wording:

- **BACK during discovery could clobber the resumed session** — the cancel guard was checked before
  a step that used to be a single HTTPS fetch and now holds sockets for seconds, and everything after
  it is global (`register`, `set_current`, the session write).
- **A single 401 abandoned the whole server**, skipping its other advertised addresses. The probe is
  unauthenticated, so that 401 is not evidence about the server's credential at all — DHCP moves the
  PMS, a NAS answers 401 at the old address, and the user's own server is dropped without the second
  address ever being tried.

Also from pass 2: the `Refused` copy said "your Plex server" for a refusal any server can raise, and
the profile-switch token fallback took the *first* server in the response when it had no machine id
to match on — which now hands a share's token to the primary, since plex.tv lists shares first.

New host tests, all pure:

| test | pins |
|---|---|
| `a_sign_in_to_a_two_server_account_settles_on_one_address_each_ours_first` | the whole of discovery over the measured account, socket faked |
| `the_three_empty_outcomes_are_distinguished` | NoServers / Silent / Refused, and a share-only sign-in |
| `a_response_from_the_wrong_machine_is_rejected_and_the_next_address_is_tried` | identity verified before acceptance |
| `a_401_moves_to_the_next_address_and_only_a_clean_sweep_is_a_refusal` | 401 is its own state, and costs one address not the server |
| `a_flow_that_moved_on_mid_dial_registers_nothing_and_stores_nothing` | BACK during discovery mutates no global |
| `only_addresses_this_transport_can_dial_are_ever_probed` | the owner's LAN / hostname / TLS candidates never dialled |
| `only_an_address_this_transport_can_dial_is_ever_chosen_and_stored` | unit 14's v6 property |
| `the_machine_identifier_is_read_from_json_and_from_xml_alike` | PMS answers XML unless the JSON Accept survives |
| `our_own_server_leads_the_roster_however_plex_tv_ordered_it` | registration order (the registry makes the FIRST registration current) |
| `switching_profile_re_keys_every_source_and_drops_the_ones_not_granted` | per-(user, server) tokens |
| `the_roster_round_trips_through_the_session_file_format` | persistence |
| `a_corrupt_or_absent_roster_never_costs_the_session` | the silent-sign-out class |
| `a_single_server_session_behaves_as_it_always_has` | no behaviour change on one server |
| `a_malformed_home_user_costs_that_tile_and_not_the_session` | same class, existing field |
| `a_hostname_ranks_behind_an_address_that_can_actually_be_dialled` | the probe.rs tiebreak |

## One integration line this PR cannot add

`auth::install_stored_roster(&session)` registers the persisted roster on a resumed session. It is
called from `start_switch`, which covers the boot picker and every "Change profile". The one path it
does **not** cover is `app.rs`'s straight-to-Home boot (a stored session with a single Plex Home
user, or any automated run), which installs the primary itself and never enters `auth`. `app.rs` is
outside this unit's file scope, so it needs one line beside its `install_pms`:

```rust
crate::auth::install_stored_roster(&session);
```

Without it, shares are registered only from the sign-in / picker paths.

## Device verification — deferred to coordinator

**Nothing here is verified on device.** I took an `--fps` run before the fleet-wide lock correction;
it showed the contention signature (6 failures, every one "scene never entered this screen") and is
**void** — not reported as a pass or a failure.

This unit's effect is in the **event log**, not on a frame: discovery runs during sign-in, and the
shared-source UI (Source chip, shelf annotation) belongs to sibling units. So the recipe below reads
the log and the roster, and uses the screen only as a liveness check.

### A. The one that actually exercises discovery (needs a human with a phone, once)

Discovery only runs on the **login** path, so it needs a real QR sign-in.

```sh
ssh root@$TV 'rm -f /tmp/plxnative-events.log; touch /tmp/plxnative-login'   # forces the QR screen
make deploy && make run RUN_SECS=120
# scan the QR with the Plex app and authorize
```

**A correct log carries these lines, in this order** (`<share-ip>` = the share's public IPv4,
`<lan>` = our server's LAN IPv4):

```
auth: authorized — discovering server
auth: resources n=<N> servers=2
auth: reached "<our server>" <lan>:32400 (ours)
auth: reached "<share-name>" <share-ip>:<share-port> (shared by <friend-handle>)
auth: 2 server(s) reached, primary '<our server>'
plex: server slot 0 registered at <lan>:32400
plex: server slot 1 registered at <share-ip>:<share-port>
auth: PMS client installed <lan>:32400
```

**The negatives matter more than the positives.** None of these may appear:

- any address starting `<owner-lan-prefix>` — that is the *owner's* LAN, and dialling it is the 8-second trap;
- an 8+ second gap between `authorized — discovering server` and `2 server(s) reached` (timestamps
  are `SDL_GetTicks` ms; the two dials should total well under 2 s on a healthy LAN);
- `answered as a DIFFERENT machine` — if this appears, an address is being answered by something
  that is not the server, and the verification is doing its job; report the line;
- a v6 literal or a hostname anywhere in a `reached`/`registered` line.

`auth: '<name>' did not answer (N address(es) tried, M not dialable)` is **not** a failure on its
own — it is expected for any server that is genuinely off. It is a failure only if it names a server
you know is up.

### B. What the persisted roster must contain (no sign-in needed once A has run once)

Reads the session file **without printing a token**:

```sh
ssh root@$TV 'grep -o "\"machine_id\":\"[^\"]*\"\|\"address\":\"[^\"]*\"\|\"port\":[0-9]*\|\"owned\":[a-z]*\|\"shared_by\":\"[^\"]*\"" /media/developer/com.beb.plxnative-auth.json'
```

Expected for this account — **two** sources, **ours first**:

| # | `owned` | `shared_by` | address it must have settled on |
|---|---|---|---|
| 0 | `true` | `""` | our server's **LAN IPv4**, port 32400 — *not* the IPv6 literal plex.tv also offers |
| 1 | `false` | `<friend-handle>` | the share's **public IPv4**, port <share-port> — *not* `<owner-lan-ip>`, *not* the internal hostname |

Two **distinct** tokens (check the count, not the values:
`grep -c '"token"' …` should be ≥ 3 — one per source plus the primary `ServerRef`).

### C. Resumed-session boot (proves the roster survives a reboot)

```sh
ssh root@$TV 'rm -f /tmp/plxnative-events.log /tmp/plxnative-login'
make run RUN_SECS=30
```

With a multi-user Plex Home, the boot picker path logs
`auth: roster restored — 2 server(s) registered`. **On a single-user account it will NOT appear** —
that is the missing `app.rs` line above, not a regression.

### D. Liveness (a frame, weak evidence, 20 s)

`tools/capture-screen.sh out.png DISPLAY` after a resumed-session boot. A correct frame is just
**today's Home**: the top tab bar, the hero at the top, poster shelves below with real titles and
artwork. Nothing about shared sources is drawn yet by this unit — if Home populates as it always
did, this unit has not broken the single-server path, which is all a frame can say here.


