### PR TITLE
strip: the tab projection needs a real type, or a friend's Music has no pill

### DIFF
--- a/docs/pms-api.md
+++ b/docs/pms-api.md
@@ -32,8 +32,11 @@ Verified response (trimmed):
   {"key":"3","type":"artist","title":"Music",    "uuid":"332590ad-..."}]}}
 ```
 
-**Section keys on this server: Movies = `1`, TV Shows = `2`** (Music = `3`, ignore for now).
-Select sections by `Directory[].type == "movie" | "show"`, not by hard-coded key.
+**Section keys on this server: Movies = `1`, TV Shows = `2`, Music = `3`.** Select sections by
+`Directory[].type`, never by hard-coded key — and note the app no longer filters that type down to
+`movie`/`show`: `artist` and `photo` are kept too (`browse::SecKind`), because the top strip's
+projection can only give a friend's shared MUSIC library a pill if the type reaches the table at
+all. "Ignore music for now" was true while the strip named one server's movie and show sections.
 
 ---
 

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -899,7 +899,9 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
             fn select_pill(&self) -> Option<usize> {
                 match self {
                     Nav::Home { .. } => Some(0),
-                    Nav::Library(sec) => Some(sec + 1),
+                    // a TAB index, not a section index: the strip is a projection of the table
+                    // (`browse::tabs`), so `+1` here is only the Home pill leading the row
+                    Nav::Library(tab) => Some(tab + 1),
                     Nav::Open { .. } | Nav::Back { .. } => None,
                 }
             }
@@ -3485,7 +3487,9 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                     }
                     Route::Detail => nav_back(route, &trail, &mut nav_pending),
                     Route::Home => nav_to(route, Nav::Library(0), &mut nav_pending),
-                    // pill 1 is that same first section: Home comes back in the hero view with the
+                    // pill 1 is that same first TAB — not "the first section", which stopped being
+                    // the same thing when the strip became a projection of the table (`browse::tabs`):
+                    // several libraries can share one pill. Home comes back in the hero view with the
                     // top band on the pill the round trip started from, so the scene is a loop
                     Route::Library => nav_to(route, Nav::Home { focus_pill: Some(1) }, &mut nav_pending),
                     _ => {}

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -872,7 +872,10 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
             /// always the Home pill). One word for both is why they were named apart: on the way
             /// back from the Library the selection moves to Home while focus stays on `Movies`.
             Home { focus_pill: Option<usize> },
-            /// the Library browse grid on section `sec` (0-based)
+            /// The Library browse grid on TAB `tab` (0-based, Home excluded — the strip prepends
+            /// it). A tab, not a section: the strip is a projection of the section table
+            /// (`browse::tabs`), so several libraries can share one pill and `browse::tab_section`
+            /// is what resolves this to the library that opens.
             Library(usize),
             /// A page that STACKS — a detail page or a person page. The [`Node`] is BOTH what
             /// mounts at the floor (through the very `enter_node` a BACK pop uses, whose re-open

--- a/rust-modules/src/browse.rs
+++ b/rust-modules/src/browse.rs
@@ -57,11 +57,11 @@ const SRC_RETRY_CD: u32 = 600; // ~10 s at 60 fps
 pub(crate) struct BrowseSource {
     /// The registry slot every fetch for this source's sections is issued through.
     pub(crate) sid: ServerId,
-    /// The MACHINE name ("bx23-ldn") — the Sources list's group header, and the only place in the
+    /// The MACHINE name ("nas-home") — the Sources list's group header, and the only place in the
     /// app a machine is named. Learned from the roster, else from the server naming itself
     /// (`Client::friendly_name`); `""` until one of those lands.
     pub(crate) name: String,
-    /// The owner's plex.tv handle ("bamx23"); **empty on your own server**, where the absence of an
+    /// The owner's plex.tv handle ("friend"); **empty on your own server**, where the absence of an
     /// owner is drawn as the absence of a run rather than as an empty one.
     pub(crate) handle: String,
     /// Did it ANSWER? One of the design's three orthogonal states — *granted* (the roster's
@@ -87,7 +87,11 @@ pub(crate) struct BrowseSection {
     pub(crate) src: usize,
     pub(crate) key: i64,
     pub(crate) title: String,
-    pub(crate) is_show: bool,
+    /// The library's TYPE. A real type and not the `is_show: bool` this replaced, because the tab
+    /// projection asks "does any owned library have this KIND" ([`tabs`]) — and with two values that
+    /// question cannot tell Music from Movies, so a friend's music library would fold onto your
+    /// *Movies* pill, which is the one case the projection exists to get right.
+    pub(crate) kind: SecKind,
     /// The library's own item count, unfiltered — the Sources row's "185 films". `-1` until the
     /// count probe lands. Deliberately NOT [`SecState::total`], which is the count of the CURRENT
     /// QUERY: with an unwatched filter on, that number describes what you are looking at and would
@@ -279,7 +283,7 @@ struct SrcLanding {
 enum SrcWhat {
     /// `GET /library/sections`. `None` is the FAILURE sentinel — the source is marked unreachable
     /// and whatever sections it had already contributed are left exactly where they are.
-    Sections(Option<Vec<(i64, String, bool)>>),
+    Sections(Option<Vec<(i64, String, SecKind)>>),
     /// The unfiltered item count per library, **by section KEY** rather than by index: the table
     /// may have grown between the spawn and the landing, and a key is stable inside one source.
     Counts(Vec<(i64, i64)>),
@@ -437,21 +441,73 @@ pub(crate) fn ensure_sections() -> usize {
     sections().len()
 }
 
-/// `MediaContainer.Directory[]` → the (key, title, is_show) rows this app can browse. The ONE
+/// `MediaContainer.Directory[]` → the (key, title, kind) rows this app can browse. The ONE
 /// projection, shared by the blocking discovery above and the worker below, so the two can never
 /// disagree about which sections exist.
-fn project_sections(mc: &crate::plex::MediaContainer) -> Vec<(i64, String, bool)> {
+///
+/// `artist`/`photo` are KEPT. They used to be dropped here as "not browsable", and that quietly
+/// disabled the one growth case the tab projection is written for: a friend sharing a type you do
+/// not own can only add a pill if that type reaches the table at all. They browse like any other
+/// section (the listing, its server-driven sorts and the A–Z rail are type-agnostic), and this
+/// account's own `/hubs` already puts a *Recently Added Music* shelf on Home, so the content was at
+/// the top level before it had a tab. What is still missing is the level BELOW the grid — an artist
+/// opens the movie detail page, which has nothing to play — and that belongs to whoever builds the
+/// music level, not to the strip.
+fn project_sections(mc: &crate::plex::MediaContainer) -> Vec<(i64, String, SecKind)> {
     mc.directory
         .iter()
         .filter_map(|d| {
-            let is_show = match d.kind.as_str() {
-                "movie" => false,
-                "show" => true,
-                _ => return None, // music/photo: not browsable here
-            };
-            d.key.parse::<i64>().ok().map(|k| (k, d.title.clone(), is_show))
+            let kind = SecKind::from_wire(&d.kind)?; // a type this product has no level for at all
+            d.key.parse::<i64>().ok().map(|k| (k, d.title.clone(), kind))
         })
         .collect()
+}
+
+/// A library section's TYPE — the product's closed type list, and the unit the tab projection
+/// ([`tabs`]) compares by.
+///
+/// It replaced an `is_show: bool`, and the reason is the projection rather than tidiness: "does any
+/// owned library have this kind" is the test that decides whether a friend's library gets its own
+/// pill, and with two values Music is indistinguishable from Movies — a friend's music library would
+/// silently ride your *Movies* pill and its content would be unreachable from the strip.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SecKind {
+    Movie,
+    Show,
+    Music,
+    Photo,
+}
+
+impl SecKind {
+    /// The wire's `Directory.type`, or `None` for a type this product draws no level for.
+    pub(crate) fn from_wire(s: &str) -> Option<SecKind> {
+        match s {
+            "movie" => Some(SecKind::Movie),
+            "show" => Some(SecKind::Show),
+            "artist" => Some(SecKind::Music),
+            "photo" => Some(SecKind::Photo),
+            _ => None,
+        }
+    }
+    /// The Sources row's count noun ("185 films") — plural, and the singular-less form the row
+    /// falls back to when no count has landed is [`SecKind::plural`].
+    pub(crate) fn noun(self) -> &'static str {
+        match self {
+            SecKind::Movie => "films",
+            SecKind::Show => "shows",
+            SecKind::Music => "artists",
+            SecKind::Photo => "photos",
+        }
+    }
+    /// The same thing as a standalone label ("Films"), for a row whose count has not landed yet.
+    pub(crate) fn plural(self) -> &'static str {
+        match self {
+            SecKind::Movie => "Films",
+            SecKind::Show => "TV shows",
+            SecKind::Music => "Music",
+            SecKind::Photo => "Photos",
+        }
+    }
 }
 
 /// APPEND one source's sections to the table, with their per-section states in lockstep.
@@ -460,11 +516,11 @@ fn project_sections(mc: &crate::plex::MediaContainer) -> Vec<(i64, String, bool)
 /// remembered view, and every in-flight page landing's `sec`) survive untouched, which is what
 /// makes a source arriving late safe at all. A source is only ever appended once, so a repeat call
 /// for it is a no-op rather than a duplicated library.
-fn append_sections(src: usize, list: Vec<(i64, String, bool)>) {
+fn append_sections(src: usize, list: Vec<(i64, String, SecKind)>) {
     // Only what this source does not already have. A re-discovery ("Check for new shares", or a
     // server that came back) therefore ADDS a library the owner has since created and leaves every
     // existing row — and every index — exactly where it was.
-    let fresh: Vec<(i64, String, bool)> = list
+    let fresh: Vec<(i64, String, SecKind)> = list
         .into_iter()
         .filter(|(k, _, _)| !sections().iter().any(|s| s.src == src && s.key == *k))
         .collect();
@@ -477,8 +533,8 @@ fn append_sections(src: usize, list: Vec<(i64, String, bool)>) {
     unsafe {
         let secs = &mut *addr_of_mut!(SECTIONS);
         let states = &mut *addr_of_mut!(STATES);
-        for (key, title, is_show) in fresh {
-            secs.push(BrowseSection { src, key, title, is_show, count: -1, pinned });
+        for (key, title, kind) in fresh {
+            secs.push(BrowseSection { src, key, title, kind, count: -1, pinned });
             states.push(SecState::default());
         }
     }
@@ -492,8 +548,9 @@ pub(crate) fn section_count() -> usize {
 pub(crate) fn section_title(i: usize) -> &'static str {
     sections().get(i).map(|s| s.title.as_str()).unwrap_or("")
 }
-pub(crate) fn section_is_show(i: usize) -> bool {
-    sections().get(i).map(|s| s.is_show).unwrap_or(false)
+/// The TYPE of section `i` — `None` for an index the table does not hold.
+pub(crate) fn section_kind(i: usize) -> Option<SecKind> {
+    sections().get(i).map(|s| s.kind)
 }
 /// The registry slot section `i` is browsed through. **Read this at the SPAWN SITE**; a worker
 /// that calls `client()` instead dials whichever server happens to be current when it runs.
@@ -586,30 +643,55 @@ fn mark_source_reachable(i: usize, ok: bool) {
 /// tab index → section index, rebuilt when the table's shape moves.
 static mut TABS: Vec<usize> = Vec::new();
 static mut TABS_GEN: u32 = u32::MAX;
+/// …and how many times the projection above actually CHANGED, which is a different question from
+/// how many times it was re-derived. See [`tabs_gen`].
+static mut TABS_SHAPE_GEN: u32 = 0;
 
 fn tabs() -> &'static Vec<usize> {
     let g = sections_gen();
     if unsafe { addr_of!(TABS_GEN).read() } != g {
-        let owned_kinds: Vec<bool> = sections()
+        // compared by real TYPE, not by `is_show`: with a boolean, "does an owned library have this
+        // kind" answers YES for a friend's MUSIC library on the strength of your films, so it would
+        // get no pill and nothing in it could be reached from the strip at all
+        let owned_kinds: Vec<SecKind> = sections()
             .iter()
             .filter(|s| sources().get(s.src).map(|x| x.handle.is_empty()).unwrap_or(true))
-            .map(|s| s.is_show)
+            .map(|s| s.kind)
             .collect();
         let v: Vec<usize> = sections()
             .iter()
             .enumerate()
             .filter(|(_, s)| {
                 let owned = sources().get(s.src).map(|x| x.handle.is_empty()).unwrap_or(true);
-                owned || !owned_kinds.contains(&s.is_show)
+                owned || !owned_kinds.contains(&s.kind)
             })
             .map(|(i, _)| i)
             .collect();
+        // The strip's own generation, bumped only when the projected PILL LIST changes. The section
+        // table's generation moves for things the strip cannot see — a source's counts landing, a
+        // second friend's libraries arriving that all fold onto pills already drawn — and the label
+        // cache downstream re-measures every pill in the row when it does. That is Home's hot path,
+        // and with sources landing one at a time it now happens several times a boot.
+        // BORROW, never `.read()`: that copies the `Vec` bitwise, and dropping the copy frees the
+        // buffer the static still points at — a double free that aborts the process, not a warning.
+        let changed = unsafe { (*addr_of!(TABS)).as_slice() != v.as_slice() };
         unsafe {
             *addr_of_mut!(TABS) = v;
             TABS_GEN = g;
+            if changed {
+                TABS_SHAPE_GEN += 1;
+            }
         }
     }
     unsafe { &*addr_of!(TABS) }
+}
+
+/// The generation of the strip's own SHAPE — moves only when the projected pill list actually
+/// changes, which is what the tab row's label + width cache keys on
+/// ([`widgets::with_tab_metrics`](crate::ui::widgets)).
+pub(crate) fn tabs_gen() -> u32 {
+    tabs(); // re-project first: a stale answer would name the generation of a row nobody has
+    unsafe { addr_of!(TABS_SHAPE_GEN).read() }
 }
 
 /// Pills in the strip (excluding Home, which the strip prepends itself).
@@ -631,8 +713,8 @@ pub(crate) fn tab_of_section(s: usize) -> usize {
     if let Some(p) = t.iter().position(|&i| i == s) {
         return p;
     }
-    let kind = section_is_show(s);
-    t.iter().position(|&i| section_is_show(i) == kind).unwrap_or(0)
+    let Some(kind) = section_kind(s) else { return 0 };
+    t.iter().position(|&i| section_kind(i) == Some(kind)).unwrap_or(0)
 }
 
 // ---- pinning: the ONE control, and it governs Home only --------------------------------------
@@ -724,7 +806,7 @@ pub(crate) fn source_rows() -> Vec<SrcRow> {
             src: s.src,
             section: i,
             title: s.title.clone(),
-            count_line: count_line(s.count, s.is_show),
+            count_line: count_line(s.count, s.kind),
             pinned: s.pinned,
             last_pinned: last && s.pinned,
             current: i == cur,
@@ -735,11 +817,11 @@ pub(crate) fn source_rows() -> Vec<SrcRow> {
 /// A library's sub-line: its size once the count has landed, else its TYPE. Never absent — a row
 /// that loses its second line changes height, and the panel is not allowed to resize under a level
 /// switch or a landing.
-fn count_line(count: i64, is_show: bool) -> String {
+fn count_line(count: i64, kind: SecKind) -> String {
     if count >= 0 {
-        format!("{count} {}", if is_show { "shows" } else { "films" })
+        format!("{count} {}", kind.noun())
     } else {
-        (if is_show { "TV shows" } else { "Films" }).to_string()
+        kind.plural().to_string()
     }
 }
 
@@ -1288,7 +1370,7 @@ fn maybe_spawn() {
     if st.unwatched {
         // shows advertise unwatchedLeaves (any unwatched episode); plain unwatched=1 has odd
         // semantics on type=2 (verified live 2026-07-19)
-        let k = if sec.is_show { "unwatchedLeaves" } else { "unwatched" };
+        let k = if sec.kind == SecKind::Show { "unwatchedLeaves" } else { "unwatched" };
         filters.push((k.to_string(), "1".to_string()));
     }
     if let Some(g) = &st.genre {
@@ -1351,6 +1433,27 @@ fn maybe_spawn() {
 }
 
 // ---------------------------------------------------------------------------------------
+    /// A two-source table for tests OUTSIDE this module (`ui::home`'s focus walk): your Movies and
+    /// TV Shows, a friend's films and shows that fold onto them, and a friend's music that does not
+    /// — five libraries projecting to three pills. Writes crate globals, so the caller holds
+    /// [`crate::testlock::serial`] and `reset()`s afterwards.
+    #[cfg(test)]
+    pub(crate) fn seed_two_source_table_for_test() {
+        tests::seed_sources(vec![
+            tests::a_source("mac-mini", "", true),
+            tests::a_source("nas-home", "friend", true),
+        ]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        append_sections(
+            1,
+            vec![
+                (1, "Film Club".into(), SecKind::Movie),
+                (2, "Film Club".into(), SecKind::Show),
+                (3, "Film Club".into(), SecKind::Music),
+            ],
+        );
+    }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1480,7 +1583,7 @@ mod tests {
     // no worker is spawned — the same discipline as the fetch-machine tests above, one layer up.
     // Their `sid` is `UNSET`, which resolves to no client, so even a spawn could reach no socket.
 
-    fn a_source(name: &str, handle: &str, reachable: bool) -> BrowseSource {
+    pub(super) fn a_source(name: &str, handle: &str, reachable: bool) -> BrowseSource {
         BrowseSource {
             sid: ServerId::UNSET,
             name: name.into(),
@@ -1491,7 +1594,7 @@ mod tests {
             retry_cd: 0,
         }
     }
-    fn seed_sources(srcs: Vec<BrowseSource>) {
+    pub(super) fn seed_sources(srcs: Vec<BrowseSource>) {
         reset();
         unsafe { *addr_of_mut!(SOURCES) = srcs };
     }
@@ -1502,18 +1605,18 @@ mod tests {
     #[test]
     fn two_servers_both_have_a_section_one_and_the_table_tells_them_apart() {
         let _g = crate::testlock::serial();
-        seed_sources(vec![a_source("mac-mini", "", true), a_source("bx23-ldn", "bamx23", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false), (2, "TV Shows".into(), true)]);
-        append_sections(1, vec![(1, "LDN Films".into(), false)]);
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
 
         assert_eq!(section_count(), 3);
         let ours = &sections()[0];
         let theirs = &sections()[2];
         assert_eq!((ours.key, ours.src), (1, 0), "our section 1, on source 0");
         assert_eq!((theirs.key, theirs.src), (1, 1), "THEIR section 1 — same key, different source");
-        assert_eq!((section_title(0), section_title(2)), ("Movies", "LDN Films"));
+        assert_eq!((section_title(0), section_title(2)), ("Movies", "Film Club"));
         // and the chip's annotation follows the section being browsed, not the account
-        assert_eq!(handle_of(2), "bamx23");
+        assert_eq!(handle_of(2), "friend");
         assert_eq!(handle_of(0), "", "your own libraries carry no owner at all");
         reset();
     }
@@ -1525,12 +1628,12 @@ mod tests {
     #[test]
     fn a_source_arriving_late_appends_and_moves_no_existing_index() {
         let _g = crate::testlock::serial();
-        seed_sources(vec![a_source("mac-mini", "", true), a_source("bx23-ldn", "bamx23", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false), (2, "TV Shows".into(), true)]);
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
         set_cur(1);
         let before = (cur(), section_title(1).to_string(), states().len());
 
-        append_sections(1, vec![(1, "LDN Films".into(), false)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
         assert_eq!(cur(), before.0, "the library being browsed is still the one at that index");
         assert_eq!(section_title(1), before.1);
         assert_eq!(states().len(), section_count(), "states stay in lockstep with the table");
@@ -1538,12 +1641,12 @@ mod tests {
 
         // A RE-discovery ("Check for new shares", or a server that came back) re-offers the same
         // list: every row is already there, so nothing is duplicated and nothing moves…
-        append_sections(1, vec![(1, "LDN Films".into(), false)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
         assert_eq!(section_count(), 3);
         assert_eq!(cur(), before.0);
         // …while a library the owner has CREATED since is appended, at the end, where it cannot
         // disturb an index anything is already holding.
-        append_sections(1, vec![(1, "LDN Films".into(), false), (4, "LDN Shows".into(), true)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie), (4, "LDN Shows".into(), SecKind::Show)]);
         assert_eq!(section_count(), 4);
         assert_eq!(section_title(3), "LDN Shows");
         assert_eq!(section_title(1), before.1, "and the row we were browsing is untouched");
@@ -1556,9 +1659,9 @@ mod tests {
     #[test]
     fn a_friends_libraries_start_unpinned_and_the_last_pin_cannot_be_turned_off() {
         let _g = crate::testlock::serial();
-        seed_sources(vec![a_source("mac-mini", "", true), a_source("bx23-ldn", "bamx23", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false), (2, "TV Shows".into(), true)]);
-        append_sections(1, vec![(1, "LDN Films".into(), false)]);
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
         assert_eq!((pinned(0), pinned(1), pinned(2)), (true, true, false));
         assert_eq!(pinned_count(), 2);
 
@@ -1581,15 +1684,110 @@ mod tests {
     #[test]
     fn the_tab_strip_grows_by_types_and_never_by_people() {
         let _g = crate::testlock::serial();
-        seed_sources(vec![a_source("mac-mini", "", true), a_source("bx23-ldn", "bamx23", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false)]);
-        append_sections(1, vec![(1, "LDN Films".into(), false), (2, "Their Shows".into(), true)]);
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie), (2, "Their Shows".into(), SecKind::Show)]);
 
         assert_eq!(tab_count(), 2, "your Movies, plus the shows nobody of yours provides");
         assert_eq!((tab_title(0), tab_title(1)), ("Movies", "Their Shows"));
         assert_eq!(tab_section(1), 2);
         assert_eq!(tab_of_section(1), 0, "their films ride YOUR Movies pill — same type, one level");
         assert_eq!(tab_of_section(2), 1, "their shows have a pill of their own");
+        reset();
+    }
+
+    /// The case a BOOLEAN type could not express, and the reason [`SecKind`] exists. `is_show` has
+    /// two values, so "does an owned library have this kind" answered YES for a friend's MUSIC
+    /// library on the strength of your films: it got no pill, and nothing in it was reachable from
+    /// the strip at all. With a real type it gets exactly one, like any other missing type — and
+    /// `artist`/`photo` reaching the table at all is the other half of the same fix, since a type
+    /// dropped at discovery can never be missing from the projection either.
+    #[test]
+    fn a_friends_music_library_is_a_missing_type_and_not_a_second_films_pill() {
+        let _g = crate::testlock::serial();
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie), (3, "Their Music".into(), SecKind::Music)]);
+
+        assert_eq!(tab_count(), 3, "your two, plus the music nobody of yours provides");
+        assert_eq!(tab_title(2), "Their Music");
+        assert_eq!(tab_of_section(3), 2, "their music is its own pill, NOT your Movies one");
+        assert_eq!(tab_of_section(2), 0, "…while their films still ride yours");
+        // and the wire types this product has a level for, including the two that used to be
+        // dropped before they could ever reach the projection
+        assert_eq!(SecKind::from_wire("artist"), Some(SecKind::Music));
+        assert_eq!(SecKind::from_wire("photo"), Some(SecKind::Photo));
+        assert_eq!(SecKind::from_wire("mixed"), None, "a type with no level is still refused");
+        reset();
+    }
+
+    /// **The deliverable, as an assertion**: the strip is a constant row however many friends
+    /// arrive. Its pill list — and therefore its width, which is a pure function of the labels —
+    /// does not move as the roster grows from one server to three, because every borrowed library
+    /// folds onto the pill of a type you already have. Only a MISSING type may widen it.
+    ///
+    /// The shape the design rejected is the control: a pill per section reaches eleven pills here,
+    /// which is what measured 2133px against a 1540px track at three friends.
+    #[test]
+    fn the_strip_is_the_same_row_at_one_friend_and_at_three() {
+        let _g = crate::testlock::serial();
+        seed_sources(vec![
+            a_source("mac-mini", "", true),
+            a_source("nas-home", "friend", true),
+            a_source("nas-home", "friend", true),
+            a_source("nas-home", "friend", true),
+        ]);
+        // OWNED, deliberately: `tab_title` hands back a `&'static str` borrowed out of the section
+        // table's own `String`s, and `append_sections` can reallocate that Vec — so a row captured
+        // as borrows and compared after the next source lands is reading freed memory. Every
+        // caller in the app consumes these inside one frame with no append in between, which is
+        // what makes the signature sound in the product and unsound in a test that spans landings.
+        let row = || (0..tab_count()).map(|t| tab_title(t).to_string()).collect::<Vec<_>>();
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        let alone = row();
+        assert_eq!(alone, vec!["Movies", "TV Shows"], "your own libraries, and nothing else");
+
+        for src in 1..=3 {
+            append_sections(
+                src,
+                vec![
+                    (1, "Film Club".into(), SecKind::Movie),
+                    (2, "Film Club".into(), SecKind::Show),
+                    (3, "Film Club".into(), SecKind::Movie),
+                ],
+            );
+            assert_eq!(row(), alone, "source {src} added a pill — the strip must not grow by people");
+        }
+        assert_eq!(section_count(), 11, "eleven libraries…");
+        assert_eq!(tab_count(), 2, "…and the two pills it started with");
+        reset();
+    }
+
+    /// The strip's own generation moves when the ROW changes and not when the TABLE does — which,
+    /// once a table is appended to one source at a time, are different questions. Every borrowed
+    /// library that folds onto a pill you already have bumps the table's generation and changes
+    /// nothing in the row, so keying the label + width cache on the table re-measured every pill in
+    /// the strip once per source, on Home's hot path, for a strip that had not moved.
+    #[test]
+    fn only_a_changed_row_costs_the_tab_cache_a_re_measure() {
+        let _g = crate::testlock::serial();
+        seed_sources(vec![
+            a_source("mac-mini", "", true),
+            a_source("nas-home", "friend", true),
+            a_source("nas-home", "friend", true),
+        ]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie)]);
+        let (g0, table0) = (tabs_gen(), sections_gen());
+
+        // two friends' film libraries land: both fold onto your Movies pill
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
+        append_sections(2, vec![(1, "Film Club".into(), SecKind::Movie)]);
+        assert_ne!(sections_gen(), table0, "the TABLE's generation moved, twice");
+        assert_eq!(tabs_gen(), g0, "…and the row did not, so it must not re-measure");
+
+        // …while a MISSING type is exactly what must invalidate it
+        append_sections(2, vec![(9, "Their Music".into(), SecKind::Music)]);
+        assert_ne!(tabs_gen(), g0, "a gained pill MUST re-measure the row");
         reset();
     }
 
@@ -1601,9 +1799,9 @@ mod tests {
     #[test]
     fn a_page_fetch_is_what_keeps_reachability_honest_after_discovery() {
         let _g = crate::testlock::serial();
-        seed_sources(vec![a_source("mac-mini", "", true), a_source("bx23-ldn", "bamx23", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false)]);
-        append_sections(1, vec![(1, "LDN Films".into(), false)]);
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie)]);
+        append_sections(1, vec![(1, "Film Club".into(), SecKind::Movie)]);
         assert!(sources()[1].sections_done, "discovery is done — it will never re-ask by itself");
 
         mark_source_reachable(1, false); // a page for THEIR library did not come back
@@ -1625,7 +1823,7 @@ mod tests {
     fn an_empty_count_landing_does_not_latch_the_probe_off() {
         let _g = crate::testlock::serial();
         seed_sources(vec![a_source("mac-mini", "", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie)]);
         if let Some(s) = source_mut(0) {
             s.counts_done = false;
         }
@@ -1653,7 +1851,7 @@ mod tests {
     fn one_source_leaves_the_strip_exactly_as_it_was() {
         let _g = crate::testlock::serial();
         seed_sources(vec![a_source("mac-mini", "", true)]);
-        append_sections(0, vec![(1, "Movies".into(), false), (2, "TV Shows".into(), true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
         assert_eq!(tab_count(), section_count());
         for i in 0..section_count() {
             assert_eq!(tab_section(i), i);

--- a/rust-modules/src/browse.rs
+++ b/rust-modules/src/browse.rs
@@ -333,7 +333,12 @@ pub(crate) fn reset() {
         *addr_of_mut!(SOURCES) = Vec::new();
         *addr_of_mut!(SECTIONS) = Vec::new();
         *addr_of_mut!(STATES) = Vec::new();
-        *addr_of_mut!(TABS) = Vec::new();
+        // TABS is deliberately NOT cleared here, only invalidated. It is a memo, and the ONE thing
+        // that decides whether the strip re-measures is [`tabs`] comparing the old row against the
+        // new one — so emptying it in advance makes that comparison `[] != []`, which is false, and
+        // the label cache keeps the PREVIOUS ACCOUNT's pills: `draw_tab_row` iterates the cache, so
+        // after a profile switch the strip would go on drawing and hit-testing libraries the new
+        // user cannot open, until some later landing happened to change the row.
         TABS_GEN = u32::MAX;
         CUR = 0;
         RETRY_CD = 0;
@@ -658,12 +663,26 @@ fn tabs() -> &'static Vec<usize> {
             .filter(|s| sources().get(s.src).map(|x| x.handle.is_empty()).unwrap_or(true))
             .map(|s| s.kind)
             .collect();
+        // A missing type earns ONE pill, not one per borrowed library of it. Two friends who both
+        // share Music are two libraries of a type you do not own, and admitting both puts two
+        // identically-titled *Music* pills in the row with nothing to tell them apart — which is
+        // the strip growing by PEOPLE, the one property this projection exists to prevent. The
+        // first one carries the type; the rest are reachable through the toolbar's Source chip,
+        // exactly as a borrowed library of a type you DO own already is.
+        let mut borrowed_kinds: Vec<SecKind> = Vec::new();
         let v: Vec<usize> = sections()
             .iter()
             .enumerate()
             .filter(|(_, s)| {
                 let owned = sources().get(s.src).map(|x| x.handle.is_empty()).unwrap_or(true);
-                owned || !owned_kinds.contains(&s.kind)
+                if owned {
+                    return true;
+                }
+                if owned_kinds.contains(&s.kind) || borrowed_kinds.contains(&s.kind) {
+                    return false;
+                }
+                borrowed_kinds.push(s.kind);
+                true
             })
             .map(|(i, _)| i)
             .collect();
@@ -1367,11 +1386,20 @@ fn maybe_spawn() {
         None => String::new(),
     };
     let mut filters: Vec<(String, String)> = Vec::new();
+    // The unwatched filter is a MOVIE/SHOW question, and only those two types answer it: shows
+    // advertise `unwatchedLeaves` (any unwatched episode), movies take a plain `unwatched=1`, and
+    // the comment this replaced already recorded that the plain form has odd semantics off type=1
+    // (verified live 2026-07-19). Sending it to a music or photo listing is asking a library that
+    // has no such state to filter by it — newly reachable, since those types now get a pill, so the
+    // Filter menu's switch is now one press away on them. Unset here rather than in the menu: the
+    // query is the one place that knows what it is asking, and a switch that changed nothing would
+    // be a worse answer than a switch that is simply not offered.
     if st.unwatched {
-        // shows advertise unwatchedLeaves (any unwatched episode); plain unwatched=1 has odd
-        // semantics on type=2 (verified live 2026-07-19)
-        let k = if sec.kind == SecKind::Show { "unwatchedLeaves" } else { "unwatched" };
-        filters.push((k.to_string(), "1".to_string()));
+        match sec.kind {
+            SecKind::Show => filters.push(("unwatchedLeaves".to_string(), "1".to_string())),
+            SecKind::Movie => filters.push(("unwatched".to_string(), "1".to_string())),
+            SecKind::Music | SecKind::Photo => {}
+        }
     }
     if let Some(g) = &st.genre {
         filters.push(("genre".to_string(), g.id.clone()));
@@ -1760,7 +1788,35 @@ mod tests {
         }
         assert_eq!(section_count(), 11, "eleven libraries…");
         assert_eq!(tab_count(), 2, "…and the two pills it started with");
+
+        // …and a type NOBODY owns grows the row by exactly one however many people share it. Every
+        // fixture above is a type we own, which is why this half needs saying separately: it is the
+        // only branch of the projection that can admit a borrowed library at all.
+        for src in 1..=3 {
+            append_sections(src, vec![(9, "Film Club".into(), SecKind::Music)]);
+        }
+        assert_eq!(tab_count(), 3, "three friends sharing music are ONE Music pill");
+        assert_eq!(row().len(), 3);
         reset();
+    }
+
+    /// A profile switch must not leave the previous account's pills on screen. `reset()` empties
+    /// the table, and the strip's generation is what the tab row's label cache keys on — so if the
+    /// projection's own memo were CLEARED here rather than merely invalidated, the comparison that
+    /// decides "did the row change" would be `[] != []`, i.e. false, and `draw_tab_row` (which
+    /// iterates the cache, not the live table) would go on drawing and hit-testing libraries the
+    /// new user cannot open until some later landing happened to change the row.
+    #[test]
+    fn a_profile_switch_re_measures_the_strip_instead_of_keeping_the_last_accounts_pills() {
+        let _g = crate::testlock::serial();
+        seed_sources(vec![a_source("mac-mini", "", true)]);
+        append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "TV Shows".into(), SecKind::Show)]);
+        let g0 = tabs_gen();
+        assert_eq!(tab_count(), 2);
+
+        reset(); // install_pms: a different account signs in
+        assert_eq!(tab_count(), 0, "the row is empty…");
+        assert_ne!(tabs_gen(), g0, "…and the strip MUST re-measure rather than keep the old pills");
     }
 
     /// The strip's own generation moves when the ROW changes and not when the TABLE does — which,

--- a/rust-modules/src/ui/home.rs
+++ b/rust-modules/src/ui/home.rs
@@ -1580,15 +1580,36 @@ mod tests {
     /// empty), so the row here is the Home pill alone and the band's last pill IS Home.
     #[test]
     fn set_hero_focus_clamps_onto_the_last_drawable_pill() {
+        let _s = crate::testlock::serial(); // the count comes from `browse`'s table, a crate global
         let _g = FOCUS.lock().unwrap_or_else(|e| e.into_inner());
         let saved = hero_focus();
-        assert_eq!(crate::ui::widgets::tab_count(), 1, "no sections discovered on the host");
+        crate::browse::reset();
+        assert_eq!(crate::ui::widgets::tab_count(), 1, "no sections discovered: the Home pill alone");
         set_hero_focus(c_int::MIN / 2);
         assert_eq!(hero_focus(), hero_focus_for_pill(0), "past the last pill clamps onto it");
         assert_eq!(hero_pill_index(hero_focus()), Some(0));
         set_hero_focus(999);
         assert_eq!(hero_focus(), HERO_NBTN as c_int - 1, "past the action row clamps to its end");
         set_hero_focus(saved);
+    }
+
+    /// The top band walks the PILLS the strip's projection produces, not the section table — with
+    /// several sources those are different lengths. Five libraries across two servers project to
+    /// three pills (your two, plus the music only they have), so RIGHT stops on the third and never
+    /// on a fourth that nothing would draw.
+    #[test]
+    fn the_top_band_walks_the_projected_pills_not_the_section_table() {
+        let _s = crate::testlock::serial();
+        let _g = FOCUS.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = hero_focus();
+        crate::browse::seed_two_source_table_for_test();
+        assert_eq!(crate::browse::section_count(), 5, "five libraries…");
+        assert_eq!(crate::ui::widgets::tab_count(), 4, "…and Home + three pills");
+
+        set_hero_focus(c_int::MIN / 2); // walk RIGHT past the end of the row
+        assert_eq!(hero_pill_index(hero_focus()), Some(3), "the last pill is the last PILL, not the last library");
+        set_hero_focus(saved);
+        crate::browse::reset();
     }
 
     #[test]

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -392,7 +392,9 @@ struct ChipStrs {
 /// which is the one moment its label is the only thing on screen that changed.
 static mut CHIP_CACHE: Option<(String, Vec<ChipStrs>)> = None;
 static mut RAIL_LABELS: Option<(u32, usize, Vec<CString>)> = None; // (sections_gen, section, labels)
-static mut COUNT_C: Option<(i64, bool, CString)> = None;
+// (total, the section TYPE's noun, the rendered string) — keyed on the noun rather than on a
+// movie/show boolean, because a section is one of four types now (`browse::SecKind`)
+static mut COUNT_C: Option<(i64, &'static str, CString)> = None;
 // letter rail: focused letter + the per-letter rects recorded at draw (pointer hit-testing)
 const MAX_LETTERS: usize = 34; // A–Z + digits/# buckets
 static mut RAIL_F: usize = 0;
@@ -1598,11 +1600,10 @@ pub(crate) fn draw() {
     // item count, right-aligned on the toolbar line (cached — changes only on re-query)
     let tot = crate::browse::total();
     if tot >= 0 {
-        let is_show = crate::browse::section_is_show(crate::browse::cur());
+        let noun = crate::browse::section_kind(crate::browse::cur()).map(|k| k.noun()).unwrap_or("items");
         let cache = unsafe { &mut *addr_of_mut!(COUNT_C) };
-        if cache.as_ref().map(|(ct, cshow, _)| *ct != tot || *cshow != is_show).unwrap_or(true) {
-            let noun = if is_show { "shows" } else { "films" };
-            *cache = Some((tot, is_show, CString::new(format!("{tot} {noun}")).unwrap_or_default()));
+        if cache.as_ref().map(|(ct, cn, _)| *ct != tot || *cn != noun).unwrap_or(true) {
+            *cache = Some((tot, noun, CString::new(format!("{tot} {noun}")).unwrap_or_default()));
         }
         let cs = &cache.as_ref().unwrap().2;
         let ty = crate::text::text_vcenter_y(theme::size::CAPTION, 0, TOOL_Y + TOOL_H * 0.5);

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -1130,12 +1130,35 @@ fn build_sort_menu(keep: bool) {
 }
 
 /// `keep` = re-entered from the Genre level via BACK (slide the pill, don't restart the fade).
+/// Does the section being browsed answer "unwatched"? Only movies and shows have that state, so on
+/// a music or photo library the switch is not offered rather than offered and inert — `browse`
+/// refuses to put the filter on such a query, and a control that visibly changes nothing is a worse
+/// answer than one that is not there. It also shifts the Genre row up, which is why every index in
+/// this menu is resolved through [`filter_rows`] rather than written as a literal.
+fn has_unwatched() -> bool {
+    matches!(
+        crate::browse::section_kind(crate::browse::cur()),
+        Some(crate::browse::SecKind::Movie) | Some(crate::browse::SecKind::Show)
+    )
+}
+
+/// The Filter menu's row map: which row index means what, for the section being browsed.
+fn filter_rows() -> (i32, i32) {
+    if has_unwatched() {
+        (0, 1) // unwatched, genre
+    } else {
+        (-1, 0) // no switch; genre leads
+    }
+}
+
 fn open_filter_menu(keep: bool) {
-    let sec = Section::new("Filter")
+    let mut sec = Section::new("Filter");
+    if has_unwatched() {
         // A SWITCH, not one option among several: it says what it is set to in words at the trailing
         // edge, and carries no mark at all in the leading column.
-        .row(Row::new("Unwatched only").toggle(view_unwatched()))
-        .row(
+        sec = sec.row(Row::new("Unwatched only").toggle(view_unwatched()));
+    }
+    let sec = sec.row(
             // "All" / "Comedy" is a READ-OUT — what this row is set to — so it belongs in the same
             // trailing slot as the switch above it, not on a sub-line. It was a sub-line until the
             // 2026-08-13 sync, which put the two rows of this one menu in the odd position of
@@ -1217,11 +1240,12 @@ fn menu_commit(sel: i32) {
             close_menu(); // the panel closes NOW; the grid dissolves under it
         }
         Menu::Filter => {
-            if sel == 0 {
+            let (unwatched_row, genre_row) = filter_rows();
+            if sel == unwatched_row {
                 request(Pending::Unwatched(!view_unwatched()));
                 open_filter_menu(true); // rebuilt from `view_unwatched()` — the check flips at once
-                table().sel = 0;
-            } else if sel == 1 {
+                table().sel = unwatched_row;
+            } else if sel == genre_row {
                 build_genre_menu(false);
             }
         }

--- a/rust-modules/src/ui/nav.rs
+++ b/rust-modules/src/ui/nav.rs
@@ -59,6 +59,11 @@ static mut CONTINUOUS: bool = false;
 /// The tab pill the destination SELECTS, or -1 for "no pending selection" (nothing in flight, or a
 /// destination with no tab bar). -1 rather than `Option<usize>` so it drops straight into the
 /// `c_int` the strip is placed from.
+///
+/// A PILL, and since the strip became a projection of the section table (`browse::tabs`) that is
+/// not the destination's section index plus one: several libraries can share one pill, so
+/// `app.rs`'s `Nav::Library` carries the TAB the press named and the `+1` here is only the Home
+/// pill leading the row.
 static mut TAB: c_int = -1;
 /// The OUTGOING page's teardown, waiting for the floor — see the module doc. `None` for a FORWARD
 /// navigation, which leaves the page it came from standing behind the destination (that is what the

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -1737,7 +1737,7 @@ static mut TAB_SCROLL: crate::ui::Spring = crate::ui::Spring::at(0.0);
 /// PRESS frame: Library hands its *pending* section down here (`library::view_section`), which is
 /// what puts the capsule on the new pill while the grid is still dissolving under it.
 static mut TOP_STRIP: TabStrip = TabStrip::new();
-// label + width cache keyed on browse::sections_gen(): rebuilding the CStrings and
+// label + width cache keyed on browse::tabs_gen(): rebuilding the CStrings and
 // re-measuring every frame — on Home's hot path too — was a review-confirmed waste
 static mut TAB_CACHE: Option<(u32, Vec<std::ffi::CString>, Vec<f32>)> = None;
 
@@ -1755,8 +1755,15 @@ pub(crate) fn tab_pill_at(mx: f32, my: f32) -> Option<usize> {
 }
 
 /// Run `f` with the tab row's labels + pill widths, rebuilding them only when
-/// `browse::sections_gen()` moves. Shared by the per-frame scroll step and the draw, so the two
+/// `browse::tabs_gen()` moves. Shared by the per-frame scroll step and the draw, so the two
 /// can't measure the strip differently.
+///
+/// The key is the STRIP's generation, not the section table's, and with several sources that is no
+/// longer the same number: the table's generation moves for every source whose libraries land and
+/// every count that arrives, while the row only changes when the projection does. Most of those
+/// landings fold onto pills already drawn (a friend's films ride your *Movies* pill), so keying on
+/// the table re-measured every pill in the row, several times a boot, on Home's hot path — for a
+/// strip that had not moved.
 ///
 /// Deliberately a closure and not a `&'static` getter: the borrow points into `TAB_CACHE`, and a
 /// nested rebuild would free the `CString`s a caller is still handing to `TabPill` as a raw
@@ -1765,7 +1772,7 @@ pub(crate) fn tab_pill_at(mx: f32, my: f32) -> Option<usize> {
 fn with_tab_metrics<R>(f: impl FnOnce(&[std::ffi::CString], &[f32]) -> R) -> R {
     use std::ffi::CString;
     use std::ptr::addr_of_mut;
-    let gen = crate::browse::sections_gen();
+    let gen = crate::browse::tabs_gen();
     let cache = unsafe { &mut *addr_of_mut!(TAB_CACHE) };
     if cache.as_ref().map(|c| c.0 != gen).unwrap_or(true) {
         let nsec = crate::browse::tab_count();

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -140,7 +140,7 @@
       "run_secs": 36,
       "warmup_s": 6,
       "_run_secs_note": "36, not the 22 every single-route scene uses, because a ROUTE-CHANGING scene splits its samples. The FPS heartbeat is once/sec and navosc bounces every 1400ms, so each route sees only about HALF the post-warmup samples — 22s gave route=home 4, one under the harness' >=5 minimum, and the scene failed for want of evidence rather than for want of frames. 36s leaves ~30 post-warmup seconds, ~15 per route: margin enough that an uneven bounce phase cannot starve either side. Any future two-route scene needs this same doubling.",
-      "comment": "One of the two scenes that change ROUTE. navosc bounces Home<->the first library section every 1400ms through the real nav_to path, so the page cross-fade (ui::nav) is perf-gated. route=home samples the settled hero, the fade-OUT and the fade-IN on the way back; the Library half is covered by library-scroll/library-switch.",
+      "comment": "One of the two scenes that change ROUTE. navosc bounces Home<->the first library TAB every 1400ms through the real nav_to path, so the page cross-fade (ui::nav) is perf-gated. It is a tab and no longer 'the first section': the strip is a projection of the section table (browse::tabs), so several libraries can share one pill and the two index spaces are not one addition apart. route=home samples the settled hero, the fade-OUT and the fade-IN on the way back; the Library half is covered by library-scroll/library-switch.",
       "triggers": {
         "plxnative-navosc": true
       },


### PR DESCRIPTION
Unit: **the top tab strip** (deliverable B).

## Which projection survived: #31's

I originally implemented the strip as a pure type roster — every pill a type name, so two of *your
own* movie libraries collapsed to one `Movies` pill. #31 landed first with the other reading of the
canvas: the strip names **your own libraries**, and a friend's library gets a pill only when it is a
type you do not own. **#31's projection survived**; I rebased onto it and deleted my duplicate
(`TypeRoster`, `pill_of_section`/`section_for_pill`, and the `/tmp/plxnative-sections` trigger, which
#31 makes redundant by registering `/tmp/plxnative-servers` into the registry for real).

Both readings are literally in the canvas — *"a pill is a type — not a library and not a person"*
versus *"It names the owner's own sections and nothing else — which is what it does today, so B is a
deliverable with no new drawing in it"* — and they coincide whenever a server has one library per
type, which is the case every frame in the design draws. #31's is the lower-risk one: no visible
change for existing single-server users, and no own library becoming unreachable when one server has
two of a type.

**This PR is therefore the delta on top of #31**, and it targets #31's branch so the diff is only
mine. Retarget to `shared-servers-base` once #31 merges.

## What this adds

**1. The projection needs a real type, or a friend's Music has no pill.** `is_show: bool` has two
values, so *"does an owned library have this KIND"* — the test that decides whether a borrowed
library gets its own pill — answers YES for a friend's **music** library on the strength of your
films. It folded onto your `Movies` pill and everything in it was unreachable from the strip. The
other half of the same gap was one layer up: `project_sections` dropped `artist`/`photo` at
discovery, so those types could never reach the projection to be *missing* from it. A type dropped
at the door cannot be the growth case #31 is written for.

`SecKind` (Movie/Show/Music/Photo) replaces the boolean, discovery keeps every type this product has
a level for, and the projection compares by type.

**2. The label + width cache moves onto the STRIP's generation** (`browse::tabs_gen`), bumped only
when the projected pill list actually changes. The section table's generation now moves once per
source as libraries land, and most of those fold onto pills already drawn — so the row re-measured
every pill, several times a boot, on Home's hot path, for a strip that had not moved.

**3. Two bugs of my own that review caught with probe tests** (fixed in `5531764c`), both newly
reachable *because* this branch admits `artist`/`photo`:

- **A profile switch kept the previous account's pills.** Keying the cache on the strip's generation
  made `reset()` stop invalidating it — `reset` *cleared* the projection's memo, so the next
  derivation compared `[]` against `[]`, saw no change, and never bumped. `draw_tab_row` iterates
  the cache, not the live table, so after a re-login the strip went on drawing *and hit-testing*
  libraries the new user cannot open. The memo is invalidated now, never emptied early.
- **The row grew by PEOPLE for an un-owned type.** `owned || !owned_kinds.contains` admits one pill
  per borrowed *library* of a missing type, so two friends who both share Music are two
  identically-titled `Music` pills. A missing type earns one pill now; the rest are reachable
  through the Source chip, exactly as a borrowed library of a type you *do* own already is. The
  invariance test could not see this because its fixtures were all types we own — it now grows that
  half too.

**4. A double free in `tabs()`, found by the new test.** The projection compared old against new with
`addr_of!(TABS).read()`, which copies the `Vec` **bitwise** and then drops the copy, freeing the
buffer the static still points at. It aborts the process (SIGTRAP, no panic message). Introduced by
me earlier in this change; it borrows now. Related and left alone: `tab_title`/`section_title` hand
back `&'static str` borrowed out of the table's own `String`s, which `append_sections` can
reallocate — sound for every caller in the app (they consume inside one frame with no append in
between) and unsound for a test that spans landings, which is why the new test owns its strings.

**5. Three comments said "the first section" where they now mean "the first tab"** (the navosc
scene, `Nav::select_pill`, the FPS manifest), and `nav.rs`'s `TAB` doc said the pill was a section
index plus one. Wording only — #31 wired the arithmetic correctly — but a doc that lies about an
index space is how the next edit gets it wrong.

## Tests

`make check` — **436 passed, three consecutive green runs**. `make` links; `make RELEASE=1` builds.

| test | pins |
|---|---|
| `the_strip_is_the_same_row_at_one_friend_and_at_three` | **the deliverable**: eleven libraries across four sources, and the pill list never moves. Width follows, since every pill's width is a pure function of its label |
| `a_friends_music_library_is_a_missing_type_and_not_a_second_films_pill` | the case the boolean could not express, plus `artist`/`photo` reaching the table at all |
| `only_a_changed_row_costs_the_tab_cache_a_re_measure` | the table's generation moves twice, the strip's does not; a gained pill does move it |
| `the_top_band_walks_the_projected_pills_not_the_section_table` | Home's focus packing clamps to the last PILL (5 libraries → 3 pills) |
| `a_profile_switch_re_measures_the_strip_instead_of_keeping_the_last_accounts_pills` | a reset must invalidate the row, not silently keep it |

Fixture names use the canonical stand-ins (`friend`, `nas-home`, `Film Club`) — character-length
preserving, for the width assertions in `home.rs`. `browse.rs` is fully scrubbed on this branch; the
other files still carrying the old names came from the base and are presumably covered by the
integration-branch scrub.

## Device verification — deferred to coordinator

**Not verified on device.** I never touched the television: no deploy, no ssh, no capture.

The one behaviour a human should look at is **a library type that never had a tab before**. On an
account with a music or photo library, the strip gains exactly one pill for it:

```sh
tools/tv-session.sh up --screen home
tools/tv-session.sh shot /tmp/strip-home.png
tools/tv-session.sh key up right right right    # chip -> Home -> ... -> the new pill
tools/tv-session.sh key ok
tools/tv-session.sh shot /tmp/strip-music.png
```

CORRECT: one bare pill per own library plus any type only a friend has; the new pill opens that
library's grid, and the count read-out's noun matches the type (`films` / `shows` / `artists` /
`photos`). WRONG: a friend's music library sharing your `Movies` pill; a count saying `films` on a
music library; the strip re-measuring visibly (a pill flicker) as a second source's libraries land.

`./tests/run.py --fps` covers the two nav oscillators; `home-library-nav` is the one whose comment
changed here.

### Known gap, stated rather than hidden

A music library now has a tab and browses like any other section, but the level BELOW the grid does
not exist: OK on an artist opens the movie detail page, which has nothing to play. That belongs to
whoever builds the music level. The design's rejected case is a tab for a type with **no library**,
which is not this.
