### PR TITLE
pins: which libraries reach Home

### DIFF
--- a/rust-modules/src/plex/models.rs
+++ b/rust-modules/src/plex/models.rs
@@ -179,6 +179,12 @@ pub struct Metadata {
     pub viewed_leaf_count: i64, // shows/seasons: episodes watched (watched = viewed >= leaf)
     #[serde(rename = "viewCount", default, deserialize_with = "de_i64")]
     pub view_count: i64, // present only once watched ≥1× (absent = unwatched)
+    /// Which library this item lives in — the section's key on the server that sent it. Carried
+    /// by hub and listing rows alike; **0 when absent**, which is "unknown", not section zero.
+    /// Half of a `pms::pin::LibKey` (the machine id is the other half — a section key is only
+    /// unique within one server), so it is what tells Home whether an item's library is pinned.
+    #[serde(rename = "librarySectionID", default, deserialize_with = "de_i64")]
+    pub library_section_id: i64,
     #[serde(default)]
     pub thumb: String,
     #[serde(default)]

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -60,6 +60,94 @@ pub struct Session {
     /// render instantly on every boot (and offline) instead of waiting on a plex.tv round-trip.
     #[serde(default)]
     pub home_users: Vec<HomeUserRef>,
+    /// Which libraries feed Home — the ONE user-facing control for shared servers
+    /// ([`crate::pms::pin`] owns the model; this is only where its answers are written down).
+    ///
+    /// **Empty means UNKNOWN, not "nothing is pinned".** Nobody has answered yet — a fresh
+    /// install, or a session written by a build that predates the field — and the resolver
+    /// therefore falls back to the defaults (your own libraries on, a friend's off). Reading
+    /// empty as "none" would greet the first boot after an upgrade with a blank Home, which is
+    /// the same class of bug [`Session::account`] documents for `home_users`.
+    ///
+    /// It is a decision LOG, not a set of pinned keys: an unpinned library is written down as
+    /// `pinned: false` rather than omitted, so "answered no" and "never asked" stay
+    /// distinguishable per library — that is what lets a share that arrives next month default
+    /// to off without re-opening the first-run question about the ones already answered.
+    ///
+    /// `de_pins` is deliberately lenient: a malformed array here degrades to "unknown" instead
+    /// of failing the whole `Session` parse. A failed parse is a SILENT SIGN-OUT — `peek` falls
+    /// through to `Session::default()` and `load` then mints a fresh client id over the top of
+    /// the real one — so no field this file gains may ever be able to cause one.
+    #[serde(default, deserialize_with = "de_pins")]
+    pub pins: Vec<LibraryPin>,
+}
+
+/// One persisted pin decision: a library, and whether it feeds Home.
+///
+/// Keyed by **(machine_id, section)** because a section key is only unique within one server —
+/// every PMS numbers its first library `1`, so a friend's Movies and yours collide on the id
+/// alone. No title is stored: a renamed library is still the same library, and this file holds
+/// secrets and is never logged, so the fewer human-readable strings in it the better.
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct LibraryPin {
+    /// the owning server's `machineIdentifier`
+    #[serde(default)]
+    pub machine_id: String,
+    /// the library's section key on that server (`/library/sections` → `key`)
+    #[serde(default)]
+    pub section: i64,
+    /// feeds Home
+    #[serde(default)]
+    pub pinned: bool,
+}
+
+/// Lenient `pins` reader — see the field's doc for why this cannot be the derived one.
+///
+/// Two levels of tolerance, and they mean different things. A value that is not an array at all
+/// (a `null`, an object, a string written by something else) is "unknown" — the whole array
+/// degrades to empty. A single malformed ROW is dropped on its own, because the rows around it
+/// are still real answers the user gave; the libraries whose rows were lost simply fall back to
+/// their default, which is exactly what a library we have never seen does.
+///
+/// Going through `serde_json::Value` is what makes "drop a row" possible at all: on a failed
+/// `Deserialize` the JSON reader is left mid-token, so every LATER field of `Session` would fail
+/// too. Parsing one complete value first cannot fail on anything but broken JSON syntax, which
+/// no longer distinguishes this field from the rest of the file.
+fn de_pins<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Vec<LibraryPin>, D::Error> {
+    use serde_json::Value;
+    let Value::Array(rows) = Value::deserialize(d)? else { return Ok(Vec::new()) };
+    // ints arrive as ints (we wrote them), but accept the string form PMS uses everywhere too —
+    // this file is hand-editable on a rooted TV, and a quoted number is the likeliest hand edit.
+    let num = |v: Option<&Value>| match v {
+        Some(Value::Number(n)) => n.as_i64(),
+        Some(Value::String(s)) => s.trim().parse().ok(),
+        _ => None,
+    };
+    // `None` for anything that is not recognisably a yes or a no — and the row is then DROPPED,
+    // not read as "off". A word we do not understand is not an answer, and a wrong `false` is the
+    // worse of the two failures: it suppresses the library's default AND counts as a decision,
+    // where a dropped row simply falls back to the default like a library we have never seen.
+    let flag = |v: Option<&Value>| match v {
+        Some(Value::Bool(b)) => Some(*b),
+        Some(Value::Number(n)) => n.as_i64().map(|n| n != 0),
+        Some(Value::String(s)) => match s.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    };
+    Ok(rows
+        .iter()
+        .filter_map(|r| {
+            let o = r.as_object()?;
+            let machine_id = o.get("machine_id")?.as_str()?.to_string();
+            let section = num(o.get("section"))?;
+            let pinned = flag(o.get("pinned"))?;
+            // a row that names no server is not a decision about any library
+            (!machine_id.is_empty()).then_some(LibraryPin { machine_id, section, pinned })
+        })
+        .collect())
 }
 
 /// One persisted who's-watching tile (avatar + PIN flag; no tokens live here).
@@ -111,6 +199,15 @@ impl Session {
             &self.server.token
         }
     }
+    /// The recorded answer for one library, or `None` when nobody has answered for it — a new
+    /// share, a library added since, or a session that predates the field. `None` is the caller's
+    /// cue to apply the DEFAULT ([`crate::pms::pin::resolve`]), never to assume "off".
+    pub fn pin_of(&self, machine_id: &str, section: i64) -> Option<bool> {
+        self.pins
+            .iter()
+            .find(|p| p.machine_id == machine_id && p.section == section)
+            .map(|p| p.pinned)
+    }
 }
 
 /// Read the persisted session and nothing else — **no minting, no write.** For readers that merely
@@ -157,9 +254,48 @@ pub fn load() -> Session {
 /// legacy 0644 session written by an older build (the mode above only applies on creation) can
 /// never expose content either: at that moment the file is zero bytes.
 pub fn save(s: &Session) {
+    // A `save` never writes the caller's `pins` — see [`set_pins`], the one writer of that field.
+    let _ = write_out(s, false);
+}
+
+/// Record the pin table — **the only writer of [`Session::pins`]**, and the reason [`save`] leaves
+/// that field alone. `false` = nothing reached disk (see below), which the first-run route relies
+/// on: it must not retire its question on a write that did not happen.
+///
+/// The field needs a single writer because every OTHER writer here saves the WHOLE struct from a
+/// snapshot of unknown age. `auth` takes one into its controller when a profile switch starts and
+/// writes that clone back when the plex.tv roster lands — a plex.tv round trip later, and a
+/// keypress in the Library toolbar is far quicker than a stalled one. Merging by "an empty table
+/// means the writer doesn't know about pins" only covers a snapshot taken before the FIRST answer;
+/// giving the field an owner covers every snapshot, of any age, forever.
+///
+/// Refuses to write when the session on disk is unreadable, for the reason [`peek`] exists: `save`
+/// truncates in place, so writing a session assembled from a failed read is a silent sign-out, and
+/// this is a path a keypress reaches.
+pub fn set_pins(pins: Vec<LibraryPin>) -> bool {
+    let mut s = peek();
+    if s.client_id.is_empty() {
+        crate::log("session: no readable session on disk — pins not saved");
+        return false;
+    }
+    s.pins = pins;
+    write_out(&s, true)
+}
+
+/// The write itself. `own_pins` = the caller owns the `pins` field (only [`set_pins`] does); every
+/// other write takes the table from disk, so no stale snapshot can revert an answer.
+/// `false` = no candidate path accepted the write.
+fn write_out(s: &Session, own_pins: bool) -> bool {
     use std::io::Write;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-    let Ok(json) = serde_json::to_vec_pretty(s) else { return };
+    let merged;
+    let s = if own_pins {
+        s
+    } else {
+        merged = Session { pins: pins_for_save(&s.pins, || peek().pins), ..s.clone() };
+        &merged
+    };
+    let Ok(json) = serde_json::to_vec_pretty(s) else { return false };
     // Try each candidate; the first that accepts the write wins. A total failure is still
     // non-fatal — but it is LOGGED, because the symptom (sign in again, every boot, forever) is
     // otherwise indistinguishable from a server-side auth problem and impossible to report.
@@ -173,11 +309,25 @@ pub fn save(s: &Session) {
         if let Ok(mut f) = opened {
             let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
             if f.write_all(&json).is_ok() {
-                return;
+                return true;
             }
         }
     }
     crate::log("session: could not persist to ANY candidate path — login will not survive a reboot");
+    false
+}
+
+/// What a plain [`save`] puts in `pins`: **what is on disk**, not what the caller is holding.
+/// Pure, so the rule is testable without a session file; `stored` is read lazily so the decision
+/// costs nothing when there is nothing to protect. The caller's copy is used only when disk has
+/// none — the migration case, where dropping it would lose a table for good.
+fn pins_for_save(incoming: &[LibraryPin], stored: impl FnOnce() -> Vec<LibraryPin>) -> Vec<LibraryPin> {
+    let disk = stored();
+    if disk.is_empty() {
+        incoming.to_vec()
+    } else {
+        disk
+    }
 }
 
 /// Clear the persisted session (sign-out) — removes the file; a fresh `client_id` is minted next
@@ -263,5 +413,108 @@ impl Session {
             can_switch: !self.account_token.is_empty(),
             name,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pure: serde only. Nothing here reads or writes the session FILE — `save`'s candidate paths
+    /// are device paths, and a host test that wandered into them would be writing a real one.
+    fn parse(json: &str) -> Session {
+        serde_json::from_str(json).expect("the session must survive whatever `pins` holds")
+    }
+
+    /// The shape a real session has, with `pins` substituted in — so every assertion below is
+    /// also an assertion that the FIELDS AROUND IT survived.
+    fn with_pins(pins: &str) -> String {
+        format!(r#"{{"client_id":"cid-1","account_token":"tok","pins":{pins}}}"#)
+    }
+
+    /// **Empty means unknown, not none.** A session written before this field existed, and one
+    /// written with an empty table, must both come back as "nobody has answered yet" — the
+    /// resolver then applies the defaults. Reading either as "nothing is pinned" is an empty Home
+    /// on the first boot after an upgrade.
+    #[test]
+    fn an_absent_or_empty_pin_table_means_unknown() {
+        assert!(parse(r#"{"client_id":"cid-1"}"#).pins.is_empty());
+        assert!(parse(&with_pins("[]")).pins.is_empty());
+        assert_eq!(parse(&with_pins("[]")).account_token, "tok", "and the session is intact");
+    }
+
+    /// A written table round-trips, and an answer of "off" survives as an ANSWER: the table is a
+    /// decision log, not a set of pinned keys, so `Some(false)` and `None` must stay different —
+    /// that difference is what lets a share arriving next month default to off without reopening
+    /// the question about the libraries already answered.
+    #[test]
+    fn a_recorded_table_round_trips_including_the_noes() {
+        let s = Session {
+            client_id: "cid-1".into(),
+            pins: vec![
+                LibraryPin { machine_id: "aaaabbbb1111".into(), section: 1, pinned: true },
+                LibraryPin { machine_id: "ccccdddd2222".into(), section: 1, pinned: false },
+            ],
+            ..Session::default()
+        };
+        let back = parse(&serde_json::to_string(&s).unwrap());
+        assert_eq!(back.pin_of("aaaabbbb1111", 1), Some(true));
+        assert_eq!(back.pin_of("ccccdddd2222", 1), Some(false), "a recorded 'off' is not 'unanswered'");
+        assert_eq!(back.pin_of("ccccdddd2222", 2), None, "…and a library nobody ruled on is unanswered");
+        assert_eq!(back.pin_of("aaaabbbb1111", 1), Some(true), "the key is per SERVER: both are library 1");
+    }
+
+    /// A corrupt table degrades to unknown — it must never fail the whole `Session` parse. That
+    /// failure is a SILENT SIGN-OUT: `peek` falls through to a default session and `load` mints a
+    /// fresh client id over the real one, so the user re-does the QR sign-in every boot and the
+    /// cause is invisible. Every shape here is one the field can meet on a rooted TV with a
+    /// hand-editable file.
+    #[test]
+    fn a_corrupt_pin_table_degrades_to_defaults_instead_of_signing_the_user_out() {
+        for bad in [r#""nope""#, "null", "17", r#"{"aaaabbbb1111":true}"#, "[1,2,3]", r#"[null,{},[]]"#] {
+            let s = parse(&with_pins(bad));
+            assert!(s.pins.is_empty(), "{bad} should read as unknown");
+            assert_eq!(s.client_id, "cid-1", "{bad} must not cost the client id");
+            assert_eq!(s.account_token, "tok", "{bad} must not cost the account token");
+        }
+    }
+
+    /// The persisted table survives a write by ANY other writer, whatever that writer is holding.
+    /// `auth` saves a whole-`Session` clone it snapshotted when a profile switch started — before
+    /// the user reached the Library toolbar and answered — so a table that is merely *older* has
+    /// to lose to disk just as an empty one does. That is why the field has one owner
+    /// ([`set_pins`]) instead of a merge rule.
+    #[test]
+    fn no_other_writer_can_revert_the_pin_table() {
+        let disk = vec![LibraryPin { machine_id: "aaaabbbb1111".into(), section: 1, pinned: false }];
+        let stale = vec![LibraryPin { machine_id: "aaaabbbb1111".into(), section: 1, pinned: true }];
+        let written = pins_for_save(&stale, || disk.clone());
+        assert_eq!(written.len(), 1);
+        assert!(!written[0].pinned, "disk wins over a snapshot of unknown age");
+
+        assert!(pins_for_save(&[], Vec::new).is_empty(), "nothing anywhere is still nothing");
+        assert_eq!(
+            pins_for_save(&stale, Vec::new).len(),
+            1,
+            "with nothing on disk the caller's copy is the only table there is"
+        );
+    }
+
+    /// Corruption is per ROW where it can be: the rows around a broken one are still answers the
+    /// user gave, and the libraries whose rows were lost simply fall back to their default —
+    /// which is exactly what a library we have never seen does. The lenient number/flag reading
+    /// is for the hand edit: a quoted number is the likeliest one.
+    #[test]
+    fn one_broken_row_costs_only_that_row() {
+        let s = parse(&with_pins(
+            r#"[{"machine_id":"aaaabbbb1111","section":"2","pinned":"1"},
+                {"section":9,"pinned":true},
+                {"machine_id":"","section":1,"pinned":true},
+                {"machine_id":"ccccdddd2222","section":1,"pinned":0}]"#,
+        ));
+        assert_eq!(s.pins.len(), 2, "the two rows that name a library survive");
+        assert_eq!(s.pin_of("aaaabbbb1111", 2), Some(true), "\"2\"/\"1\" read as 2/true");
+        assert_eq!(s.pin_of("ccccdddd2222", 1), Some(false), "0 reads as false");
     }
 }

--- a/rust-modules/src/pms.rs
+++ b/rust-modules/src/pms.rs
@@ -179,6 +179,426 @@ pub(crate) fn parse_item(it: &crate::plex::Metadata) -> PmsMovie {
 // PAGED catalog — sparse store + off-thread page fetches via `section_items_query`). This
 // module stays hub-only; `browse` reuses `parse_item` above for its listings.
 
+// ---- pinning: which libraries reach Home ----------------------------------------------------
+
+// The presses that drive this — the Sources list's `On Home` level and the first-run route —
+// land in sibling units; the model goes in first so both are written against ONE answer instead
+// of each inventing its own. Until they arrive, most of the surface below is reachable only from
+// the tests, which is what this allow is for.
+#[allow(dead_code)]
+pub(crate) mod pin {
+    //! **Which libraries feed Home** — the one user-facing control shared servers introduce, and
+    //! the only thing in the app that a granted library can be turned off from.
+    //!
+    //! Three states, orthogonal, and conflating any two of them is the bug this module exists to
+    //! prevent:
+    //!
+    //! - **granted** — plex.tv's answer. Not a setting. The app has no server on/off at all; a
+    //!   share you were given is browsable whether or not it is pinned.
+    //! - **pinned** — the only control there is. A pinned library feeds Home; an unpinned one
+    //!   does not. *Nothing else changes.*
+    //! - **reachable** — a fact about right now. A pinned server that does not answer still reads
+    //!   `On`, because nothing was turned off (hiding it would read as a revoked share).
+    //!
+    //! **Home consults the pin, and nothing else does.** The section table, the tab strip, the
+    //! browse grid's paging, the sort menu and the A–Z rail all come from the GRANT. That is why
+    //! unpinning your own server is legitimate and gets no warning: a friend's films on your front
+    //! door, your own library still one press away on its own tab. The single call site is
+    //! [`super::build_hubs`], which is what makes the claim checkable — grep `feeds_home`.
+    //!
+    //! ## The rules, and where each is enforced
+    //!
+    //! 1. **Defaults** ([`resolve`]): your own libraries pinned, a friend's not. The point of
+    //!    asking is not to put a stranger's shelves on your front door unannounced.
+    //! 2. **The last pinned library cannot be unpinned** ([`apply`]). An empty Home is the only
+    //!    real failure this control can produce, so the refusal lives in the data layer and no UI
+    //!    can route around it. (The list still draws the row live — only its *value* dims. Dim
+    //!    means unavailable, and that library is the one that works.)
+    //! 3. **Unknown is not none.** An empty persisted table means nobody has answered yet, so the
+    //!    defaults apply; an empty ROSTER means we have not been told what exists yet, so the
+    //!    gate passes everything ([`PinSet::feeds_home`]). Both readings exist because the
+    //!    opposite one shows an empty Home on a first boot after an upgrade.
+    //! 4. **Continue Watching's merge is conditional on pinning** — a borrowed item joins the
+    //!    merged shelf only once its library is pinned. It falls out of rule 3's single gate: the
+    //!    shelf is built from items, and every item goes through it.
+    //!
+    //! ## Threading
+    //!
+    //! The resolved set is main-thread state like every other static in this module. The hub
+    //! fetch runs on a worker, so it takes a [`snapshot`] **captured at the spawn site** and
+    //! carries it in — nothing here is read from a worker thread.
+    use crate::plex::session::{self, LibraryPin};
+    use std::ptr::{addr_of, addr_of_mut};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A library's identity across servers: `machineIdentifier` + its section key. A section key
+    /// is only unique within one server (every PMS numbers its first library `1`).
+    #[derive(Clone, Default, PartialEq, Eq, Debug)]
+    pub(crate) struct LibKey {
+        pub(crate) machine_id: String,
+        pub(crate) section: i64,
+    }
+
+    impl LibKey {
+        pub(crate) fn new(machine_id: &str, section: i64) -> Self {
+            LibKey { machine_id: machine_id.to_string(), section }
+        }
+    }
+
+    /// One granted library, as the pin model needs to see it. Everything else about a library —
+    /// its title, its type, the handle of the friend who shared it, whether it answered — belongs
+    /// to the roster that owns the grant, not here.
+    ///
+    /// It maps straight off what the roster already holds: `machine_id` is the registry key
+    /// (`plex::account::Resource::client_identifier`, i.e. `Client::machine_id`), `section` is a
+    /// `LibrarySection::key` from that server's `/library/sections`, and `owned` is
+    /// `Resource::owned` — plex.tv's own word for it, not a guess derived from `source_title`.
+    #[derive(Clone, Debug)]
+    pub(crate) struct Granted {
+        pub(crate) key: LibKey,
+        /// the account's own server, as opposed to a share someone gave it
+        pub(crate) owned: bool,
+    }
+
+    /// One resolved library: is it on Home, and is it ours. `owned` rides along because both
+    /// readers need it — the rescue in [`resolve`] prefers your own libraries, and the Sources
+    /// list groups by server.
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub(crate) struct Row {
+        pub(crate) key: LibKey,
+        pub(crate) owned: bool,
+        pub(crate) on: bool,
+    }
+
+    /// The resolved answer for every granted library: what the persisted table says, or the
+    /// default where it says nothing. One value, read by Home AND by the list that governs it —
+    /// they must never be able to disagree, which is why the rescue in [`resolve`] is here and
+    /// not a floor Home applies on its own.
+    #[derive(Clone, Default, PartialEq, Eq, Debug)]
+    pub(crate) struct PinSet {
+        rows: Vec<Row>,
+    }
+
+    /// What [`set`] did — the last-pinned refusal is a value, not a silent no-op, so the UI can
+    /// tell "you turned it off" from "that one is holding Home up".
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub(crate) enum Set {
+        /// the pin moved (and was persisted)
+        Applied,
+        /// already in that state — nothing to do
+        Unchanged,
+        /// refused: it is the last pinned library, and Home may not be emptied
+        LastPinned,
+        /// no such library in the granted roster (a stale row, or the roster has not landed)
+        NotGranted,
+    }
+
+    /// Resolve the roster against the persisted decisions. **Pure** — the whole model is here.
+    ///
+    /// Per library: the recorded answer if there is one, else the default (own → on, shared →
+    /// off). Then the rescue below, for a non-empty roster that resolves to NOTHING pinned.
+    ///
+    /// The rescue is not a floor over the user's choice — the last-pinned rule means they cannot
+    /// reach an empty set by pressing OK. It catches the two ways the WORLD can produce one: an
+    /// account with **no libraries of its own** (a borrowed-only install is not a mode — it draws
+    /// the same Home as anyone else), and a grant disappearing out from under the only pin the
+    /// user had.
+    ///
+    /// A rescued value is a REAL value, not a private correction: the Sources list is this same
+    /// function, so the user sees those rows reading `On`, and the next [`record`] writes them
+    /// down as the answers they are. That is deliberate. The alternative — keeping the rescue
+    /// ephemeral so the file still says `off` — makes the file disagree with the screen, and Home
+    /// then changes on its own the day the missing grant comes back, which is the harder bug to
+    /// explain. Nothing here can write something the user was not shown.
+    ///
+    /// **Which libraries it pins is the whole subtlety**, because the alternative to an empty Home
+    /// must not be a stranger's shelves on the front door — the thing rule 1 exists to prevent. It
+    /// takes the first tier below that matches anything, and takes ONE row from a tier that
+    /// contradicts an answer, all of a tier that contradicts nothing. So it overrules a recorded
+    /// "off" only where the alternative is an empty Home, overrules YOUR OWN first (an owned
+    /// library on your own Home is never a surprise), and takes back exactly one when it does.
+    pub(crate) fn resolve(roster: &[Granted], persisted: &[LibraryPin]) -> PinSet {
+        let recorded: Vec<Option<bool>> = roster
+            .iter()
+            .map(|g| {
+                persisted
+                    .iter()
+                    .find(|p| p.machine_id == g.key.machine_id && p.section == g.key.section)
+                    .map(|p| p.pinned)
+            })
+            .collect();
+        let mut rows: Vec<Row> = roster
+            .iter()
+            .zip(&recorded)
+            .map(|(g, rec)| Row { key: g.key.clone(), owned: g.owned, on: rec.unwrap_or(g.owned) })
+            .collect();
+        if !rows.is_empty() && !rows.iter().any(|r| r.on) {
+            // Tiers, in order, and how much of each to take back. Note what is NOT here: "your own,
+            // unanswered". Such a row defaults ON, so it cannot be present when nothing is on —
+            // the rescue only ever meets libraries that are off for a REASON.
+            type Tier = fn(&Row, bool) -> bool;
+            const TIERS: [(Tier, bool); 3] = [
+                // yours, all of which must be answered "off" to be here — so take back ONE, the
+                // fewest answers that can un-empty Home, and yours before anyone else's.
+                (|r, _| r.owned, true),
+                // shares nobody has ruled on: no answer to contradict, so all of them. This is the
+                // borrowed-only account, which is not a mode — it gets the Home an owner gets.
+                (|_, answered| !answered, false),
+                // everything is answered off and none of it is yours: one, so the door opens.
+                (|_, _| true, true),
+            ];
+            let hits = |t: Tier| -> Vec<bool> {
+                rows.iter().zip(&recorded).map(|(r, rec)| t(r, rec.is_some())).collect()
+            };
+            if let Some((h, one)) = TIERS.iter().map(|&(t, one)| (hits(t), one)).find(|(h, _)| h.contains(&true)) {
+                for (r, _) in rows.iter_mut().zip(h).filter(|(_, hit)| *hit) {
+                    r.on = true;
+                    if one {
+                        break;
+                    }
+                }
+            }
+        }
+        PinSet { rows }
+    }
+
+    /// Flip one library, enforcing the last-pinned rule. **Pure** — [`set`] is this plus the
+    /// statics and the write, so the rule is testable without a session file.
+    pub(crate) fn apply(rows: &mut [Row], key: &LibKey, on: bool) -> Set {
+        let Some(i) = rows.iter().position(|r| &r.key == key) else { return Set::NotGranted };
+        if rows[i].on == on {
+            return Set::Unchanged;
+        }
+        if !on && rows.iter().filter(|r| r.on).count() <= 1 {
+            return Set::LastPinned; // the only real failure this control can produce
+        }
+        rows[i].on = on;
+        Set::Applied
+    }
+
+    impl PinSet {
+        /// Does an item from this library reach Home?
+        ///
+        /// **Unknown passes.** An empty set means no roster has been installed yet (boot, or a
+        /// build with no roster at all) and a key we have never heard of is equally unanswered —
+        /// in both cases the honest answer is the item, not a blank Home. The gate can only ever
+        /// subtract from what the user has explicitly answered.
+        ///
+        /// Compares the fields rather than building a `LibKey` to look one up: this runs once per
+        /// item of every hub of both responses, and the temporary key would be a heap allocation
+        /// per item — a few hundred per fetch, on an ARMv7 set, to answer a string comparison.
+        pub(crate) fn feeds_home(&self, machine_id: &str, section: i64) -> bool {
+            self.rows
+                .iter()
+                .find(|r| r.key.section == section && r.key.machine_id == machine_id)
+                .map(|r| r.on)
+                .unwrap_or(true)
+        }
+        /// One library's row, or None when the roster does not name it. **Everything that asks a
+        /// question about a SPECIFIC library goes through here**, because [`feeds_home`]'s
+        /// "unknown passes" answer is right for an item reaching Home and wrong for every other
+        /// question: an unknown key is not "the last pinned library", and it is not a row the
+        /// Sources list can draw.
+        ///
+        /// [`feeds_home`]: PinSet::feeds_home
+        pub(crate) fn row(&self, key: &LibKey) -> Option<&Row> {
+            self.rows.iter().find(|r| &r.key == key)
+        }
+        /// The libraries Home should fetch. (A multi-source Home fetches only these; a source
+        /// with none of its libraries pinned is not contacted for Home at all.)
+        pub(crate) fn pinned(&self) -> impl Iterator<Item = &LibKey> {
+            self.rows.iter().filter(|r| r.on).map(|r| &r.key)
+        }
+        /// How many libraries feed Home.
+        pub(crate) fn pinned_count(&self) -> usize {
+            self.rows.iter().filter(|r| r.on).count()
+        }
+        /// This library is pinned and is the only one — the row whose value the list draws dimmed,
+        /// and the one press [`apply`] refuses.
+        pub(crate) fn is_last_pinned(&self, key: &LibKey) -> bool {
+            self.pinned_count() == 1 && self.row(key).is_some_and(|r| r.on)
+        }
+        /// A roster has been resolved (as opposed to "we have not been told yet").
+        pub(crate) fn is_known(&self) -> bool {
+            !self.rows.is_empty()
+        }
+        /// The whole table, for the Sources list: one row per granted library, in roster order.
+        /// Borrowed from THIS set — take a [`snapshot`] and read it from that, never from the
+        /// process-wide one, which [`set`] mutates and [`install_roster`] replaces wholesale.
+        pub(crate) fn rows(&self) -> &[Row] {
+            &self.rows
+        }
+        /// The libraries Home must leave out — the only part of this set Home can observe, since
+        /// an unknown key passes. Two sets with the same exclusions produce the same Home, which
+        /// is what [`install_roster`] compares to decide whether a refetch is owed at all.
+        /// SORTED, because roster order is plex.tv's to choose and nothing promises it is stable:
+        /// compared in arrival order, the same libraries coming back shuffled would read as a
+        /// change and refetch Home for nothing — the very thing the comparison is here to avoid.
+        fn exclusions(&self) -> Vec<&LibKey> {
+            let mut out: Vec<&LibKey> = self.rows.iter().filter(|r| !r.on).map(|r| &r.key).collect();
+            out.sort_by(|a, b| (&a.machine_id, a.section).cmp(&(&b.machine_id, b.section)));
+            out
+        }
+    }
+
+    // ---- process state (main thread only) ----------------------------------------------------
+
+    /// The resolved answer. Empty until a roster lands — which the gate reads as "unknown".
+    ///
+    /// The roster ITSELF is deliberately not kept beside it. There is no re-resolve path — [`set`]
+    /// moves a row in place and [`record`] writes it through — so a stored copy would be state
+    /// [`reset`] has to keep in sync for nothing, and it would suggest a "re-resolve from what we
+    /// last knew" that does not exist. The roster's owner already holds it; it is handed here to be
+    /// resolved, not to be stored.
+    static mut PINS: PinSet = PinSet { rows: Vec::new() };
+    /// Bumped whenever the answer changes. Home's [`super::pump`] watches it and refetches, so a
+    /// pin toggled in the Library toolbar reaches the shelves without the UI having to know that
+    /// Home is even a thing — and several toggles in one visit coalesce into one fetch.
+    static PIN_GEN: AtomicU32 = AtomicU32::new(0);
+
+    fn pins() -> &'static PinSet {
+        unsafe { &*addr_of!(PINS) }
+    }
+
+    /// Install the granted roster (call on every roster landing — boot, a refresh, "Check for new
+    /// shares"). Re-resolves against the persisted decisions; does NOT write anything, because
+    /// resolving is not answering: writing here would spend the first-run question the moment a
+    /// roster arrived.
+    pub(crate) fn install_roster(roster: &[Granted]) {
+        let resolved = resolve(roster, &session::peek().pins);
+        let (n, on) = (resolved.rows.len(), resolved.pinned_count());
+        // Only an EXCLUSION is observable on Home (an unknown key passes), so a roster landing
+        // that changes none of them owes no refetch. That is the ordinary boot: the roster arrives
+        // moments after the blocking hub fetch, and without this every single boot would refetch
+        // both hub endpoints and drop a populated Home back to Loading to arrive at the same
+        // shelves.
+        let same = resolved.exclusions() == pins().exclusions();
+        unsafe { *addr_of_mut!(PINS) = resolved };
+        if !same {
+            PIN_GEN.fetch_add(1, Ordering::SeqCst);
+        }
+        crate::log(&format!("pins: {on} of {n} libraries feed Home"));
+    }
+
+    /// The resolved set, as owned data — **capture this at the spawn site**, never inside a
+    /// worker (`static mut` is main-thread-only here, like every other static in this module).
+    pub(crate) fn snapshot() -> PinSet {
+        pins().clone()
+    }
+
+    /// Does this library feed Home? (main-thread convenience over [`snapshot`])
+    pub(crate) fn feeds_home(machine_id: &str, section: i64) -> bool {
+        pins().feeds_home(machine_id, section)
+    }
+
+    /// This library is the last pinned one — the list draws its value dimmed and OK does nothing.
+    pub(crate) fn is_last_pinned(key: &LibKey) -> bool {
+        pins().is_last_pinned(key)
+    }
+
+    // There is deliberately NO borrowing accessor for the whole table. One would hand out a
+    // `&'static` into `PINS`, and the obvious use of it — walk the rows, press OK on one — would
+    // then hold a shared borrow of the very rows `set` takes `&mut` to, with `install_roster` free
+    // to drop the Vec underneath it. The Sources list walks a `snapshot()` instead: it is a dozen
+    // rows built once per panel, and it cannot be invalidated by the press it exists to make.
+
+    /// The pin generation (see [`PIN_GEN`]).
+    pub(crate) fn gen() -> u32 {
+        PIN_GEN.load(Ordering::SeqCst)
+    }
+
+    /// Pin or unpin one library, persist the answer, and tell Home. The last-pinned refusal is
+    /// returned rather than swallowed — see [`Set`].
+    ///
+    /// A failed WRITE is not in the return value, and that is a decision rather than an oversight:
+    /// there is no such row in the design and no words for one on screen. It is logged instead, so
+    /// the fact survives where it can be read — a support log — rather than becoming a fourth case
+    /// every call site has to pretend to render. What an unsaved pin does NOT do is hold forever:
+    /// [`install_roster`] re-resolves from the file, so the next roster landing — a refresh,
+    /// "Check for new shares" — puts the library back the way disk says.
+    pub(crate) fn set(key: &LibKey, on: bool) -> Set {
+        let r = apply(unsafe { &mut (*addr_of_mut!(PINS)).rows }, key, on);
+        if r == Set::Applied {
+            record();
+            PIN_GEN.fetch_add(1, Ordering::SeqCst);
+            crate::ui::idle::invalidate(); // the row's value flips under a settled panel
+        }
+        r
+    }
+
+    /// Write the current answers down — including the ones that are still defaults. The first-run
+    /// screen calls this for BOTH of its exits (`Start watching` and the skip): the defaults it
+    /// showed were an answer, and recording them is what stops that screen coming back. A share
+    /// that arrives afterwards is unanswered on its own and lands unpinned, in the Sources list,
+    /// where "Check for new shares" already lives.
+    ///
+    /// **False means nothing was written** — no roster has resolved (so there is nothing to
+    /// answer), or the session file is unreadable. It is returned rather than swallowed because
+    /// the caller's whole reason for calling is that this screen must not come back, and a silent
+    /// no-op here is a first-run question asked again on every boot. A route that shows a LIST of
+    /// libraries can only be up when [`PinSet::is_known`], so in practice this is a tripwire.
+    pub(crate) fn acknowledge() -> bool {
+        record()
+    }
+
+    /// Has anyone ever answered? (Empty means unknown — see [`session::Session::pins`].) The
+    /// first-run route's gate; a boot-path read, not a per-frame one — it opens the session file.
+    pub(crate) fn asked() -> bool {
+        !session::peek().pins.is_empty()
+    }
+
+    /// Persist the resolved table into the session, keeping decisions about libraries outside the
+    /// current roster (a server that is merely not in this roster read — a stale grant, or a
+    /// roster that has not landed yet — must not lose the answer the user gave it).
+    fn record() -> bool {
+        let rows = pins().rows();
+        if rows.is_empty() {
+            crate::log("pins: nothing resolved to record (no roster yet)");
+            return false;
+        }
+        // A row whose server has no `machineIdentifier` is UNKEYED, and the reader drops exactly
+        // those (`session::de_pins`) — a half-blank key names no library, and two servers with
+        // blank ids would be the same one. Writing them would round-trip to nothing: the pin would
+        // read as saved, then be gone at the next boot, taking the first-run question's answer with
+        // it. So they are skipped here, loudly, rather than written into a hole.
+        let (keyed, unkeyed): (Vec<&Row>, Vec<&Row>) = rows.iter().partition(|r| !r.key.machine_id.is_empty());
+        if !unkeyed.is_empty() {
+            crate::log(&format!(
+                "pins: {} librar{} on a server with no machineIdentifier — held for this run, not saved",
+                unkeyed.len(),
+                if unkeyed.len() == 1 { "y" } else { "ies" }
+            ));
+        }
+        if keyed.is_empty() {
+            return false;
+        }
+        let mut s = session::peek();
+        s.pins.retain(|p| !keyed.iter().any(|r| r.key.machine_id == p.machine_id && r.key.section == p.section));
+        s.pins.extend(keyed.iter().map(|r| LibraryPin {
+            machine_id: r.key.machine_id.clone(),
+            section: r.key.section,
+            pinned: r.on,
+        }));
+        // …through the field's one writer, which also reports whether anything reached disk. A
+        // `save` here would be the stale-snapshot bug this model spent a finding learning about.
+        session::set_pins(s.pins)
+    }
+
+    /// Drop the roster and the resolved set — the identity-change wipe, driven by
+    /// [`super::reset`]. The next account's pins come from ITS session file, and until its roster
+    /// lands the gate is back to passing everything.
+    pub(crate) fn reset() {
+        unsafe { *addr_of_mut!(PINS) = PinSet::default() };
+        PIN_GEN.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Test hook: install a resolved set directly, without a session file or a roster fetch.
+    #[cfg(test)]
+    pub(crate) fn seed_for_test(rows: Vec<Row>) {
+        unsafe { *addr_of_mut!(PINS) = PinSet { rows } };
+    }
+}
+
 // ---- home hubs: each hub is a titled slice of the catalog ----
 struct HubRow {
     title: String,
@@ -270,13 +690,57 @@ pub(crate) fn refetch_hubs_reconcile() -> c_int {
 /// old comment was defending is intact — all three statics still only ever move together.
 pub(crate) fn pms_fetch_hubs() -> c_int {
     HUB_GEN.fetch_add(1, Ordering::SeqCst); // supersede any retry already in flight
-    match catch_unwind(fetch_build) {
+    dev_roster();
+    // Read on the MAIN THREAD and passed in, exactly as `kick_refetch` does it for the worker —
+    // one rule for both callers, so the off-thread path can never be the only one that is safe.
+    let src = source_id();
+    let pins = pin::snapshot();
+    unsafe { std::ptr::addr_of_mut!(PIN_APPLIED).write(pin::gen()) };
+    match catch_unwind(|| fetch_build(&src, &pins)) {
         Ok(Some(build)) => commit(build),
         _ => {
             fail();
             catalog().len() as c_int
         }
     }
+}
+
+/// dev: **`/tmp/plxnative-shared=<csv of section keys>`** — the pin model's only on-device
+/// handle until the Sources list lands.
+///
+/// It installs a granted roster made of THIS server's own sections, marking the listed ones as
+/// though a friend had shared them — so they arrive **unpinned by default** and their shelves
+/// leave Home, while the tab strip, the browse grid, its sort menu and its A–Z rail (all of which
+/// read the grant, never the pin) stay exactly as they were. That pair of boots is the whole
+/// visible claim of this unit, and there is no other way to photograph it before the roster
+/// transport and the toolbar chip exist. An empty value (`touch` the file) installs the roster
+/// with everything owned, which is the "nothing is excluded" control.
+///
+/// **List all but one.** Listing EVERY section is the rescue case, not the demo: nothing would
+/// resolve pinned, so `resolve` un-empties Home and the screen is unchanged — correct behaviour
+/// that looks exactly like a broken feature. The boot log settles it either way; it prints
+/// `pins: <on> of <n> libraries feed Home` right after the roster line.
+///
+/// Costs one small `GET /library/sections` per hub fetch while it is armed, and nothing at all
+/// otherwise: `dev::read` is a compile-time `None` in a `RELEASE=1` build, so the fetch below is
+/// unreachable and folds away with it. Re-runs until a roster is installed, so it survives a
+/// profile switch (which resets the pins) without a latch of its own.
+fn dev_roster() {
+    if pin::snapshot().is_known() {
+        return;
+    }
+    let Some(spec) = crate::dev::read("shared") else { return };
+    let shared: Vec<i64> = spec.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+    let mid = source_id();
+    let Some(mc) = crate::plex::client_opt().and_then(|c| c.sections()) else { return };
+    let roster: Vec<pin::Granted> = mc
+        .directory
+        .iter()
+        .filter_map(|d| d.key.trim().parse::<i64>().ok())
+        .map(|k| pin::Granted { key: pin::LibKey::new(&mid, k), owned: !shared.contains(&k) })
+        .collect();
+    crate::log(&format!("pins: dev roster — {} libraries, {:?} treated as shared", roster.len(), shared));
+    pin::install_roster(&roster);
 }
 
 /// The catalog/hubs/pool triple a fetch produces, before it is committed. Owned data only, so
@@ -286,7 +750,10 @@ type HubBuild = (Vec<PmsMovie>, Vec<HubRow>, Vec<usize>);
 /// GET /hubs and project it — the whole fetch, minus the commit. `None` = the request failed
 /// (transport, HTTP, or parse), which is NOT the same as a server with no hubs (`Some` with an
 /// empty build). Shared verbatim by the blocking boot fetch and the off-thread retry.
-fn fetch_build() -> Option<HubBuild> {
+///
+/// `pins` is the pin gate, carried IN rather than read here: this runs on a worker for every
+/// retry, and the resolved set is main-thread state.
+fn fetch_build(src: &str, pins: &pin::PinSet) -> Option<HubBuild> {
     let c = crate::plex::client_opt()?;
     let mc = c.home_hubs(12)?;
     // The Continue Watching shelf comes from the DEDICATED hub, not from `/hubs`'s
@@ -295,11 +762,49 @@ fn fetch_build() -> Option<HubBuild> {
     // last consistent values, and `pump` retries on a backoff. Losing the most important shelf to a
     // transient error would be worse than briefly showing the previous one.
     let cw = c.continue_watching(12)?;
-    Some(build_hubs(&mc, &cw))
+    Some(build_hubs(&mc, &cw, src, pins))
 }
 
+/// The `machineIdentifier` these hubs' items should be keyed on — the other half of a
+/// [`pin::LibKey`], since a section key is only unique within one server. **Main thread only**
+/// (it reads the session file), so the fetch path captures it at the spawn site like the pin set.
+///
+/// Two sources, in this order, and the second is not a nicety. The registry keys on the id and
+/// hands each server's `Client` its own — but the legacy `plex::install(host, port, token)`, which
+/// is still how EVERY boot on this build reaches its server, registers with an empty one
+/// (`plex/servers.rs`: the caller has a stored address and no id). An empty id matches no row, so
+/// the whole gate would quietly pass everything while looking like it worked. The stored session
+/// has the real id — `auth` writes `ServerRef::machine_id` from the same `clientIdentifier` the
+/// roster is keyed by — so it is the fallback until a registration supplies one.
+fn source_id() -> String {
+    let live = crate::plex::client_opt().map(|c| c.machine_id().to_string()).unwrap_or_default();
+    if !live.is_empty() {
+        return live;
+    }
+    unsafe {
+        if (*std::ptr::addr_of!(SOURCE)).is_none() {
+            *std::ptr::addr_of_mut!(SOURCE) = Some(crate::plex::session::peek().server.machine_id);
+        }
+        (*std::ptr::addr_of!(SOURCE)).clone().unwrap_or_default()
+    }
+}
+/// Cache for [`source_id`]'s session fallback — cleared by [`reset`], i.e. exactly when
+/// `install_pms` can have changed which server we are on.
+static mut SOURCE: Option<String> = None;
+
 /// Project a /hubs response into the catalog/hubs/pool triple. Pure — no statics, no I/O.
-fn build_hubs(mc: &crate::plex::MediaContainer, cw: &crate::plex::MediaContainer) -> HubBuild {
+///
+/// **This is the one place Home consults the pin** (`pins.feeds_home`), and it consults it per
+/// ITEM rather than per shelf, because the merged Continue Watching row draws from every source
+/// at once: a borrowed film joins it only once its library is pinned, and a shelf left empty by
+/// the filter is dropped like any other empty one. The hero pool is built from the shelves below,
+/// so it inherits the same gate for free — a borrowed hero is always the consequence of a pin.
+fn build_hubs(
+    mc: &crate::plex::MediaContainer,
+    cw: &crate::plex::MediaContainer,
+    src: &str,
+    pins: &pin::PinSet,
+) -> HubBuild {
     let mut new_cat: Vec<PmsMovie> = Vec::new();
     let mut new_hubs: Vec<HubRow> = Vec::new();
     let mut new_pool: Vec<usize> = Vec::new();
@@ -321,8 +826,11 @@ fn build_hubs(mc: &crate::plex::MediaContainer, cw: &crate::plex::MediaContainer
     let mut shelves: Vec<(String, String, Vec<&crate::plex::Metadata>)> = Vec::new(); // (title, hubIdentifier, items)
     let mut cw_idx: Option<usize> = None; // shelves slot of Continue Watching
     for hub in cw.hub.iter() {
-        let items: Vec<&crate::plex::Metadata> =
-            hub.metadata.iter().filter(|m| !SKIP.contains(&m.kind.as_str())).collect();
+        let items: Vec<&crate::plex::Metadata> = hub
+            .metadata
+            .iter()
+            .filter(|m| !SKIP.contains(&m.kind.as_str()) && pins.feeds_home(src, m.library_section_id))
+            .collect();
         if items.is_empty() {
             continue;
         }
@@ -339,7 +847,12 @@ fn build_hubs(mc: &crate::plex::MediaContainer, cw: &crate::plex::MediaContainer
         if hub.hub_identifier == "home.continue" || hub.hub_identifier == "home.ondeck" {
             continue; // superseded by the dedicated hub above
         }
-        shelves.push((hub.title.clone(), hub.hub_identifier.clone(), hub.metadata.iter().collect()));
+        let items: Vec<&crate::plex::Metadata> =
+            hub.metadata.iter().filter(|m| pins.feeds_home(src, m.library_section_id)).collect();
+        if items.is_empty() {
+            continue; // every item belonged to an unpinned library — the shelf is not Home's
+        }
+        shelves.push((hub.title.clone(), hub.hub_identifier.clone(), items));
     }
     if let Some(si) = cw_idx {
         // stable sort: most recently played first; equal timestamps keep hub order.
@@ -438,6 +951,12 @@ static HUB_GEN: AtomicU32 = AtomicU32::new(0);
 /// fetch again for the rest of the session.
 static HUBS_FETCHING: AtomicBool = AtomicBool::new(false);
 
+/// The [`pin`] generation the committed shelves were built against. [`pump`] refetches when it
+/// falls behind, which is how a pin toggled in the Library toolbar reaches Home: the UI changes
+/// one bit and says nothing to this module, several toggles in one visit coalesce into one fetch,
+/// and no keypress ever blocks the loop on a network round trip. Main-thread only, like the rest.
+static mut PIN_APPLIED: u32 = 0;
+
 /// Seconds until the next automatic attempt, and the consecutive-failure count that sizes it.
 /// Main-thread only (stepped by [`pump`], which the Home update drives).
 static mut RETRY_S: f32 = 0.0;
@@ -512,8 +1031,13 @@ fn kick_refetch() {
         std::ptr::addr_of_mut!(RETRY_S).write(0.0);
     }
     let gen = HUB_GEN.load(Ordering::SeqCst);
+    // CAPTURE AT THE SPAWN SITE: the resolved pin set and the source id are main-thread state
+    // (the latter reads the session file), so both are read here and MOVED into the worker.
+    let src = source_id();
+    let pins = pin::snapshot();
+    let pin_gen = pin::gen();
     let spawned = crate::task::spawn_small("hubs", move || {
-        let built = catch_unwind(fetch_build).ok().flatten();
+        let built = catch_unwind(|| fetch_build(&src, &pins)).ok().flatten();
         // filled OUTSIDE the guard so a panicking fetch still lands (as a failure) rather than
         // latching the single flight forever
         *HUB_RESULT.lock().unwrap_or_else(|e| e.into_inner()) =
@@ -525,6 +1049,11 @@ fn kick_refetch() {
         HUBS_FETCHING.store(false, Ordering::SeqCst);
         fail();
     } else {
+        // Only now: `PIN_APPLIED` claims the committed shelves were built against these pins, and
+        // a refused spawn builds nothing. Setting it before the spawn would retire the pin-change
+        // trigger for a fetch that never ran, leaving an unpinned library's shelves on Home until
+        // some unrelated retry happened to come round.
+        unsafe { std::ptr::addr_of_mut!(PIN_APPLIED).write(pin_gen) };
         crate::log("hubs: retrying (off-thread)");
     }
 }
@@ -568,6 +1097,20 @@ pub(crate) fn pump(dt: f32) {
             HubLanding::Failed(_) => fail(),
         }
     }
+    // A pin moved since these shelves were built, so they describe a Home the user has since
+    // changed. Refetch rather than filter what is committed: an unpinned library's items are gone
+    // from the catalog the shelves index into, and a newly pinned one was never fetched at all.
+    //
+    // Only from Ready, which is what keeps this off the ladder's toes: any other state already
+    // owes a fetch, and that fetch takes a fresh snapshot anyway. Without the guard, a refused
+    // spawn (`fail()` → Failed, PIN_APPLIED left behind) would come straight back here on the next
+    // frame and try again — a worker spawn attempt per frame, the exact thing the backoff exists
+    // to prevent.
+    let pin_stale = unsafe { std::ptr::addr_of!(PIN_APPLIED).read() } != pin::gen();
+    if pin_stale && hub_state() == HubState::Ready && !HUBS_FETCHING.load(Ordering::SeqCst) {
+        kick_refetch(); // sets PIN_APPLIED once the worker is actually running
+        return;
+    }
     // Anything but Ready with nothing in flight is a state only a fetch can leave: Failed (with a
     // backoff owed) or a Loading whose worker landed stale and was dropped — the latter owes
     // nothing, so it re-kicks on the spot rather than wedging Home on a spinner forever.
@@ -607,13 +1150,19 @@ pub(crate) fn reset() {
     HUB_GEN.fetch_add(1, Ordering::SeqCst); // a worker still running belongs to the old identity
     *HUB_RESULT.lock().unwrap_or_else(|e| e.into_inner()) = None;
     HUBS_FETCHING.store(false, Ordering::SeqCst);
+    // The pins belong to the account too: the next one's answers live in ITS session file, and
+    // its roster has not landed yet. Both statics move with the catalog, and `PIN_APPLIED` is
+    // squared with the (now bumped) generation so the boot fetch below isn't immediately redone.
+    pin::reset();
     unsafe {
         *std::ptr::addr_of_mut!(CATALOG) = Vec::new();
         *std::ptr::addr_of_mut!(HUBS) = Vec::new();
         *std::ptr::addr_of_mut!(HERO_POOL) = Vec::new();
+        *std::ptr::addr_of_mut!(SOURCE) = None; // the new identity's server may not be this one
         std::ptr::addr_of_mut!(HUB_STATE).write(HubState::Loading);
         std::ptr::addr_of_mut!(RETRY_N).write(0);
         std::ptr::addr_of_mut!(RETRY_S).write(0.0);
+        std::ptr::addr_of_mut!(PIN_APPLIED).write(pin::gen());
     }
 }
 
@@ -728,6 +1277,315 @@ mod tests {
         assert_eq!(hub_len(0), 2, "the stale build must not replace the current catalog");
         assert_eq!(hub_state(), HubState::Ready, "nor be counted as a failure of the current one");
         reset();
+    }
+
+    // ---- pinning: which libraries reach Home ------------------------------------------------
+    //
+    // All pure: `resolve` and `apply` are the whole model, and `build_hubs` is a projection. None
+    // of these touch the session file or a socket.
+
+    use pin::{Granted, LibKey, Row};
+
+    fn own(section: i64) -> Granted {
+        Granted { key: LibKey::new("aaaabbbb1111", section), owned: true }
+    }
+    fn theirs(section: i64) -> Granted {
+        Granted { key: LibKey::new("ccccdddd2222", section), owned: false }
+    }
+    fn recorded(machine: &str, section: i64, pinned: bool) -> crate::plex::session::LibraryPin {
+        crate::plex::session::LibraryPin { machine_id: machine.into(), section, pinned }
+    }
+    fn row(machine: &str, section: i64, on: bool) -> Row {
+        Row { key: LibKey::new(machine, section), owned: machine == "aaaabbbb1111", on }
+    }
+
+    /// The defaults, on a roster nobody has answered for: your own libraries feed Home, a
+    /// friend's do not. The point of asking is not to put a stranger's shelves on your front door
+    /// unannounced — and asking is a screen, not a silent default.
+    #[test]
+    fn a_fresh_roster_pins_your_own_libraries_and_not_a_friends() {
+        let roster = [own(1), own(2), theirs(1)];
+        let p = pin::resolve(&roster, &[]);
+        assert!(p.feeds_home("aaaabbbb1111", 1));
+        assert!(p.feeds_home("aaaabbbb1111", 2));
+        assert!(!p.feeds_home("ccccdddd2222", 1), "a share must not reach Home unannounced");
+        assert_eq!(p.pinned_count(), 2);
+    }
+
+    /// A section key is only unique WITHIN a server — both of these are library 1 — so the
+    /// machine id is load-bearing in the key, not decoration.
+    #[test]
+    fn a_recorded_answer_beats_the_default_and_is_keyed_per_server() {
+        let roster = [own(1), theirs(1)];
+        let table = [recorded("aaaabbbb1111", 1, false), recorded("ccccdddd2222", 1, true)];
+        let p = pin::resolve(&roster, &table);
+        assert!(!p.feeds_home("aaaabbbb1111", 1), "unpinning your own server is legitimate");
+        assert!(p.feeds_home("ccccdddd2222", 1), "and a friend's library reaches Home once pinned");
+    }
+
+    /// The one real failure this control can produce is an empty Home, so the last pinned library
+    /// refuses to be unpinned — in the DATA LAYER, where no UI can route around it. It is not
+    /// unavailable, though: pinning something else frees it immediately.
+    #[test]
+    fn the_last_pinned_library_cannot_be_unpinned() {
+        let mut rows = vec![row("aaaabbbb1111", 1, true), row("ccccdddd2222", 1, false)];
+        assert_eq!(pin::apply(&mut rows, &LibKey::new("aaaabbbb1111", 1), false), pin::Set::LastPinned);
+        assert!(rows[0].on, "and the refusal must not have moved it half-way");
+
+        assert_eq!(pin::apply(&mut rows, &LibKey::new("ccccdddd2222", 1), true), pin::Set::Applied);
+        assert_eq!(
+            pin::apply(&mut rows, &LibKey::new("aaaabbbb1111", 1), false),
+            pin::Set::Applied,
+            "with a second library pinned, the first is ordinary again"
+        );
+        assert_eq!(
+            pin::apply(&mut rows, &LibKey::new("ccccdddd2222", 1), false),
+            pin::Set::LastPinned,
+            "…and now the friend's is the one holding Home up"
+        );
+    }
+
+    /// The rule is about the LAST one, not about your own: a set holding one pinned library is
+    /// what the list draws dimmed, whoever owns it.
+    ///
+    /// The unknown key is the trap. `feeds_home` answers "yes" for a library the roster does not
+    /// name — right for an item reaching Home, wrong here: with one library pinned it would make
+    /// EVERY unknown key read as "the one holding Home up", so the list would draw an unrelated
+    /// row's value dimmed while `apply` cheerfully answered `NotGranted` for it.
+    #[test]
+    fn the_last_pinned_row_is_the_one_the_list_dims() {
+        let roster = [own(1), theirs(1)];
+        let p = pin::resolve(&roster, &[]);
+        assert!(p.is_last_pinned(&LibKey::new("aaaabbbb1111", 1)));
+        assert!(!p.is_last_pinned(&LibKey::new("ccccdddd2222", 1)), "an unpinned row is not 'the last pinned'");
+        assert!(!p.is_last_pinned(&LibKey::new("eeeeffff3333", 3)), "and neither is a library nobody has heard of");
+    }
+
+    /// An account with no libraries of its own is not a mode — it draws the same Home as anyone
+    /// else. The defaults alone would leave it empty, so a roster that resolves to nothing pinned
+    /// is rescued whole. (The same rescue covers the only other way to reach an empty set: the
+    /// grant behind your one pinned library disappearing.)
+    #[test]
+    fn a_borrowed_only_account_still_gets_a_home() {
+        let roster = [theirs(1), theirs(2)];
+        let p = pin::resolve(&roster, &[]);
+        assert_eq!(p.pinned_count(), 2, "nothing pinned would be an empty Home");
+    }
+
+    /// …but the rescue is a fallback, not a floor: the moment ANY library resolves pinned, the
+    /// rest keep the answer they were given.
+    #[test]
+    fn the_rescue_never_overrides_a_real_answer() {
+        let roster = [theirs(1), theirs(2)];
+        let p = pin::resolve(&roster, &[recorded("ccccdddd2222", 1, true), recorded("ccccdddd2222", 2, false)]);
+        assert!(p.feeds_home("ccccdddd2222", 1));
+        assert!(!p.feeds_home("ccccdddd2222", 2));
+    }
+
+    /// And when it does have to fire, WHICH libraries it pins is the whole point: never a share
+    /// nobody has ruled on while a library of your own is standing there.
+    ///
+    /// The case that made this a rule: you unpin your own library while a friend's is pinned
+    /// (legal — the last-pinned rule was satisfied), then that friend revokes the share. Pinning
+    /// "everything left" would put two never-answered strangers on your front door — the exact
+    /// thing the defaults exist to prevent — so your own library comes back instead, even though
+    /// it is the one row that carries a recorded "off".
+    #[test]
+    fn the_rescue_reaches_for_your_own_library_before_a_strangers() {
+        let roster = [own(1), theirs(2), theirs(3)];
+        let p = pin::resolve(&roster, &[recorded("aaaabbbb1111", 1, false)]);
+        assert!(p.feeds_home("aaaabbbb1111", 1), "your own library is the one that comes back");
+        assert!(!p.feeds_home("ccccdddd2222", 2), "not a share nobody has ruled on");
+        assert!(!p.feeds_home("ccccdddd2222", 3));
+
+        // …and an unanswered library of your own is preferred to an answered one, so the rescue
+        // takes back as little as it can.
+        let p = pin::resolve(&[own(1), own(2)], &[recorded("aaaabbbb1111", 1, false)]);
+        assert!(!p.feeds_home("aaaabbbb1111", 1), "the recorded 'off' survives while anything else can serve");
+        assert!(p.feeds_home("aaaabbbb1111", 2));
+    }
+
+    /// When the rescue has to contradict an answer, it contradicts exactly ONE. Unpinning both of
+    /// your own libraries is legal while a friend's is pinned; if that share is then revoked, one
+    /// library must come back — not the pair, because the second one buys nothing that the first
+    /// has not already bought, and the next press writes whatever this returns down as the user's
+    /// own answer.
+    ///
+    /// The tier that takes only one is the tier that overrules something. The tier that takes all
+    /// of them ("shares nobody has ruled on") contradicts nothing, and a borrowed-only account
+    /// gets the whole Home an owner would.
+    #[test]
+    fn the_rescue_takes_back_one_answer_not_every_answer() {
+        let both_off = [recorded("aaaabbbb1111", 1, false), recorded("aaaabbbb1111", 2, false)];
+        let p = pin::resolve(&[own(1), own(2)], &both_off);
+        assert_eq!(p.pinned_count(), 1, "one library un-empties Home; the second answer stands");
+        assert!(p.feeds_home("aaaabbbb1111", 1), "and it is the first, not an arbitrary one");
+
+        let borrowed = pin::resolve(&[theirs(1), theirs(2), theirs(3)], &[]);
+        assert_eq!(borrowed.pinned_count(), 3, "nothing was answered, so nothing is being overruled");
+    }
+
+    /// **Empty means unknown, not none.** No roster installed (boot, or a build that never
+    /// installs one) and a library the roster does not name both pass the gate — the alternative
+    /// is a Home that blanks itself on a first boot after an upgrade, which is the failure this
+    /// whole model is shaped to avoid.
+    #[test]
+    fn an_unresolved_roster_and_an_unknown_library_both_feed_home() {
+        let unknown = pin::PinSet::default();
+        assert!(!unknown.is_known());
+        assert!(unknown.feeds_home("aaaabbbb1111", 1), "no roster yet is not 'nothing is pinned'");
+        assert!(unknown.feeds_home("", 0), "…including an item that names no library at all");
+
+        let p = pin::resolve(&[own(1)], &[]);
+        assert!(p.feeds_home("some-other-server", 7), "a library nobody has ruled on reaches Home");
+    }
+
+    /// Continue Watching's merge is conditional on pinning: a borrowed item joins the merged
+    /// shelf only once its library is pinned. Graded through `build_hubs`, because that is the
+    /// ONE place Home consults the pin — and it filters per ITEM, since the merged row is the one
+    /// shelf whose items come from several libraries at once.
+    #[test]
+    fn continue_watching_merges_only_the_libraries_that_are_pinned() {
+        let cw: crate::plex::MediaContainer = serde_json::from_str(
+            r#"{"Hub":[{"hubIdentifier":"continueWatching","title":"Continue Watching","Metadata":[
+                 {"type":"movie","ratingKey":"1","title":"Ours","thumb":"/t1","librarySectionID":1},
+                 {"type":"movie","ratingKey":"2","title":"Theirs","thumb":"/t2","librarySectionID":"4"}
+               ]}]}"#,
+        )
+        .expect("fixture parses");
+        let empty: crate::plex::MediaContainer = serde_json::from_str("{}").unwrap();
+        assert_eq!(cw.hub[0].metadata[1].library_section_id, 4, "PMS string-encodes ids");
+
+        // both pinned: the shelf merges, most-recently-played order
+        let both = pin::resolve(&[own(1), own(4)], &[]);
+        let (cat, hubs, _) = build_hubs(&empty, &cw, "aaaabbbb1111", &both);
+        assert_eq!(hubs.len(), 1);
+        assert_eq!(hubs[0].len, 2);
+        assert_eq!(cat.len(), 2);
+
+        // section 4 unpinned: its item leaves the merged shelf, and nothing else moves
+        let one = pin::resolve(&[own(1), own(4)], &[recorded("aaaabbbb1111", 4, false)]);
+        let (cat, hubs, _) = build_hubs(&empty, &cw, "aaaabbbb1111", &one);
+        assert_eq!(hubs[0].len, 1, "the merged shelf shortens rather than showing a dead card");
+        assert_eq!(cat[0].title, "Ours");
+
+        // the same item on a DIFFERENT server is a different library — an unpinned section 4 on
+        // ours must not filter a friend's section 4
+        let (_, hubs, _) = build_hubs(&empty, &cw, "ccccdddd2222", &one);
+        assert_eq!(hubs[0].len, 2);
+    }
+
+    /// **The defining rule, and it is a negative one: Home consults the pin and nothing else does.**
+    /// Tabs, grid, sort menu and A–Z rail all come from the GRANT, so unpinning a library must take
+    /// it off Home while leaving it exactly as browsable as it was.
+    ///
+    /// Two halves, because the rule has two. The first is behavioural: one `/library/sections`
+    /// answer and one hub answer, and the SAME section is gone from Home while still standing in
+    /// the directory the section table is built from (`browse::ensure_sections` maps that array
+    /// 1:1). The second is structural, and it is the half that will actually catch the regression:
+    /// `browse.rs` — which owns the section table, the paged grid, the server-driven sort menu and
+    /// the letter rail — must not so much as NAME the pin model. A source-text assertion is a blunt
+    /// instrument, but the thing being defended is a design rule about which module may ask a
+    /// question, and that is precisely what a call-site check can state and a behavioural test
+    /// cannot. (`ui/library.rs` is deliberately NOT probed: the Sources list lives in that toolbar
+    /// by design, and it is the one screen that must ask.)
+    #[test]
+    fn home_consults_the_pin_and_nothing_else_does() {
+        let sections: crate::plex::MediaContainer = serde_json::from_str(
+            r#"{"Directory":[{"key":"1","type":"movie","title":"Movies"},
+                             {"key":"2","type":"show","title":"TV Shows"}]}"#,
+        )
+        .expect("fixture parses");
+        let hubs_json: crate::plex::MediaContainer = serde_json::from_str(
+            r#"{"Hub":[{"hubIdentifier":"home.movies.recent","title":"Recently Added Movies","type":"movie","Metadata":[
+                 {"type":"movie","ratingKey":"9","title":"A Film","thumb":"/t","librarySectionID":1}]},
+               {"hubIdentifier":"home.television.recent","title":"Recently Added TV","type":"show","Metadata":[
+                 {"type":"show","ratingKey":"7","title":"A Show","thumb":"/t2","librarySectionID":2}]}]}"#,
+        )
+        .expect("fixture parses");
+        let empty: crate::plex::MediaContainer = serde_json::from_str("{}").unwrap();
+
+        let off = pin::resolve(&[own(1), own(2)], &[recorded("aaaabbbb1111", 1, false)]);
+        let (cat, shelves, _) = build_hubs(&hubs_json, &empty, "aaaabbbb1111", &off);
+        assert_eq!(shelves.len(), 1, "Home loses the unpinned library's shelf");
+        assert_eq!(cat[0].title, "A Show");
+        assert!(
+            sections.directory.iter().any(|d| d.key == "1"),
+            "…and the section table it is browsed from is untouched: the tab, the grid, its sort \
+             menu and its A–Z rail all come from the grant"
+        );
+
+        const BROWSE: &str = include_str!("browse.rs");
+        for probe in ["pms::pin", "feeds_home", "PinSet", "is_last_pinned"] {
+            assert!(
+                !BROWSE.contains(probe),
+                "browse.rs names `{probe}` — the section table, the grid's paging, the sort menu \
+                 and the letter rail must come from the GRANT. Pinning governs Home only."
+            );
+        }
+    }
+
+    /// What the model WRITES has to be what it reads back. The two halves live in different
+    /// modules — `pin::record` builds the rows, `session::de_pins` parses them — and the hole they
+    /// left between them was silent: a library whose server has no `machineIdentifier` was written
+    /// happily and dropped on the way back in, so a pin read as saved and was gone by the next
+    /// boot, taking the first-run question's answer with it. Written rows are keyed rows only.
+    #[test]
+    fn every_recorded_row_round_trips_through_the_session() {
+        use crate::plex::session::{LibraryPin, Session};
+        let resolved = [row("aaaabbbb1111", 1, true), row("aaaabbbb1111", 2, false), row("", 3, true)];
+        let written: Vec<LibraryPin> = resolved
+            .iter()
+            .filter(|r| !r.key.machine_id.is_empty()) // `record`'s rule
+            .map(|r| LibraryPin { machine_id: r.key.machine_id.clone(), section: r.key.section, pinned: r.on })
+            .collect();
+        let json = serde_json::to_string(&Session { pins: written, ..Session::default() }).unwrap();
+        let back: Session = serde_json::from_str(&json).expect("a written session parses");
+        assert_eq!(back.pins.len(), 2, "the unkeyed row is not written, because it cannot be read");
+        assert_eq!(back.pin_of("aaaabbbb1111", 1), Some(true));
+        assert_eq!(back.pin_of("aaaabbbb1111", 2), Some(false), "and a 'no' comes back a 'no'");
+    }
+
+    /// A friend can revoke a share between two boots, and the answer the user gave about it is
+    /// still on file. The roster is what exists; the table is only what was said about it — so a
+    /// row naming a server that is no longer granted is simply not in the resolved set, and
+    /// nothing indexes one table by the other's length.
+    #[test]
+    fn a_pin_for_a_revoked_share_is_dropped_not_a_panic() {
+        let table = [recorded("ccccdddd2222", 1, true), recorded("eeeeffff3333", 4, false), recorded("aaaabbbb1111", 1, true)];
+        let p = pin::resolve(&[own(1)], &table);
+        assert_eq!(p.rows().len(), 1, "the resolved set is the ROSTER, not the file");
+        assert!(p.feeds_home("aaaabbbb1111", 1));
+        assert!(p.is_last_pinned(&LibKey::new("aaaabbbb1111", 1)), "and it is now the last one standing");
+        // the revoked rows are neither resolved nor reachable — asking about one is a question
+        // about a library that does not exist, and the honest answer is the permissive one
+        assert!(p.feeds_home("ccccdddd2222", 1));
+        assert_eq!(pin::apply(&mut p.rows().to_vec(), &LibKey::new("eeeeffff3333", 4), true), pin::Set::NotGranted);
+    }
+
+    /// A shelf whose every item belonged to an unpinned library is not drawn empty — it is not
+    /// drawn at all. (Absence on Home is the design's answer; a shelf that cannot be scrolled
+    /// into is worse than a shelf that isn't there.) The hero pool is built from the shelves, so
+    /// it empties with them — a borrowed hero is always the consequence of a pin.
+    #[test]
+    fn an_unpinned_librarys_shelf_is_absent_from_home_hero_included() {
+        let hubs_json: crate::plex::MediaContainer = serde_json::from_str(
+            r#"{"Hub":[{"hubIdentifier":"home.movies.recent","title":"Recently Added","type":"movie","Metadata":[
+                 {"type":"movie","ratingKey":"9","title":"Theirs","thumb":"/t","art":"/a","librarySectionID":4}
+               ]}]}"#,
+        )
+        .expect("fixture parses");
+        let empty: crate::plex::MediaContainer = serde_json::from_str("{}").unwrap();
+
+        let (_, shelves, pool) = build_hubs(&hubs_json, &empty, "aaaabbbb1111", &pin::resolve(&[own(4)], &[]));
+        assert_eq!(shelves.len(), 1, "pinned: the shelf is there");
+        assert_eq!(pool.len(), 1, "…and it can supply the rotating hero");
+
+        let off = pin::resolve(&[own(4), own(1)], &[recorded("aaaabbbb1111", 4, false)]);
+        let (cat, shelves, pool) = build_hubs(&hubs_json, &empty, "aaaabbbb1111", &off);
+        assert!(shelves.is_empty(), "no heading, no row, no placeholder");
+        assert!(cat.is_empty());
+        assert!(pool.is_empty(), "and no hero the user cannot open");
     }
 
     /// `reset` is the profile-switch wipe: the previous user's shelves must not survive it, and


### PR DESCRIPTION
## Pinning — which libraries reach Home

The data layer for the one user-facing control shared servers introduce. A per-library `pinned`
flag, persisted in the session, with **Home as its only reader**.

Three states, kept apart deliberately:

| state | who decides | what it governs |
|---|---|---|
| **granted** | plex.tv | everything browsable. Not a setting — the app has no server on/off at all |
| **pinned** | the user, in the Sources list | Home, and nothing else |
| **reachable** | right now | nothing; an unreachable pinned server still reads `On` |

### What reads the pin

`pms::build_hubs`, once, and nothing else — asserted two ways. Behaviourally: one
`/library/sections` answer and one hub answer, and the unpinned library is gone from Home while
still standing in the directory the section table is built from. Structurally: a test reads
`browse.rs` — which owns the section table, the grid's paging, the server-driven sort menu and the
A–Z rail — and fails if it so much as names the pin model. `ui/library.rs` is deliberately *not*
probed: the Sources list lives in that toolbar by design and is the one screen that must ask.

The gate is per **item**, not per shelf, because the merged Continue Watching row draws from every
source at once: a borrowed film joins it only once its library is pinned (design §C). The hero pool
is built from the shelves below it, so it inherits the same gate for free.

### The rules, and where each lives

- **Defaults** (`pin::resolve`) — your own libraries pinned, a friend's not.
- **The last pinned library cannot be unpinned** (`pin::apply`) — in the data layer, so no UI can
  route around it. The list still draws the row live; only its *value* dims.
- **Empty means unknown, twice.** An empty persisted table = nobody has answered → defaults apply.
  An unresolved roster = we have not been told what exists → the gate passes everything. Either
  read the other way is a blank Home on the first boot after an upgrade.
- **A corrupt table degrades per row**, never failing the `Session` parse — that failure is a silent
  sign-out (`peek` falls through to a default, `load` mints a fresh client id over the real one).
- **The rescue.** The user cannot reach an empty pin set, but the world can: an account with no
  libraries of its own, or the grant behind your only pin disappearing. `resolve` un-empties it,
  reaching for your own library before a stranger's, and taking back exactly **one** answer when it
  has to overrule one.

### Two things this needed from its neighbours

- `Metadata::librarySectionID` (+6 lines in `models.rs`) — half of a library's key. Verified present
  on every hub row and every Continue Watching row of a live PMS, as an int, with the string form
  the OpenAPI spec also documents covered by `de_i64`.
- `session::set_pins` — **one writer** for `Session::pins`. Every other writer saves the whole
  struct from a snapshot of unknown age (`auth` takes one when a profile switch starts and writes it
  back when the roster lands), so a merge rule keyed on "empty means it doesn't know" only covers
  snapshots older than the *first* answer. An owner covers every snapshot of any age.

### Integration seam for the sibling units

- The roster unit calls `pms::pin::install_roster(&[Granted { key: LibKey { machine_id, section },
  owned }])` on every roster landing. `machine_id` is `Resource::client_identifier` (= the registry
  key, = `Client::machine_id`), `owned` is `Resource::owned` — plex.tv's own word, not a guess off
  `sourceTitle`. It writes nothing: resolving is not answering.
- The Sources list walks `pin::snapshot()` (owned data — there is deliberately no borrowing
  accessor, see the comment where one would go) and presses `pin::set(&key, on) -> Set`.
  `Set::LastPinned` is the refusal the `valueDim` treatment renders.
- The first-run route gates on `pin::asked()` and calls `pin::acknowledge()` on **both** exits —
  `Start watching` and the skip. It returns `false` if nothing was written.
- Home needs no wiring: `pin::set` bumps a generation and `pms::pump` refetches, so several toggles
  in one visit coalesce into one fetch and no keypress blocks the loop.

### Tests

437 total (+19 here), all pure — no session file, no socket, no TV:

- the defaults on a fresh roster; a recorded answer beating the default, keyed per server
- the last-pinned refusal, and that pinning a second library frees the first
- the rescue: a borrowed-only account, own-before-stranger, and one answer taken back rather than every answer
- unknown-is-not-none for both an unresolved roster and an unnamed library
- Continue Watching merging only pinned libraries; an unpinned library's shelf absent from Home, hero included
- `home_consults_the_pin_and_nothing_else_does` — the negative rule, behavioural + structural
- a revoked share's persisted row dropped rather than panicking
- the write/read round trip through the session's own serde, including that an unkeyed row is never written
- a corrupt table (six shapes) degrading to defaults with the client id and account token intact
- one broken row costing only that row; no other writer able to revert the table

## Device verification — deferred to coordinator

**Not verified on device.** No frame of this was seen on the TV: I never held the lock, and per the
coordinator's instruction I did not drive the television. Everything above is host-side.

The unit is inert until a roster is installed, so there is a dev trigger for exactly this. All
values below are placeholders — substitute from `tests/manifest.local.json` / `src/config.local.h`.

**Recipe** (one build, one unbroken locked window — the pair is only evidence if nothing redeploys
between the two captures):

```sh
make deploy                                   # dev build; RELEASE=1 compiles the trigger out
ssh root@<tv-host> 'rm -f /tmp/plxnative-*'   # a stale trigger silently changes the boot screen
ssh root@<tv-host> 'printf %s "<pms-token>" > /tmp/plxnative-token'   # from src/config.local.h

# A — control: the roster is installed, nothing is excluded
ssh root@<tv-host> 'touch /tmp/plxnative-shared'
make run && tools/capture-screen.sh a-control.png DISPLAY

# B — one library treated as a friend's share, so it arrives UNPINNED
ssh root@<tv-host> 'printf %s "<movies-section-key>" > /tmp/plxnative-shared'
make run && tools/capture-screen.sh b-unpinned.png DISPLAY
```

`<movies-section-key>` is the `key` of a section that contributes shelves to Home —
`curl -H 'X-Plex-Token: …' http://<pms-host>:<pms-port>/library/sections`. On a stock layout the
movie library is `1` and TV is `2`; picking the TV one is the stronger capture, because Continue
Watching is usually drawn entirely from episodes and disappears whole (design §C's merge rule).

**A correct pair:** B differs from A by exactly that library's shelves — they are absent, with no
empty shelf, no spinner row and no placeholder (design §D). Everything else is byte-for-byte the
same screen: the tab strip still names the library, the profile chip, the clock and every other
shelf unmoved. **If anything else moves, that is the bug** — pinning governs Home only. Pressing
into that library's tab must still browse it normally, with its sort menu and A–Z rail intact.

**The log line that settles it either way**, in `/tmp/plxnative-events.log`:

```
pins: dev roster — 3 libraries, [1] treated as shared
pins: 2 of 3 libraries feed Home
```

Do **not** list every section: with nothing left pinned the rescue fires (Home is never empty by
design), so the screen is unchanged and correct, which reads exactly like a broken feature. The
second log line says `3 of 3` when that happens.

**Not reachable from a boot trigger, and host-tested instead:** the last-pinned refusal and the
persistence round trip both need the Sources list's OK, which lands in a sibling unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxZ585ehWMnuScciTQ9WgV
