### PR TITLE
tv-lock: the television gets a mutex, and it is enforced

### DIFF
--- a/.claude/hooks/tv-lock-guard-test.py
+++ b/.claude/hooks/tv-lock-guard-test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Cases for the TV-lock guard's classifier. `python3 .claude/hooks/tv-lock-guard-test.py`.
+
+Host-only, no television and no lock state involved: it imports the guard and asks it to classify
+command lines. The pairs below are the ones that matter, and half of them are FALSE POSITIVES —
+the guard's real failure mode is not missing an `ssh root@`, it is refusing `pgrep -fl
+"…|make deploy"`, which is the pre-flight that asks whether anybody is on the set. Both of the
+quoting cases here fired for real in the first two minutes the hook was live.
+
+Addresses below are RFC 5737 documentation ranges, never this household's: the TV's real address
+lives in the gitignored `.tv-host` and nowhere in the tree (docs/distribution.md §"private data").
+The guard keys on `root@`, not on any particular host, so a placeholder tests it exactly.
+"""
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("guard", os.path.join(HERE, "tv-lock-guard.py"))
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+BLOCK, ALLOW = True, False
+CASES = [
+    # --- must be blocked: everything that reaches the television --------------
+    (BLOCK, "make deploy"),
+    (BLOCK, "make FLAVOR=debug RELEASE=1 deploy"),
+    (BLOCK, "make test"),
+    (BLOCK, "make -C /repo run RUN_SECS=30"),
+    (BLOCK, "./tests/run.py --fps"),
+    (BLOCK, "python3 tests/run.py --filter seek"),
+    (BLOCK, "tools/tv-session.sh up --screen home"),
+    (BLOCK, "tools/tv-session.sh key down ok"),
+    (BLOCK, "tools/capture-screen.sh out.png DISPLAY"),
+    (BLOCK, "ssh root@192.0.2.10 'cat /tmp/plxnative-events.log'"),
+    (BLOCK, "sshpass -p alpine scp pkg/plxnative root@192.0.2.10:/tmp/"),
+    (BLOCK, "echo hi && make deploy"),
+    (BLOCK, "./tests/run.py --fps | tee out.log"),
+    (BLOCK, "for f in stable debug; do ssh root@1.2.3.4 fuser x; done"),
+    (BLOCK, 'echo "$(ssh root@1.2.3.4 uptime)"'),          # substitution inside double quotes
+    (BLOCK, "luna-send -i luna://x/y '{}' # via ssh root@1.2.3.4"),
+
+    # --- must be allowed: host-only work, read-only diagnostics, quoted text --
+    (ALLOW, "make check"),
+    (ALLOW, "make lint"),
+    (ALLOW, "make sim && make sim-shot"),
+    (ALLOW, "make -s print-appdir FLAVOR=stable"),
+    (ALLOW, "cargo +nightly test --lib"),
+    (ALLOW, "tools/tv-lock.sh acquire --why 'verify hud'"),
+    (ALLOW, "tools/tv-lock.sh status"),
+    (ALLOW, "tools/tv-session.sh log 'route='"),
+    (ALLOW, "tools/tv-session.sh status"),
+    (ALLOW, "tools/crash-report.sh --flavor debug"),
+    (ALLOW, ".claude/skills/wake-tv/wake-tv.sh"),
+    (ALLOW, 'pgrep -fl "tests/run.py|capture-screen|make deploy"'),   # the pre-flight itself
+    (ALLOW, 'ps aux | grep -c "[s]sh .*192.0.2.10"'),
+    (ALLOW, 'git commit -m "make deploy now takes the TV lock; tests/run.py releases it"'),
+    (ALLOW, 'grep -rn "ssh root@" docs/'),
+    (ALLOW, "ssh someserver.example.com uptime"),
+    (ALLOW, "PLX_TV_LOCK_BYPASS=1 ssh root@1.2.3.4 uptime"),          # the documented hatch
+]
+
+
+HEREDOC_DOC = """cat > .claude/skills/tv-lock/SKILL.md <<'EOF'
+Take the lock before `make deploy`, and never a raw `ssh root@1.2.3.4`.
+  tools/tv-session.sh up --screen home
+EOF"""
+
+HEREDOC_PY = """python3 - <<'PY'
+s = "refuses raw `ssh root@…`; every TV-facing tool requires it"
+open('MEMORY.md', 'w').write(s)
+PY"""
+
+HEREDOC_SSH = """ssh root@1.2.3.4 <<'EOF'
+luna-send -i luna://com.webos.applicationManager/launch '{}'
+EOF"""
+
+CASES += [
+    # Heredoc BODIES are data — writing documentation about the lock must not trip the lock.
+    # Both of these fired for real while this mechanism was being built.
+    (ALLOW, HEREDOC_DOC),
+    (ALLOW, HEREDOC_PY),
+    # …but the line that OPENS the heredoc is still a command, and this is how hand-driven TV
+    # work has actually been written in this project.
+    (BLOCK, HEREDOC_SSH),
+]
+
+
+def blocked(cmd):
+    if "PLX_TV_LOCK_BYPASS=1" in cmd:
+        return False
+    return any(guard.classify(seg) for seg in guard.segments(guard.strip_heredocs(cmd)))
+
+
+def main():
+    fails = 0
+    for want, cmd in CASES:
+        got = blocked(cmd)
+        if got != want:
+            fails += 1
+            print(f"  FAIL  expected {'BLOCK' if want else 'ALLOW'}, got "
+                  f"{'BLOCK' if got else 'ALLOW'}: {cmd}")
+    print(f"tv-lock-guard: {len(CASES) - fails}/{len(CASES)} cases correct")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/tv-lock-guard.py
+++ b/.claude/hooks/tv-lock-guard.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: no command may drive the television without holding its lock.
+
+WHY A HOOK AND NOT JUST A CONVENTION. Every TV-facing tool in this repo now takes the lock
+(`make deploy`, `tests/run.py`, `tools/tv-session.sh`, `tools/capture-screen.sh`), so the only way
+left to collide is to go around them — a raw `ssh root@<tv> luna-send …`, an `scp` into the app
+directory, a `sshpass` one-liner out of a memory or a doc. Those are exactly what an agent reaches
+for when a tool refuses, and the damage from two lanes on one set is not a clean failure: it is
+plausible WRONG data (an fps number measured while somebody else's binary was landing, a capture
+of a screen the other job navigated away from). Nothing downstream can tell that from a real
+regression, so it has to be stopped at the point of the command.
+
+WHAT IT COSTS. Nothing on an unrelated command: the classifier is pure string work over the
+command line, and the lease check is a single small file read, with no ssh and no network. The
+television is never contacted from here.
+
+WHAT IT DELIBERATELY DOES NOT BLOCK.
+  * read-only diagnostics that cannot disturb a running session: `tools/crash-report.sh`,
+    `tv-session.sh log|status`, `make -s print-*`;
+  * the lock tool itself and `wake-tv.sh` — waking a set is harmless and is how you get to a
+    television you are about to lock;
+  * every host-only path, which is most of this repo: `make check`, `make sim`, cargo, the
+    simulator. When this hook refuses something, the simulator (`ui-sim` skill) is usually the
+    right next move rather than waiting.
+
+THE ESCAPE HATCH is a prefix on the command itself — `PLX_TV_LOCK_BYPASS=1 ssh root@…`. It is for
+a human who knows the set is theirs (and for breaking a genuinely wedged lock); an agent reaching
+for it is an agent working around a lock rather than waiting for one.
+
+FAIL-OPEN ON ITS OWN BUGS, fail-closed on the answer: a crash in this file must not wedge every
+Bash call in the session, but "no lease" is a refusal.  Contract: exit 0 allows, exit 2 blocks and
+feeds stderr back to the model.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+STATE_DIR = os.environ.get("PLX_TV_LOCK_STATE") or os.path.expanduser("~/.plxnative/tv-lock")
+
+# Anything that reaches the television. Matched against the COMMAND WORD of each segment (so a
+# `git commit -m "make deploy now locks the TV"` is a git command, not a deploy).
+TV_MAKE_GOALS = {"deploy", "run", "run-stream", "kill", "test", "install", "uninstall"}
+TV_SCRIPTS = {"tv-session.sh", "capture-screen.sh", "stream-screen.py", "remote-dpad.py", "run.py"}
+ALWAYS_OK = {"tv-lock.sh", "wake-tv.sh", "crash-report.sh"}
+# `luna-send` only exists on the set, so seeing it here means an ssh payload.
+RAW_SSH = re.compile(r"\b(sshpass|ssh|scp|rsync)\b")
+ROOT_AT = re.compile(r"root@")
+
+
+def segments(cmd):
+    """Split a shell command into segments on ; && || | & and newlines — QUOTE-AWARE.
+
+    A plain regex split gets this wrong in a way that reads as the guard being broken:
+    `pgrep -fl "tests/run.py|capture-screen"` splits inside the quoted PATTERN and hands the tail
+    to the classifier as if it were a command, so the pre-flight that ASKS whether anybody is on
+    the television is itself refused. (Both of those fired in the first two minutes this hook was
+    live, on this file's own author.) A false positive here is worse than a miss: it blocks work
+    that never touches the set, and it teaches the reader to reach for the bypass.
+    """
+    out, cur, quote, i = [], [], None, 0
+    while i < len(cmd):
+        c = cmd[i]
+        if quote:
+            cur.append(c)
+            if c == quote and cmd[i - 1:i] != "\\":
+                quote = None
+            i += 1
+            continue
+        if c in "'\"":
+            quote = c
+            cur.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < len(cmd):
+            cur.append(c)
+            cur.append(cmd[i + 1])
+            i += 2
+            continue
+        if c in ";\n|&":
+            # `&&` and `||` end a segment, as do a bare `|`, `;`, `&` and a newline. Consume the
+            # pair so the second character cannot start an empty one.
+            i += 2 if cmd[i:i + 2] in ("&&", "||") else 1
+            out.append("".join(cur))
+            cur = []
+            continue
+        cur.append(c)
+        i += 1
+    out.append("".join(cur))
+    # Command substitution runs whatever is inside it, and `"$(ssh root@…)"` is inside double
+    # quotes as far as the scanner above is concerned — so its contents are pulled out and graded
+    # as segments of their own, wherever they appeared.
+    #
+    # BACKTICKS ARE DELIBERATELY NOT DONE HERE, though they are the same shell feature: in this
+    # repo a backtick is overwhelmingly markdown, not substitution — every doc, skill and memory
+    # this agent writes is full of `ssh root@…` in prose, and treating those as commands blocks
+    # the writing of the very documentation that explains the lock. (It did, on its second minute.)
+    # The `$( )` form carries no such ambiguity.
+    for inner in re.findall(r"\$\(([^()]*)\)", cmd):
+        if inner.strip():
+            out.extend(segments(inner))
+    return [seg for seg in out if seg.strip()]
+
+
+HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
+
+def strip_heredocs(cmd):
+    """Remove heredoc BODIES, keeping the line that introduces them.
+
+    A heredoc body is data — a file being written, a Python program, a commit message — and this
+    agent writes them constantly. Classifying their contents means `cat > SKILL.md <<'EOF'`
+    containing the words `make deploy` is refused as a deploy, which is both wrong and maddening.
+    The introducing line survives, so `ssh root@tv <<EOF` (a real way this project's TV work has
+    been driven by hand) is still caught on the `ssh` itself.
+    """
+    lines = cmd.split("\n")
+    out, i = [], 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        delims = [m.group(2) for m in HEREDOC.finditer(line)]
+        i += 1
+        for d in delims:
+            while i < len(lines) and lines[i].strip() != d:
+                i += 1
+            i += 1                      # consume the terminator itself
+    return "\n".join(out)
+
+
+def words(seg):
+    return seg.strip().split()
+
+
+def command_word(w):
+    """First word that is not an env assignment (FOO=bar) or a `sudo`/`time`-style prefix."""
+    for tok in w:
+        if "=" in tok.split("/")[0] and not tok.startswith("/") and re.match(r"^\w+=", tok):
+            continue
+        # Wrappers, and the shell keywords a split leaves at the head of a segment: `for f in …;
+        # do ssh root@… ; done` hands the classifier a segment whose first word is `do`, and a
+        # loop is exactly the shape a per-flavour device check is written in.
+        if tok in ("sudo", "time", "env", "nohup", "exec", "command",
+                   "do", "then", "else", "{", "(", "!", "&&", "||"):
+            continue
+        return tok
+    return ""
+
+
+def classify(seg):
+    """Return a reason string if this segment drives the TV, else None."""
+    w = words(seg)
+    if not w:
+        return None
+    cw = command_word(w)
+    base = os.path.basename(cw)
+    if base in ALWAYS_OK:
+        return None
+    # `python3 tools/foo.py` / `bash tools/foo.sh`: the interpreter is not the command.
+    if base in ("python3", "python", "bash", "sh", "zsh") and len(w) > 1:
+        for tok in w[1:]:
+            b = os.path.basename(tok)
+            if b in ALWAYS_OK:
+                return None
+            if b in TV_SCRIPTS:
+                base, cw = b, tok
+                break
+
+    if base in TV_SCRIPTS:
+        # Two subcommands of tv-session are read-only and stay allowed; everything else drives.
+        if base == "tv-session.sh":
+            subs = [t for t in w[1:] if not t.startswith("-")]
+            if subs and subs[0] in ("log", "status"):
+                return None
+        return f"{base} drives the television"
+
+    if base == "make":
+        goals = [t for t in w[1:] if not t.startswith("-") and "=" not in t]
+        hit = TV_MAKE_GOALS.intersection(goals)
+        if hit:
+            return "make " + " ".join(sorted(hit)) + " talks to the television"
+        return None
+
+    if RAW_SSH.search(cw) and (ROOT_AT.search(seg) or "luna-send" in seg):
+        return "a raw ssh/scp to the television, around every tool that takes the lock"
+
+    if "luna-send" in seg and ROOT_AT.search(seg):
+        return "a luna-send on the television"
+    return None
+
+
+def repo_root(cwd):
+    try:
+        out = subprocess.run(["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True, timeout=5)
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return os.path.abspath(cwd)
+
+
+def lease_for(lane):
+    """A live lease for THIS lane (this checkout), or None.
+
+    Reads only the local mirror `tools/tv-lock.sh` writes when it takes a lock. That is the cheap
+    half of a two-sided lock — the television holds the authoritative copy, and the tools reconcile
+    the two on every use. Here we only need to know whether this lane ever took one and whether it
+    has run out, which the mirror answers without a round trip.
+    """
+    if not os.path.isdir(STATE_DIR):
+        return None
+    now = time.time()
+    for name in os.listdir(STATE_DIR):
+        if not name.endswith(".lease"):
+            continue
+        try:
+            body = open(os.path.join(STATE_DIR, name)).read()
+        except OSError:
+            continue
+        f = dict(re.findall(r"^(\w+)='?([^'\n]*)'?$", body, re.M))
+        if os.path.realpath(f.get("LANE", "")) != os.path.realpath(lane):
+            continue
+        try:
+            if float(f.get("EXPIRES", 0)) > now:
+                return f
+        except ValueError:
+            continue
+    return None
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if not cmd.strip():
+        return 0
+    if re.search(r"\bPLX_TV_LOCK_BYPASS=1\b", cmd):
+        return 0
+
+    reasons = []
+    for seg in segments(strip_heredocs(cmd)):
+        why = classify(seg)
+        if why:
+            reasons.append((seg.strip()[:120], why))
+    if not reasons:
+        return 0
+
+    lane = repo_root(payload.get("cwd") or os.getcwd())
+    if lease_for(lane):
+        return 0
+
+    seg, why = reasons[0]
+    sys.stderr.write(
+        "BLOCKED: this lane does not hold the television's lock.\n"
+        f"  the command: {seg}\n"
+        f"  why blocked: {why}\n"
+        "\n"
+        "There is ONE dev set and no OS-level mutex. Two jobs on it do not fail cleanly — they\n"
+        "produce plausible WRONG data (an fps number measured while another lane's deploy landed,\n"
+        "a capture of a screen the other job navigated away from), which reads exactly like a real\n"
+        "regression. So take the lock, or use the simulator:\n"
+        "\n"
+        "  tools/tv-lock.sh status                      # who holds it, and is anyone on it unlocked\n"
+        "  tools/tv-lock.sh acquire --why '<what for>'  # take it (add --wait 540 to queue)\n"
+        "  …device work…\n"
+        "  tools/tv-lock.sh release                     # hand it back\n"
+        "\n"
+        "Host-only work needs no lock and is not blocked: make check, make sim (the ui-sim skill\n"
+        "runs N simulators at once). See .claude/skills/tv-lock/SKILL.md.\n")
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:          # a bug in the guard must not wedge every Bash call
+        sys.stderr.write(f"tv-lock-guard: internal error, allowing ({e})\n")
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/tv-lock-guard.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/crash-triage/SKILL.md
+++ b/.claude/skills/crash-triage/SKILL.md
@@ -11,6 +11,10 @@ description: >
 
 # Crash triage on the TV
 
+> **Collecting evidence is read-only and needs no lock** (`tools/crash-report.sh`, `tv-session.sh
+> log`) — but the moment you RE-RUN to reproduce, take the television's lock first:
+> `tools/tv-lock.sh acquire --why "reproduce <crash>"`. See the **`tv-lock`** skill.
+
 The C tracer (`src/main.c`) catches the fatal signals, writes what it knows, then
 **re-raises to `SIG_DFL`** so the OS crash daemon still captures a real backtrace. Per
 crash it emits:

--- a/.claude/skills/decompile-tv-lib/SKILL.md
+++ b/.claude/skills/decompile-tv-lib/SKILL.md
@@ -115,6 +115,8 @@ Two further results from the same pass, both of which would have been expensive 
 ## House rules
 
 - **Never modify anything on the device.** `pull` is read-only `scp`; the TV is a shared mutex
+  (`tools/tv-lock.sh` / the `tv-lock` skill — harvesting takes no lock, but anything that RUNS the
+  app does)
   and other work may be running against it. Wake it with `.claude/skills/wake-tv/wake-tv.sh`.
 - Record what you harvested. `pull` writes `MANIFEST.txt` with a sha256 per file, so a finding
   can be tied to the exact binary it came from — firmware updates change these.

--- a/.claude/skills/tv-lock/SKILL.md
+++ b/.claude/skills/tv-lock/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: tv-lock
+description: >
+  Take, hold and hand back the ONE dev television, so two jobs never drive it at once. Use before
+  ANY device work — "deploy to the TV", "run the test suite", "screenshot the TV", "reproduce it
+  on device", "measure the frame rate", "capture the video plane" — and whenever a command is
+  refused with "the television is held by another lane", "BLOCKED: this lane does not hold the
+  television's lock", or a tool says somebody else is on the set. Also covers running SEVERAL
+  agents at once against one TV ("fan this out", "run these in parallel", "another agent is using
+  the TV"), what to do while you wait, and when it is safe to break a lease. There is one set, one
+  app instance, and no OS-level mutex: two jobs on it do not fail cleanly, they produce plausible
+  WRONG data that reads exactly like a real regression.
+---
+
+# The television is a mutex — this is how you hold it
+
+There is exactly one dev set, one app instance on it, and webOS enforces nothing. Two
+`tests/run.py` runs, or a run plus a `make deploy`, or a capture session plus either, **kill each
+other's app**. The damage is never a clean failure. It is:
+
+- a `timeline_climb` that failed because the other lane closed the app mid-case;
+- an fps number measured while somebody else's binary was landing under it;
+- a capture of a screen the other job navigated to;
+- an event log graded as yours, written by their session.
+
+None of those can be told from a real regression by reading them. That is the whole reason this
+exists: sequencing by hand only works while one person is doing the sequencing, and "you own the
+television exclusively" is a sentence that is true when written and false the moment a second lane
+starts.
+
+## The loop
+
+```bash
+tools/tv-lock.sh status                             # who has it, and is anybody on it unlocked
+tools/tv-lock.sh acquire --why "verify HUD change"  # take it (add --wait 540 to queue for it)
+  … device work: tools/tv-session.sh up, ./tests/run.py, make deploy, captures …
+tools/tv-session.sh down                            # hand the APP back (interactive boot)
+tools/tv-lock.sh release                            # hand the TELEVISION back
+```
+
+One-shot jobs get the whole thing in a single command, released even on Ctrl-C:
+
+```bash
+tools/tv-lock.sh with --why "fps suite" -- ./tests/run.py --fps
+```
+
+**Take a lease for the SESSION, not per command.** Every TV-facing tool already takes a short
+implicit lease when nobody holds the set, so a lone `make deploy` cannot collide — but that lease
+ends with the command, and *the gap between two of your own commands is exactly where another lane
+lands*. If you are going to touch the set more than once, acquire first.
+
+| command | what it does |
+|---|---|
+| `status` | holder, how long held, how long left, why — plus the unlocked-user pre-flight |
+| `acquire [--why T] [--wait S] [--ttl MIN] [--as LABEL]` | take it; `--wait` polls instead of failing |
+| `renew [--ttl MIN]` | extend a lease you hold (long sessions; `with` does it for you) |
+| `release` | hand it back |
+| `require [--quiet] [--advisory]` | assert + renew; what the tools call, rarely typed by hand |
+| `with [opts] -- CMD…` | acquire → run → release, through Ctrl-C, SIGTERM and a crash |
+| `break [--yes]` | steal a lease; names the holder first and refuses a LIVE one without `--yes` |
+| `selftest` | exercises the entire protocol against a temp dir — **no television involved** |
+
+Default lease: **45 minutes**, renewed automatically whenever a tool uses the set, so a real
+session never ages out under itself. The implicit one is **10 minutes**.
+
+## It is enforced, not advisory
+
+Four layers, so there is no "I forgot" path:
+
+1. **`tools/tv-session.sh`** — `up`, `key`, `click`, `shot` and `down` require the lock. `log` and
+   `status` are read-only: they take nothing and refuse nothing, but they name the holder, because
+   reading a log another lane's app is writing is how a session gets graded as your own.
+2. **The Makefile** — `deploy`, `run`, `run-stream`, `kill`, `install` and `uninstall` take
+   `tv-lock-require` as a prerequisite (last in the list for `deploy`, so a two-minute FFmpeg build
+   does not happen while holding the set).
+3. **`tests/run.py`** — acquires where it commits to driving the TV and releases in the same
+   `finally` as the teardown; it *inherits* a lease this lane already holds rather than re-taking
+   it, so `with -- ./tests/run.py` works unchanged. `tools/capture-screen.sh` requires it too.
+4. **A `PreToolUse` hook** (`.claude/hooks/tv-lock-guard.py`) — refuses any Bash command that
+   drives the set without a lease: a raw `ssh root@…`, an `scp` into the app directory, a
+   `sshpass` one-liner, `make deploy`, `tests/run.py`. It reads one local file, never the network,
+   and blocks nothing host-side.
+
+## When it refuses
+
+**Do not work around it.** A refusal means a real job is on the set; going around it corrupts
+*both* results, and yours will look like a regression rather than an accident.
+
+1. **Look**: `tools/tv-lock.sh status` — it prints who, from which checkout, since when, why, and
+   how long is left.
+2. **Queue**: `tools/tv-lock.sh acquire --wait 540 --why "…"` polls every 5 s. Keep it under ~9
+   minutes so it fits inside one tool call; re-run it if it times out.
+3. **Meanwhile, do the host half.** Most work does not need a television:
+   - `make check` — the host unit suite, sub-second;
+   - **`make sim`** — the real app core on macOS against the real PMS, screenshotting itself, and
+     **N instances run at once**. Layout, focus, navigation, every screen and the whole Plex data
+     layer are answerable there. See the **`ui-sim`** skill. It cannot answer frame rate, text
+     rasterization, or anything about video — those, and only those, need the set.
+4. **Break it only when it is a corpse**: `tools/tv-lock.sh break` refuses a live lease and tells
+   you how long it has left; `break --yes` takes it anyway. An expired lease needs no break at all
+   — the next `acquire` takes it and says whose it was.
+
+## Two things the lock cannot see
+
+- **A human watching television.** The lock knows about jobs, not about the household. `status`
+  therefore also runs the old pre-flight — `fuser` on **both** installs' own binaries (inode-scoped;
+  `pidof plxnative` matches both, since both binaries carry that name) and a count of ssh sessions
+  on the set. `N ssh sessions (one is mine)` is the check that actually fires, and it sees machines
+  whose processes you cannot: read the warning, do not dismiss it as your own connection.
+- **Work started before the lock existed**, or from a checkout without these tools. Same warning,
+  same rule.
+
+## Fleets
+
+When farming device work out to several agents, **the television is the scheduling constraint, not
+a detail**. Give exactly one lane device access at a time and say so in the other prompts; run the
+rest host-only or on the simulator. The lock now makes the second lane *fail* instead of silently
+corrupting the first, but a fleet that all queue on one set is still a fleet running in series —
+plan the work so only one lane needs the device.
+
+A lane is a **checkout**: the lease belongs to the worktree, so every Bash call, `make` and nested
+tool inside it inherits the same lease, and a second worktree on the same Mac is a different lane.
+
+## Under the hood (enough to debug it)
+
+- The lock is a **directory on the television**, `/tmp/plx-tv.lock`, holding one `owner` file.
+  `mkdir` is the atomic create-if-absent primitive that works on the set's busybox userland; the
+  whole decision is taken on the TV in one round trip, never as a read here and a write back.
+- It lives on the **device** because the device is the resource — a host-side file cannot see the
+  second worktree, the second Mac, or the colleague on the sofa. Under `/tmp` because a TV reboot
+  is the one event that also makes every holder's session meaningless.
+- The name deliberately does **not** start with `plxnative-`: for the stable install the app's
+  runtime root *is* `/tmp`, and any file there with that prefix marks the boot as automated and
+  suppresses the who's-watching picker (`dev::any_trigger_present`). It is also outside the glob
+  `make run` and `tests/run.py` clear, so a teardown cannot drop somebody's lease.
+- **Every timestamp is the host's.** pmlog's wall clock on this set runs ~3 h off, so a lease
+  minted from the TV's own `date` would expire in the past or three hours late.
+- Each lane keeps a local mirror of its lease under `~/.plxnative/tv-lock/`, which is what makes
+  the hook free and what lets `require` skip the round trip for a minute. The television always
+  holds the authority; the tools reconcile the two on every use.
+- `tools/tv-lock.sh selftest` runs the real protocol text under a local `sh` against a temp
+  directory: who wins a contended acquire, that a live lease is not stealable, that an expired one
+  is, that release is owner-scoped. Run it after touching the tool — it needs no television.
+- `python3 .claude/hooks/tv-lock-guard-test.py` grades the hook's classifier the same way, and
+  **half its cases are false positives** — `pgrep -fl "…|make deploy"`, a heredoc that documents
+  the lock, a commit message that mentions it. That is the guard's real failure mode: refusing
+  work that never touches the set teaches the reader to reach for the bypass. Add a case there
+  before widening what the guard matches.
+
+The escape hatch is `PLX_TV_LOCK_BYPASS=1 <command>`, which both the tools and the hook honour. It
+is for a human who knows the set is theirs. Reaching for it because a lock said no is the one move
+this whole mechanism exists to prevent.

--- a/.claude/skills/tv-session/SKILL.md
+++ b/.claude/skills/tv-session/SKILL.md
@@ -19,6 +19,14 @@ description: >
 
 # Working on the TV
 
+> **FIRST: take the television's lock.** One set, no OS-level mutex — two jobs on it produce
+> plausible WRONG data rather than a clean failure. `tools/tv-lock.sh acquire --why "…"` before the
+> session and `release` after (and `tools/tv-lock.sh status` to see who has it). Every driving
+> subcommand below refuses without it; `log` and `status` are read-only and only name the holder.
+> The **`tv-lock` skill** is the workflow, and the reason to take one lease for the whole session
+> rather than letting each command take its own: the gap between two of your own commands is where
+> another lane lands.
+
 > **Before booking the TV: can the simulator answer this?** `make sim` runs the same app core on
 > macOS — real UI, real PMS data, boot triggers, the same FIFO tokens, self-screenshotting, and
 > several instances at once. Layout, focus, navigation and the whole data layer are answerable
@@ -45,6 +53,10 @@ tools/tv-session.sh shot [out.png]          # panel capture (video plane include
 tools/tv-session.sh log [--flavor <f>] [regex]   # the on-device event log
 tools/tv-session.sh down [--flavor <f>]     # hand the TV back
 ```
+
+`down` hands back the APP (interactive boot, triggers cleared); `tools/tv-lock.sh release` hands
+back the TELEVISION. Do both, in that order — a released lock with an automated app still on
+screen is the next lane's confusing morning.
 
 `--flavor <f>` selects **which install** the command talks to, and every subcommand accepts it —
 each of them names an app id, an app directory or a runtime root, and none of those is a single

--- a/.claude/skills/ui-sim/SKILL.md
+++ b/.claude/skills/ui-sim/SKILL.md
@@ -14,6 +14,13 @@ description: >
 
 # ui-sim — verify UI work on macOS, finish on the TV
 
+
+> **This is also what you do while the television is locked.** One set, one lane at a time
+> (`tools/tv-lock.sh`, the **`tv-lock`** skill): when a device command is refused because another
+> lane holds it, the simulator is usually the answer rather than the queue — N instances run at
+> once, each with its own `PLXNATIVE_RUNTIME_DIR`. Come back to the TV only for what the simulator
+> provably cannot answer (frame rate, text rasterization, video, the video plane).
+
 `plxnative-sim` is the same application core the television runs, linked against desktop SDL2 and
 desktop GL. It draws the real interface against your real Plex Media Server, on this Mac.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,44 +468,60 @@ used: **libcurl** (`net.rs`) does the plex.tv account/login TLS+DNS that the raw
 
 ## Testing / verification (two tiers: a fast host unit suite, then the device)
 
-> ### THERE IS ONE TELEVISION AND IT IS A MUTEX. NOTHING ENFORCES THIS.
+> ### THERE IS ONE TELEVISION AND IT IS A MUTEX. TAKE THE LOCK.
 >
-> There is exactly one dev set, one app instance on it, and **no lock of any kind** — not a file,
-> not a flag, not the harness. The only thing keeping two jobs off it is whoever is sequencing the
-> work, and that is precisely why it goes wrong: two `tests/run.py` runs, or a run plus a
-> `make deploy`, or a capture session plus either, **kill each other's app**. The damage is not a
-> clean failure — it is *plausible wrong data*: bogus `timeline_climb` failures, an fps number
-> measured while somebody else's binary was being deployed underneath, a capture of a screen the
-> other job navigated away from. You cannot tell those from a real regression by looking at them.
+> There is exactly one dev set, one app instance on it, and webOS enforces nothing: two
+> `tests/run.py` runs, or a run plus a `make deploy`, or a capture session plus either, **kill each
+> other's app**. The damage is not a clean failure — it is *plausible wrong data*: bogus
+> `timeline_climb` failures, an fps number measured while somebody else's binary was being deployed
+> underneath, a capture of a screen the other job navigated away from. You cannot tell those from a
+> real regression by looking at them.
 >
-> **Before any device work, check — do not assume.** Owning it a minute ago is not owning it now:
+> **Since 2026-08-22 there IS a lock, and it is enforced** — this section said "no lock of any
+> kind, the only thing keeping two jobs off it is whoever is sequencing the work" for as long as
+> that was true, and hand-sequencing failed exactly the way it was always going to. The mechanism
+> is **`tools/tv-lock.sh`**, a lease held in a directory ON THE TELEVISION (`/tmp/plx-tv.lock`, so
+> it spans worktrees and machines, and outside the `plxnative-*` prefix so it neither trips
+> `dev::any_trigger_present` nor gets swept by a teardown). The workflow is the **`tv-lock` skill**:
 >
 > ```sh
-> pgrep -fl "tests/run.py|capture-screen|make deploy" ; ps aux | grep -c "[s]sh .*$(cat .tv-host)"
-> for f in stable debug; do          # BOTH installs — see below for why once is not enough
->   printf '%s: ' "$f"
->   ssh root@$(cat .tv-host) "fuser $(make -s print-appdir FLAVOR=$f)/plxnative || echo NONE"
-> done                               # `ps` finds nothing on this busybox TV
+> tools/tv-lock.sh status                             # who has it; also the unlocked-user pre-flight
+> tools/tv-lock.sh acquire --why "what this is for"   # --wait 540 queues instead of failing
+>   … device work …
+> tools/tv-lock.sh release
+> tools/tv-lock.sh with --why "fps suite" -- ./tests/run.py --fps   # one-shot, released on Ctrl-C
 > ```
 >
-> **A `NONE`/`NONE` answer is not "the set is free", and reading it that way cost a collision on
-> 2026-08-22.** `fuser` is inode-scoped and honest, which is exactly its limit: it sees only the
-> instants an app is UP, and hand-driven device work is a close → deploy → launch → measure loop
-> that is legitimately down between iterations. The `pgrep` above misses that job too — it names the
-> three HARNESS commands, and most device work is raw `ssh root@… <<EOF` and `luna-send`. **The
-> ssh-client COUNT is the check that actually fires**, because it is the one that sees a job between
-> its app instances — so read those pids' argv (`pgrep -fl "ssh .*$(cat .tv-host)"`) rather than
-> counting them, and treat any you cannot account for as OCCUPIED. A count explained away as "my own
-> grep pipeline" is how the collision happened.
+> **You cannot skip it.** `tv-session.sh` (`up`/`key`/`click`/`shot`/`down`), `make deploy`/`run`/
+> `run-stream`/`kill`/`install`/`uninstall`, `tests/run.py` and `tools/capture-screen.sh` all take
+> it, and a **`PreToolUse` hook** (`.claude/hooks/tv-lock-guard.py`) refuses any Bash command that
+> reaches the set without a lease — including a raw `ssh root@…`, an `scp` into the app directory
+> and a `sshpass` one-liner. With nobody holding the set, a single command takes a short implicit
+> lease rather than failing; **a SESSION should take a real one**, because the gap between two of
+> your own commands is exactly where another lane lands. Read-only diagnostics are deliberately not
+> blocked: `tv-session.sh log|status`, `tools/crash-report.sh`, `make -s print-*`.
 >
+> **What the lock cannot see is a human watching television**, or a job started from a checkout
+> without these tools — so `status` also runs the old pre-flight: `fuser` on **both** installs' own
+> binaries plus a count of ssh sessions taken ON the set (which therefore also sees other machines).
 > `fuser` on the app directory's own binary, not `pidof plxnative`: both installs' binaries are
 > named `plxnative`, so a name-scoped test matches BOTH and returns two pids in an order busybox
 > does not promise. `fuser` is inode-scoped, so it answers about one install
-> (`docs/two-installs.md` §4.2) — **which is exactly why this one has to ask twice**, since the
-> question here is "is anybody else using the television", not "is my install alive". A single
-> `fuser` reports NONE while the OTHER install is mid-film or mid-release-verification, and with no
-> `FLAVOR` on the command line `print-appdir` answers `debug`, so the bare form silently never asks
-> about the app the household watches with at all.
+> (`docs/two-installs.md` §4.2) — **which is why it has to ask twice**, since the question is "is
+> anybody else using the television", not "is my install alive". A single `fuser` reports NONE while
+> the OTHER install is mid-film or mid-release-verification.
+>
+> **And a `NONE`/`NONE` answer is still not "the set is free" — reading it that way cost a collision
+> on 2026-08-22, which is what the lock above came out of.** `fuser` is inode-scoped and honest,
+> which is exactly its limit: it sees only the instants an app is UP, and hand-driven device work is
+> a close → deploy → launch → measure loop that is legitimately down between iterations. A `pgrep`
+> for the three HARNESS command names misses that job too, because most device work is raw
+> `ssh root@… <<EOF` and `luna-send`. **The ssh COUNT is the check that actually fires**, because it
+> is the one that sees a job between its app instances — so read those pids' argv
+> (`pgrep -fl "ssh .*$(cat .tv-host)"`) rather than counting them, and treat any you cannot account
+> for as OCCUPIED. A count explained away as "my own grep pipeline" is how the collision happened.
+> The hook now stops an unlocked job for anybody working in this repo; it cannot stop one started
+> before the lock existed, or from a checkout that does not have it.
 >
 > **When farming work out to several agents, the TV is the scheduling constraint, not a detail.**
 > Give device access to **at most one lane at a time** and say so in the other prompts; run the rest
@@ -513,7 +529,11 @@ used: **libcurl** (`net.rs`) does the plex.tv account/login TLS+DNS that the raw
 > which is the whole reason it exists). Telling two prompts "you own the television exclusively" is
 > *not* a mutex — each is true when written and false the moment the second one starts. That exact
 > mistake was made on 2026-08-21 with a blur measurement and a Dolby capture running at once, and it
-> was caught by luck rather than by anything failing loudly.
+> was caught by luck rather than by anything failing loudly; the lock above is what came of it, and
+> a **lane is a CHECKOUT** — the lease belongs to the worktree, so every command inside one inherits
+> it and a second worktree on the same Mac is a second lane. The lock turns that collision into a
+> refusal, but a fleet that all queue on one set is a fleet running in series: plan the work so only
+> one lane needs the device.
 >
 > If you find a collision: stop **one** job (`TaskStop`), let the other finish, then re-run the
 > stopped one from scratch — do not salvage its half-collected numbers. Check afterwards for a

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,13 @@
 # Which television. `make TV=1.2.3.4 …` overrides for one invocation; otherwise it comes from the
 # gitignored `.tv-host` (one line, an IP or hostname), so this repository carries nobody's home
 # network. `tools/` reads the same file via $TV_HOST. Absent, the targets that need a TV say so.
-TV       ?= $(strip $(shell cat .tv-host 2>/dev/null))
+# The second `cat` is for a LINKED WORKTREE, and it is not a convenience: `.tv-host` is gitignored,
+# so a worktree cut from this repo has none — and worktrees are exactly where the parallel agents
+# live. Without it, the checkouts most likely to collide over the one television are also the only
+# ones that cannot ask `tools/tv-lock.sh` who is holding it, which is how a lane ends up dialling
+# `root@` out of somebody's memory instead. `--git-common-dir` is the MAIN checkout's `.git` from
+# anywhere in the worktree family (and plain `.git` in the main one, where the first cat already won).
+TV       ?= $(strip $(shell cat .tv-host 2>/dev/null || cat "$$(git rev-parse --git-common-dir 2>/dev/null)/../.tv-host" 2>/dev/null))
 # Expanded only inside a recipe, so `make`, `make check` and `make ipk` never need a TV at all —
 # but anything that talks to one fails with this sentence instead of dialling `root@`.
 # `alpine` is NOT a secret: it is webosbrew's published dev-mode root password, the same on every
@@ -53,6 +59,27 @@ TV_OR_DIE = $(if $(TV),$(TV),$(error no TV configured — put its IP in .tv-host
 SSH       = sshpass -p alpine ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 root@$(TV_OR_DIE)
 SCP       = sshpass -p alpine scp -O -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 RUN_SECS ?= 18
+
+# --- THE TELEVISION IS A MUTEX, and this is what enforces it -------------------------------
+#
+# One dev set, one app instance, no OS-level lock: two jobs on it do not fail cleanly, they
+# produce plausible WRONG data (a bogus timeline_climb, an fps number measured while somebody
+# else's binary was being deployed underneath). Every recipe below that TOUCHES the television
+# takes `tv-lock-require` as its first prerequisite, so the refusal happens before the first scp
+# rather than halfway through one.
+#
+# It is cheap: `require` re-checks a lease this lane verified in the last minute from a local file,
+# with no ssh at all, which is what makes it affordable on `run-stream` — a recipe tests/run.py
+# invokes once per case. And it is not a gate you have to remember: with nobody holding the set it
+# takes a short implicit lease rather than failing, so a lone `make deploy` still works and still
+# cannot collide with a fleet job. A SESSION should take a real one (`tools/tv-lock.sh acquire`),
+# because the gap between two of your own commands is where another lane lands.
+#
+# `$(TV)` rather than `$(TV_OR_DIE)`: with no television configured this must stay silent and let
+# the recipe's own ssh produce the familiar error, not replace it with a complaint about a lock.
+TVLOCK = tools/tv-lock.sh
+tv-lock-require:
+	@$(if $(TV),TV=$(TV),) $(TVLOCK) require --quiet --why "make $(or $(MAKECMDGOALS),deploy) [$(FLAVOR)]"
 
 # --- WHICH INSTALL: the FLAVOR axis --------------------------------------------------------
 #
@@ -510,7 +537,11 @@ pkg/.flavor/$(FLAVOR)/appinfo.json: pkg/appinfo.json ci/flavor.py ci/mkipk.py
 # the ACB bind needs — a stuck pipeline rather than an error. A flavour has to be INSTALLED once
 # from its own package (`make FLAVOR=$(FLAVOR) install`), and failing here names that, instead of
 # failing three steps later as something else.
-deploy: pkg/plxnative $(FFMPEG_STAGED) $(APPINFO) release-guard
+# `tv-lock-require` is LAST in that list, not first, and that is the whole point of where it sits:
+# prerequisites run left to right, and a cold `make deploy` spends ~2 minutes building FFmpeg
+# before it touches the television. Taking the lock first would hold the set through a build that
+# needs no television — and, on the short implicit lease, could even let it expire before the scp.
+deploy: pkg/plxnative $(FFMPEG_STAGED) $(APPINFO) release-guard tv-lock-require
 	@echo "deploying $(if $(RELEASE),RELEASE,dev) build ($(RUST_CFG)) to $(APPID) [$(FLAVOR)]"
 	@$(SSH) 'test -d $(APPDIR)' || { \
 	  echo "$(APPDIR) does not exist on $(TV) — the $(FLAVOR) flavour is not installed."; \
@@ -584,7 +615,7 @@ BOOT_SH = $(CLOSE_SH) \
 	  rm -f $(EVENTLOG) $(RUNDIR)/plxnative-gputime.jsonl $(RUNDIR)/plxnative-hwcnt.jsonl; \
 	  luna-send -i "luna://com.webos.applicationManager/launch" "{\"id\":\"$(APPID)\"}" >/dev/null 2>&1 & LP=$$!;
 
-run:
+run: tv-lock-require
 	@echo "running $(APPID) [$(FLAVOR)] — log $(EVENTLOG)"
 	$(SSH) '$(BOOT_SH) \
 	  sleep $(RUN_SECS); kill $$LP 2>/dev/null; sleep 1; \
@@ -596,12 +627,12 @@ run:
 # 60s. Hanging up kills the tail; the trap takes the luna-send subscription with it so 18
 # cases don't leave 18 of them behind. There is no time limit here on purpose — the caller
 # owns the deadline (run.py caps each case at its manifest run_secs).
-run-stream:
+run-stream: tv-lock-require
 	$(SSH) '$(BOOT_SH) \
 	  trap "kill $$LP 2>/dev/null" EXIT INT TERM HUP; \
 	  tail -F -n +1 $(EVENTLOG)'
 
-kill:
+kill: tv-lock-require
 	$(SSH) '$(CLOSE_SH) echo closed $(APPID)'
 
 clean:
@@ -742,7 +773,7 @@ release-guard:
 # fact that keeps the session file outside it (paths.rs) — so an install wipes whatever was in
 # there and leaves the PACKAGED binary behind. Ending here would leave you looking at a build you
 # did not make, which is the "plausible wrong data" failure this repo cares most about.
-install: ipk
+install: ipk tv-lock-require
 	@echo "installing $(IPK) as $(APPID) on $(TV)"
 	$(SCP) $(IPK) root@$(TV):/tmp/
 	@# `script -qc` because luna-send needs a tty (see the webos-screen-capture note); `-i` keeps
@@ -757,7 +788,7 @@ install: ipk
 
 # Remove a flavour from the television. Refuses the stable id: uninstalling the app the household
 # watches with is not something a make target should make easy, and appinstalld gives no undo.
-uninstall:
+uninstall: tv-lock-require
 	@test "$(FLAVOR)" != stable || { echo "refusing to uninstall $(APPID_STABLE) — do that from the TV's own app list"; exit 1; }
 	$(SSH) 'script -qc "luna-send -i -a com.webos.appInstallService \
 	  luna://com.webos.appInstallService/dev/remove \
@@ -892,5 +923,5 @@ fetch-profile:
 	-$(SCP) root@$(TV):$(RUNDIR)/plxnative-hwcnt.jsonl pkg/plxnative-hwcnt.jsonl
 	@ls -l pkg/plxnative-*.jsonl 2>/dev/null || echo "no profiler output in $(RUNDIR) on the TV ($(APPID))"
 
-.PHONY: all setup-env deploy run run-stream kill check lint test ipk clean threadprobe sockprobe logmprobe mali-hwcnt-probe sim sim-run sim-shot sim-token sim-clean macapp macapp-zip fetch-profile \
+.PHONY: all setup-env deploy run run-stream kill check lint test ipk clean tv-lock-require threadprobe sockprobe logmprobe mali-hwcnt-probe sim sim-run sim-shot sim-token sim-clean macapp macapp-zip fetch-profile \
         release-guard install uninstall $(QUERY_GOALS)

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,14 @@ on this page, and the default is the **debug** build.
 - `run.py` — the runner (Python 3 stdlib only; macOS system `python3` is fine).
 - `README.md` — this file.
 
+**The runner takes the television's lock** (`tools/tv-lock.sh`) at the point it commits to driving
+the set, and releases it after the teardown. There is one dev TV and no OS-level mutex: a second
+job during a run does not fail cleanly, it produces plausible wrong results — a `timeline_climb`
+that failed because the other lane closed the app, an fps sample taken while a deploy was landing.
+If the set is held, the run refuses and names the holder; queue for it with
+`tools/tv-lock.sh acquire --wait 540`, or wrap the whole run in
+`tools/tv-lock.sh with --why "…" -- ./tests/run.py …`. See the `tv-lock` skill.
+
 The split is not just anonymisation. The symbolic key keeps "five cases deliberately share one
 item" visible in the tracked file — which is the fact the per-case resume reset exists for — and
 it makes a mis-set item a named setup error instead of a mystery failure.

--- a/tests/run.py
+++ b/tests/run.py
@@ -1177,6 +1177,53 @@ def teardown(tv):
 # exit without closing an app the user may be watching.
 _TEARDOWN_TV = None
 
+# Whether THIS run took the television's lock (as opposed to inheriting one the operator or an
+# outer `tv-lock.sh with` already held). Only a lock we took is a lock we release: dropping an
+# inherited one would hand the set away in the middle of somebody's larger session.
+_LOCK_TAKEN = False
+TVLOCK = os.path.join(REPO_ROOT, "tools", "tv-lock.sh")
+
+
+def acquire_tv_lock(tv, why):
+    """Take the television's lock, or refuse to run.
+
+    The whole suite is one long exclusive session: it closes the app between cases, wipes the
+    runtime root, injects tokens and grades a log it assumes only it is writing. A second job on
+    the set during any of that does not produce a clean failure — it produces a plausible wrong
+    one (a bogus timeline_climb, an fps sample taken while another lane's deploy was landing),
+    which is indistinguishable from a real regression when you read the summary.
+
+    A lease this lane already holds is inherited rather than re-taken, so
+    `tools/tv-lock.sh with -- ./tests/run.py` and a hand-held session both work unchanged.
+    """
+    global _LOCK_TAKEN
+    if not os.access(TVLOCK, os.X_OK):
+        return
+    env = dict(os.environ, TV=tv)
+    held = subprocess.run([TVLOCK, "status"], env=env, capture_output=True, text=True)
+    if "HELD BY THIS LANE" in held.stdout:
+        print("TV lock: already held by this lane — inheriting it")
+        return
+    # `--wait 0`: a harness that blocks for ten minutes inside somebody's tool call is worse than
+    # one that says who has the set and exits. `--wait <s>` is the caller's choice, not ours.
+    r = subprocess.run([TVLOCK, "acquire", "--why", why, "--as", "tests/run.py"], env=env)
+    if r.returncode != 0:
+        sys.exit("refusing to run: the television is held by another lane (see above). "
+                 "Wait for it (tools/tv-lock.sh acquire --wait 540), or run host-side work "
+                 "meanwhile (make check, make sim).")
+    _LOCK_TAKEN = True
+
+
+def release_tv_lock(tv):
+    """Give the set back. Never raises — it runs in the same finally as teardown."""
+    if not _LOCK_TAKEN:
+        return
+    try:
+        subprocess.run([TVLOCK, "release"], env=dict(os.environ, TV=tv),
+                       capture_output=True, timeout=30)
+    except Exception:
+        pass
+
 
 def arm_teardown(tv):
     global _TEARDOWN_TV
@@ -1978,6 +2025,7 @@ def main():
                                                  cfg["pms"]["port"], test_user["id"])
                 cfg["inject_token"] = True
         print(f"install: {APPID} [{FLAVOUR}] — triggers and log under {RUNDIR}")
+        acquire_tv_lock(cfg["tv"], f"tests/run.py --fps ({len(scenes)} scenes) [{FLAVOUR}]")
         arm_teardown(cfg["tv"])
         if args.build:
             do_build(cfg["tv"])
@@ -2014,6 +2062,7 @@ def main():
         sys.exit("every selected case needs a second server, and none is configured "
                  f"(see {MANIFEST_LOCAL})")
 
+    acquire_tv_lock(cfg["tv"], f"tests/run.py ({len(cases)} cases) [{FLAVOUR}]")
     arm_teardown(cfg["tv"])
     if args.build:
         do_build(cfg["tv"])
@@ -2073,4 +2122,8 @@ if __name__ == "__main__":
     finally:
         if _TEARDOWN_TV:
             teardown(_TEARDOWN_TV)
+            # AFTER teardown, never before: the close, the trigger wipe and the token clear are
+            # still device work, and handing the lock back first would let the next lane start
+            # driving an app this one is still closing.
+            release_tv_lock(_TEARDOWN_TV)
     sys.exit(code)

--- a/tools/capture-screen.sh
+++ b/tools/capture-screen.sh
@@ -37,7 +37,18 @@ set -euo pipefail
 # The TV's address comes from $TV_HOST, else the gitignored .tv-host next to the Makefile (the
 # same file `make TV=` falls back to) — the repo carries no home-network address of its own.
 TV_HOST="${TV_HOST:-$(cat "$(dirname "$0")/../.tv-host" 2>/dev/null || true)}"
+# A linked worktree has no `.tv-host` of its own (it is gitignored), and that is where the parallel
+# agents live — ask the Makefile, which knows the main checkout's copy.
+[ -n "$TV_HOST" ] || TV_HOST="$(make -s -C "$(dirname "$0")/.." print-tv 2>/dev/null | head -1)"
 [ -n "$TV_HOST" ] || { echo "no TV configured — put its IP in .tv-host, or set TV_HOST=<ip>" >&2; exit 1; }
+
+# A capture is a MEASUREMENT of one moment on a set that only one lane may be steering: taken
+# during somebody else's session it is a picture of a screen THEY navigated to, and nothing in the
+# resulting PNG says so. So it takes the television's lock like any other device job.
+# NB `if`, not `[ -x … ] && …`: this script runs under `set -e`, where a trailing `&&` that tests
+# false IS a failing command and would exit 1 before taking a single picture.
+_LOCK="$(dirname "$0")/tv-lock.sh"
+if [ -x "$_LOCK" ]; then TV="$TV_HOST" "$_LOCK" require --quiet --why "capture-screen.sh"; fi
 TV_USER="${TV_USER:-root}"
 TV_PASS="${TV_PASS:-alpine}"
 CAP_W="${CAP_W:-1920}"

--- a/tools/tv-lock.sh
+++ b/tools/tv-lock.sh
@@ -1,0 +1,640 @@
+#!/usr/bin/env bash
+#
+# tv-lock.sh — the mutex the television never had.
+#
+#   tv-lock.sh status                       who holds the set, and is anybody on it unlocked
+#   tv-lock.sh acquire --why "<what>"       take it (waits with --wait, steals only when expired)
+#   tv-lock.sh renew                        extend the lease you already hold
+#   tv-lock.sh release                      hand it back
+#   tv-lock.sh require                      assert + renew; what every TV-facing tool calls
+#   tv-lock.sh with --why "<what>" -- CMD…  acquire, run CMD, release even on Ctrl-C
+#   tv-lock.sh break                        steal a live lease (names the holder first)
+#   tv-lock.sh selftest                     exercise the whole protocol with NO television
+#
+# WHY THIS EXISTS. There is one dev set, one app instance on it, and nothing in webOS, ssh or
+# this repo enforces one user at a time. Two `tests/run.py` runs, or a run plus a `make deploy`,
+# or a capture session plus either, kill each other's app — and the damage is not a clean failure,
+# it is PLAUSIBLE WRONG DATA: a bogus timeline_climb, an fps number measured while somebody else's
+# binary was being deployed underneath, a capture of a screen the other job navigated away from.
+# None of those can be told from a real regression by looking at them. Sequencing by hand is what
+# was keeping jobs apart, and "at most one lane at a time" is a rule that is true when written and
+# false the moment a second agent starts.
+#
+# WHERE THE LOCK LIVES: on the TELEVISION, at $REMOTE_LOCK — a directory, because `mkdir` is the
+# one create-if-absent primitive that is atomic on every filesystem including this set's busybox
+# userland. On the device rather than on a dev Mac because the television is the resource: a
+# host-side file cannot see the second worktree, the second machine, or the colleague on the sofa,
+# and this project's collisions come from exactly those. It is under /tmp deliberately — a TV
+# reboot clears it, which is the one event that also makes every holder's session meaningless.
+#
+# The name does NOT begin with `plxnative-`, and that is load-bearing rather than cosmetic: for the
+# stable install the app's runtime root IS /tmp, and any file there matching that prefix marks the
+# boot as automated and suppresses the who's-watching picker (`dev::any_trigger_present`). A lock
+# named `plxnative-tv.lock` would silently change which screen the app boots to — for every
+# session, including the ones it was taken to protect. It is also outside the `plxnative-*` glob
+# that `make run` and `tests/run.py` clear, so a teardown cannot drop somebody's lease.
+#
+# THE CLOCK IS THE HOST'S. Every timestamp written into the lock comes from the machine taking it,
+# never from `date` on the TV: pmlog's wall clock on this set runs about three hours off, so a
+# lease minted against it would expire in the past or three hours late. Hosts are NTP-synced to
+# each other; the television is not synced to anything that matters here.
+#
+# See .claude/skills/tv-lock/SKILL.md for the workflow, and CLAUDE.md's testing section for what
+# the lock does and does not protect (it cannot see a human watching a film with the remote).
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+REMOTE_LOCK="${PLX_TV_LOCK_PATH:-/tmp/plx-tv.lock}"
+STATE_DIR="${PLX_TV_LOCK_STATE:-$HOME/.plxnative/tv-lock}"
+
+# Lease lengths, in minutes. An EXPLICIT acquire is a session and gets the long one; the implicit
+# lease `require` takes when nobody holds the set is short on purpose, because nothing will ever
+# come back to release it — it exists so a lone `make deploy` still cannot collide, not so a
+# forgotten one can hold the television for an hour.
+TTL_MIN="${PLX_TV_LOCK_TTL:-45}"
+AUTO_TTL_MIN=10
+
+# ---------------------------------------------------------------- identity ---
+# The LANE, not the process: a lease belongs to a checkout (this worktree), so every Bash call,
+# every `make`, every nested tool in that lane inherits it, and a second worktree on the same Mac
+# is a different lane — which is precisely the fleet case that collides today.
+LANE="${PLX_TV_LOCK_LANE:-$REPO}"
+lane_slug() {
+  local h; h=$(printf '%s' "$LANE" | shasum 2>/dev/null | cut -c1-12)
+  [ -n "$h" ] || h=$(printf '%s' "$LANE" | cksum | tr -d ' ' | cut -c1-12)
+  printf '%s-%s' "$(basename "$LANE" | tr -c 'A-Za-z0-9._-' '_')" "$h"
+}
+LEASE="$STATE_DIR/$(lane_slug).lease"
+
+now()  { date +%s; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$*" >&2; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$*" >&2; }
+info() { printf '  · %s\n' "$*"; }
+
+# Anything that reaches the lock file has to survive being read back by `sed` and re-embedded in a
+# shell script, so it is stripped to one harmless line rather than quoted through three layers.
+sane() { printf '%s' "${1:-}" | tr '\n\r' '  ' | tr -d "'\"\\\\\`\$" | cut -c1-160; }
+
+fmt_dur() {  # seconds -> "1h 04m" / "7m 12s" / "9s"
+  local s="${1:-0}"; [ "$s" -lt 0 ] && s=0
+  if   [ "$s" -ge 3600 ]; then printf '%dh %02dm' $((s/3600)) $(((s%3600)/60))
+  elif [ "$s" -ge 60 ];   then printf '%dm %02ds' $((s/60)) $((s%60))
+  else printf '%ds' "$s"; fi
+}
+
+# ------------------------------------------------------------------- the TV ---
+# Resolution order ends in a fallback the rest of the repo does not have, and it matters here more
+# than anywhere: `.tv-host` is gitignored, so a LINKED WORKTREE has none — and worktrees are where
+# the parallel agents live. Without this, the one lane most likely to collide is also the only one
+# that cannot ask who holds the set.
+resolve_tv() {
+  local h="${TV:-${TV_HOST:-}}"
+  [ -n "$h" ] || h="$(cat "$REPO/.tv-host" 2>/dev/null)"
+  if [ -z "$h" ]; then
+    local common; common="$(git -C "$REPO" rev-parse --git-common-dir 2>/dev/null)"
+    [ -n "$common" ] && h="$(cat "$common/../.tv-host" 2>/dev/null)"
+  fi
+  [ -n "$h" ] || h="$(make -s -C "$REPO" print-tv 2>/dev/null | head -1)"
+  printf '%s' "$(printf '%s' "$h" | tr -d ' \t\n\r')"
+}
+HOST="$(resolve_tv)"
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
+          -o ConnectTimeout=8 -o BatchMode=yes)
+# Key auth first (this Mac has one), sshpass second so a machine without the key still works. The
+# password is webosbrew's published dev-mode root password — the same on every rooted set, so it
+# identifies nobody; the ADDRESS is the part that stays out of the repo.
+ssh_tv() {
+  ssh "${SSH_OPTS[@]}" "root@$HOST" "$@" 2>/dev/null && return 0
+  local rc=$?
+  command -v sshpass >/dev/null 2>&1 || return $rc
+  sshpass -p alpine ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+      -o LogLevel=ERROR -o ConnectTimeout=8 "root@$HOST" "$@" 2>/dev/null
+}
+
+# ------------------------------------------------------- the protocol itself ---
+# ONE round trip per operation, and the whole decision is taken ON THE TELEVISION. Reading the
+# owner here and writing it back would be a check-then-act with a network in the middle, which is
+# not a lock at all — two lanes reading "free" a millisecond apart would both write themselves in.
+#
+# $1 = acquire | renew | release | status.  Everything else rides in as pre-set shell variables so
+# nothing has to be quoted through ssh twice.
+remote_op() {
+  local mode="$1" ttl_s="$2" force="${3:-0}"
+  local exp=$(( $(now) + ttl_s ))
+  local owner
+  owner="token=$TOKEN
+expires=$exp
+acquired=${ACQUIRED_AT:-$(now)}
+ttl=$ttl_s
+user=$(sane "${USER:-unknown}")
+host=$(sane "$(hostname -s 2>/dev/null || hostname)")
+lane=$(sane "$LANE")
+branch=$(sane "$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null)")
+label=$(sane "${LABEL:-}")
+why=$(sane "${WHY:-}")
+pid=$$"
+
+  local script
+  script="$(cat <<PLX_HDR
+set -u
+L='$REMOTE_LOCK'
+O="\$L/owner"
+NOW=$(now)
+TOK='$TOKEN'
+MODE='$mode'
+FORCE='$force'
+OWNER=\$(cat <<'PLX_OWNER'
+$owner
+PLX_OWNER
+)
+PLX_HDR
+)"
+  script="$script
+$REMOTE_BODY"
+
+  if [ -n "${PLX_TV_LOCK_LOCAL:-}" ]; then printf '%s\n' "$script" | sh
+  else printf '%s\n' "$script" | ssh_tv 'sh -s'; fi
+}
+
+# The device half, kept as one string so `selftest` can run the identical text under a local `sh`
+# against a temp directory — the protocol is then tested for real, with no television involved.
+# POSIX only: this runs under busybox ash on the set.
+REMOTE_BODY='
+w() { printf "%s\n" "$OWNER" > "$O"; }   # QUOTE the format: bare %s\n loses the backslash to the
+                                             # shell and appends a literal "n", which then swallows the
+                                             # @@prev delimiter into the last field.
+EX=0
+if [ "$MODE" = acquire ]; then
+  MK=0; mkdir "$L" 2>/dev/null && MK=1
+  # A lock directory with no owner file yet is an acquire IN FLIGHT (the two writes cannot be one
+  # syscall). Treating that as a corpse would let the second lane steal the first one mid-take, so
+  # give it a moment before believing it.
+  if [ "$MK" = 0 ] && [ ! -f "$O" ]; then sleep 1; fi
+else
+  MK=0
+  [ -d "$L" ] || MK=2
+fi
+CT=$(sed -n "s/^token=//p" "$O" 2>/dev/null)
+CE=$(sed -n "s/^expires=//p" "$O" 2>/dev/null)
+[ -n "$CE" ] || CE=0
+case "$MODE" in
+  acquire)
+    if   [ "$MK" = 1 ];            then ACT=acquired
+    elif [ "$CT" = "$TOK" ];       then ACT=renewed
+    elif [ "$FORCE" = 1 ];         then ACT=broken
+    elif [ "$NOW" -gt "$CE" ];     then ACT=stolen
+    else                                ACT=held; EX=1
+    fi
+    if [ "$ACT" != held ]; then
+      [ "$ACT" = acquired ] || cp "$O" "$L/previous" 2>/dev/null
+      w
+    fi ;;
+  renew)
+    if   [ "$MK" = 2 ];      then ACT=absent;  EX=1
+    elif [ "$CT" = "$TOK" ]; then w; ACT=renewed
+    else                          ACT=notmine; EX=1
+    fi ;;
+  release)
+    if   [ "$MK" = 2 ];      then ACT=absent
+    elif [ "$CT" = "$TOK" ] || [ "$FORCE" = 1 ]; then rm -rf "$L"; ACT=released
+    else                          ACT=notmine; EX=1
+    fi ;;
+  status)
+    if   [ "$MK" = 2 ];        then ACT=free
+    elif [ ! -f "$O" ];        then ACT=held
+    elif [ "$NOW" -gt "$CE" ]; then ACT=expired
+    else                            ACT=held
+    fi ;;
+esac
+echo "act=$ACT"
+echo "@@owner"
+case "$ACT" in free|absent|released) ;; *) cat "$O" 2>/dev/null ;; esac
+echo "@@prev"
+case "$ACT" in stolen|broken) cat "$L/previous" 2>/dev/null ;; esac
+echo "@@end"
+exit $EX
+'
+
+# Split one remote reply into $ACT and the two owner blocks.
+RESP=""; ACT=""; OWNER_BLK=""; PREV_BLK=""
+parse_resp() {
+  ACT="$(printf '%s\n' "$RESP" | sed -n 's/^act=//p' | head -1)"
+  OWNER_BLK="$(printf '%s\n' "$RESP" | sed -n '/^@@owner$/,/^@@prev$/p' | sed '1d;$d')"
+  PREV_BLK="$(printf '%s\n' "$RESP" | sed -n '/^@@prev$/,/^@@end$/p'   | sed '1d;$d')"
+}
+fld() { printf '%s\n' "$2" | sed -n "s/^$1=//p" | head -1; }
+
+# "gleb@studio [bridge-cse] since 12m, 33m left — why: fps suite" — one line, because it is
+# printed by tools that are in the middle of saying something else.
+describe() {
+  local blk="$1" u h l w lab exp acq n
+  u=$(fld user "$blk"); h=$(fld host "$blk"); l=$(fld lane "$blk"); w=$(fld why "$blk")
+  lab=$(fld label "$blk"); exp=$(fld expires "$blk"); acq=$(fld acquired "$blk"); n=$(now)
+  local who="$u@$h"; [ -n "$lab" ] && who="$who ($lab)"
+  local held="" left=""
+  [ -n "$acq" ] && held=" held $(fmt_dur $((n - acq)))"
+  if [ -n "$exp" ]; then
+    if [ "$n" -gt "$exp" ]; then left=", EXPIRED $(fmt_dur $((n - exp))) ago"
+    else left=", $(fmt_dur $((exp - n))) left"; fi
+  fi
+  printf '%s%s%s\n' "$who" "$held" "$left"
+  [ -n "$l" ] && printf '    lane: %s\n' "$l"
+  [ -n "$w" ] && printf '    why:  %s\n' "$w"
+  return 0
+}
+
+# ------------------------------------------------------------ the local lease ---
+# The token proves the lease is MINE, and it lives in two places: here (so any later shell in this
+# lane can prove it) and in the lock on the TV. A hook reads only this file, which is why it costs
+# nothing on every Bash call; the television stays the authority, and `require` reconciles them.
+lease_write() {
+  mkdir -p "$STATE_DIR" 2>/dev/null; chmod 700 "$STATE_DIR" 2>/dev/null
+  umask 077
+  cat > "$LEASE" <<EOF
+TOKEN='$TOKEN'
+EXPIRES=$1
+ACQUIRED=${ACQUIRED_AT:-$(now)}
+VERIFIED=$(now)
+TV='$HOST'
+LANE='$LANE'
+EOF
+}
+lease_clear() { rm -f "$LEASE"; }
+lease_load() {
+  TOKEN=""; EXPIRES=0; ACQUIRED=0; VERIFIED=0
+  [ -f "$LEASE" ] && . "$LEASE" 2>/dev/null
+  FILE_TOKEN="$TOKEN"
+  # An inherited token beats the file: inside `with`, or inside anything it spawned, the lease is
+  # the parent's and may not have been written for this lane at all.
+  [ -n "${PLX_TV_LOCK_TOKEN:-}" ] && TOKEN="$PLX_TV_LOCK_TOKEN"
+  [ -n "$TOKEN" ]
+}
+new_token() {
+  TOKEN="$( (head -c 12 /dev/urandom 2>/dev/null | od -An -tx1 | tr -d ' \n') )"
+  [ -n "$TOKEN" ] || TOKEN="$$-$(now)"
+  ACQUIRED_AT="$(now)"
+}
+
+need_host() {
+  [ -n "$HOST" ] && return 0
+  bad "no TV configured — put its IP in .tv-host, or pass TV=<ip>"
+  return 1
+}
+
+# `acquire` is the entry point to a device session, so it wakes the set rather than reporting it
+# unreachable: the TV drops to standby after a few idle minutes and every automation session starts
+# there. Asleep, every assertion downstream reads as a total regression.
+ensure_awake() {
+  ssh_tv true && return 0
+  info "TV not answering — waking (Wake-on-LAN)"
+  TV_HOST="$HOST" "$REPO/.claude/skills/wake-tv/wake-tv.sh" >/dev/null 2>&1
+  ssh_tv true
+}
+
+# ------------------------------------------------------------------ commands ---
+WHY=""; LABEL=""; WAIT=0; FORCE=0; QUIET=0; ADVISORY=0; TTL_OVERRIDE=""
+parse_opts() {
+  ARGS_REST=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --why)   WHY="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
+      --why=*) WHY="${1#*=}"; shift ;;
+      --as)    LABEL="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
+      --as=*)  LABEL="${1#*=}"; shift ;;
+      --wait)  WAIT="${2:-0}"; shift; [ $# -gt 0 ] && shift ;;
+      --wait=*) WAIT="${1#*=}"; shift ;;
+      --ttl)   TTL_OVERRIDE="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
+      --ttl=*) TTL_OVERRIDE="${1#*=}"; shift ;;
+      --force|--yes) FORCE=1; shift ;;
+      --quiet) QUIET=1; shift ;;
+      --advisory) ADVISORY=1; shift ;;
+      --)      shift; ARGS_REST=("$@"); return 0 ;;
+      *)       ARGS_REST+=("$1"); shift ;;
+    esac
+  done
+}
+
+do_acquire() {  # $1 = ttl minutes, $2 = force ; assumes TOKEN set
+  local ttl_s=$(( $1 * 60 ))
+  RESP="$(remote_op acquire "$ttl_s" "$2")"; parse_resp
+  [ -n "$ACT" ] || { bad "no answer from $HOST — the TV is unreachable"; return 2; }
+  # VERIFY, always. Stealing an expired lease is a write, not a compare-and-swap, so two lanes
+  # deciding to steal in the same second can both write — and the loser has to find out here
+  # rather than in an fps number three minutes from now.
+  local got; got=$(fld token "$OWNER_BLK")
+  case "$ACT" in
+    acquired|renewed|stolen|broken)
+      if [ "$got" != "$TOKEN" ]; then
+        bad "lost a race for the lock — it is now held by:"; describe "$OWNER_BLK" >&2; return 1
+      fi
+      lease_write "$(fld expires "$OWNER_BLK")"
+      return 0 ;;
+    held) return 1 ;;
+    *)    bad "unexpected lock reply: $ACT"; return 2 ;;
+  esac
+}
+
+cmd_acquire() {
+  parse_opts "$@"
+  need_host || exit 2
+  local ttl="${TTL_OVERRIDE:-$TTL_MIN}"
+  ensure_awake || { bad "TV unreachable — cannot take the lock (see the wake-tv skill)"; exit 2; }
+
+  # Already mine? Renew in place. Two acquires in one lane is the normal shape when a session
+  # spans several Bash calls, and it must not be an error, or every wrapper would need to know
+  # whether the caller had already taken it.
+  if lease_load; then
+    RESP="$(remote_op status 0 0)"; parse_resp
+    if [ "$(fld token "$OWNER_BLK")" = "$TOKEN" ]; then
+      ACQUIRED_AT="$(fld acquired "$OWNER_BLK")"
+      do_acquire "$ttl" 0 && { ok "lock renewed (already yours) — $(fmt_dur $((ttl*60))) from now"; exit 0; }
+    fi
+  fi
+
+  new_token
+  local deadline=$(( $(now) + WAIT ))
+  while :; do
+    if do_acquire "$ttl" "$FORCE"; then
+      case "$ACT" in
+        stolen) warn "took an EXPIRED lease from:"; describe "$PREV_BLK" >&2 ;;
+        broken) warn "BROKE a live lease held by:"; describe "$PREV_BLK" >&2 ;;
+      esac
+      ok "TV lock held by this lane for $(fmt_dur $((ttl*60)))${WHY:+ — $WHY}"
+      info "release it: tools/tv-lock.sh release"
+      preflight_note
+      exit 0
+    fi
+    [ "$ACT" = held ] || exit 2
+    if [ "$(now)" -ge "$deadline" ]; then
+      bad "the TV is held by another lane:"
+      describe "$OWNER_BLK" >&2
+      echo "" >&2
+      echo "  Do NOT work around this. Either:" >&2
+      echo "    - wait:      tools/tv-lock.sh acquire --wait 540 --why '…'" >&2
+      echo "    - work host-side meanwhile: make check, or the simulator (make sim / ui-sim skill)" >&2
+      echo "    - if that lease is a corpse: tools/tv-lock.sh break   (it names the holder first)" >&2
+      exit 1
+    fi
+    info "held by $(fld user "$OWNER_BLK")@$(fld host "$OWNER_BLK") — waiting ($(fmt_dur $((deadline - $(now)))) left)"
+    sleep 5
+  done
+}
+
+cmd_release() {
+  parse_opts "$@"
+  need_host || exit 2
+  if ! lease_load; then info "no lease in this lane — nothing to release"; exit 0; fi
+  RESP="$(remote_op release 0 "$FORCE")"; parse_resp
+  case "$ACT" in
+    released) lease_clear; ok "TV released" ;;
+    absent)   lease_clear; info "lock was already gone (TV rebooted, or someone broke it)" ;;
+    notmine)  lease_clear
+              warn "your lease was gone — the TV is now held by:"; describe "$OWNER_BLK" >&2 ;;
+    "")       bad "no answer from $HOST; local lease dropped anyway"; lease_clear; exit 2 ;;
+  esac
+  exit 0
+}
+
+cmd_renew() {
+  parse_opts "$@"
+  need_host || exit 2
+  lease_load || { bad "no lease in this lane to renew"; exit 1; }
+  local ttl="${TTL_OVERRIDE:-$TTL_MIN}"
+  RESP="$(remote_op renew $(( ttl * 60 )) 0)"; parse_resp
+  case "$ACT" in
+    renewed) lease_write "$(fld expires "$OWNER_BLK")"; ok "lease renewed — $(fmt_dur $((ttl*60))) from now" ;;
+    *) bad "cannot renew (act=$ACT) — the lease is no longer yours"; exit 1 ;;
+  esac
+}
+
+# The pre-flight the CLAUDE.md block used to spell by hand. It answers the OTHER half of the
+# question the lock cannot: a lease says no other LOCKED job is on the set, and this says whether
+# anybody is on it anyway — an older job, a colleague, a human with the remote.
+preflight_note() {
+  local sd dd out
+  sd="$(make -s -C "$REPO" FLAVOR=stable print-appdir 2>/dev/null)"
+  dd="$(make -s -C "$REPO" FLAVOR=debug  print-appdir 2>/dev/null)"
+  [ -n "$sd" ] && [ -n "$dd" ] || return 0
+  # ONE round trip for both installs and the ssh count. `fuser` on each install's own binary,
+  # never `pidof plxnative`: both binaries carry that name, so a name-scoped test matches BOTH and
+  # answers in an order busybox does not promise.
+  out="$(ssh_tv "for d in '$sd' '$dd'; do printf '%s ' \"\$(fuser \$d/plxnative 2>/dev/null || echo NONE)\"; done; echo; netstat -an 2>/dev/null | grep -c 'ESTABLISHED.*:22 \|:22 .*ESTABLISHED'")"
+  local apps ssh_n
+  apps="$(printf '%s\n' "$out" | head -1)"
+  ssh_n="$(printf '%s\n' "$out" | sed -n '2p')"
+  case "$apps" in
+    *[0-9]*) info "note: an app is already running on the set (stable/debug: $apps)" ;;
+  esac
+  # The count includes THIS command's own connection, so 2+ means somebody else is on the wire —
+  # possibly from a machine whose processes you cannot see with `ps`.
+  if [ -n "$ssh_n" ] && [ "$ssh_n" -gt 1 ] 2>/dev/null; then
+    warn "$ssh_n ssh sessions on the TV (one is mine) — somebody may be driving it unlocked"
+  fi
+}
+
+cmd_status() {
+  parse_opts "$@"
+  need_host || exit 2
+  echo "== TV lock: $HOST"
+  if ! ssh_tv true; then bad "TV unreachable (asleep? see the wake-tv skill)"; exit 2; fi
+  lease_load || true
+  RESP="$(remote_op status 0 0)"; parse_resp
+  case "$ACT" in
+    free)    ok "FREE — nobody holds the television" ;;
+    expired) warn "EXPIRED lease still on the set (next acquire takes it):"; describe "$OWNER_BLK" ;;
+    held)
+      if [ -n "${TOKEN:-}" ] && [ "$(fld token "$OWNER_BLK")" = "$TOKEN" ]; then
+        ok "HELD BY THIS LANE:"; describe "$OWNER_BLK"
+      else
+        bad "HELD by another lane:"; describe "$OWNER_BLK"
+      fi ;;
+    *) bad "no answer from the lock (act=${ACT:-none})" ;;
+  esac
+  preflight_note
+  [ "$ACT" = free ] || [ "$ACT" = expired ] || return 0
+}
+
+cmd_break() {
+  parse_opts "$@"
+  need_host || exit 2
+  RESP="$(remote_op status 0 0)"; parse_resp
+  if [ "$ACT" = free ]; then info "nothing to break — the lock is free"; exit 0; fi
+  echo "breaking a lease held by:" >&2; describe "$OWNER_BLK" >&2
+  if [ "$FORCE" != 1 ] && [ "$ACT" = held ]; then
+    local exp; exp=$(fld expires "$OWNER_BLK")
+    if [ -n "$exp" ] && [ "$(now)" -lt "$exp" ]; then
+      bad "that lease is LIVE ($(fmt_dur $((exp - $(now)))) left). If you are sure it is a corpse:"
+      echo "    tools/tv-lock.sh break --yes" >&2
+      echo "  A live lease usually means a real job is mid-run; breaking it corrupts BOTH." >&2
+      exit 1
+    fi
+  fi
+  new_token; WHY="${WHY:-broke a stale lease}"
+  do_acquire "${TTL_OVERRIDE:-$TTL_MIN}" 1 || exit 1
+  ok "lock broken and taken by this lane"
+}
+
+# What every TV-facing tool calls. Three jobs: refuse when somebody else holds the set, keep a
+# live session's lease from ageing out under it, and — when nobody holds it at all — take a SHORT
+# implicit lease rather than making a lone `make deploy` fail. That last branch is why a one-off
+# command still cannot collide with a fleet job, without anybody having typed anything.
+cmd_require() {
+  parse_opts "$@"
+  if [ "${PLX_TV_LOCK_BYPASS:-0}" = 1 ]; then
+    warn "PLX_TV_LOCK_BYPASS=1 — TV lock NOT checked (you are on your own for collisions)"; exit 0
+  fi
+  [ -n "$HOST" ] || exit 0            # no TV configured: the caller will fail on its own terms
+
+  # THE FAST PATH, and the only reason this is affordable as a prerequisite of every TV-facing
+  # make recipe: a lease this lane verified against the television less than a minute ago, with
+  # minutes still to run, is re-checked from the local file alone — no ssh, no round trip. What it
+  # gives up is narrow and deliberate: someone who BREAKS a live lease (`break --yes`, never
+  # automatic) can go unnoticed for up to a minute. Expiry cannot hide here, because the local
+  # copy carries the same expiry the TV does.
+  if lease_load && [ -n "$FILE_TOKEN" ] && [ "$TOKEN" = "$FILE_TOKEN" ] \
+     && [ $(( $(now) - ${VERIFIED:-0} )) -lt 60 ] && [ $(( ${EXPIRES:-0} - $(now) )) -gt 120 ]; then
+    [ "$QUIET" = 1 ] || ok "TV lock held by this lane"
+    exit 0
+  fi
+
+  RESP="$(remote_op status 0 0)"; parse_resp
+  if [ -z "$ACT" ]; then
+    # Unreachable is not a collision — an asleep television has nobody on it either. Let the
+    # caller's own command produce the real error instead of a lock complaint about a lock the
+    # TV cannot even be asked about.
+    [ "$QUIET" = 1 ] || warn "cannot reach $HOST to check the TV lock — continuing"
+    exit 0
+  fi
+  if lease_load && [ "$(fld token "$OWNER_BLK")" = "$TOKEN" ]; then
+    # Renew when under half the lease is left, so a long session never expires mid-run and a short
+    # command does not pay for an extra round trip it does not need.
+    local exp ttl; exp=$(fld expires "$OWNER_BLK"); ttl=$(fld ttl "$OWNER_BLK")
+    if [ -n "$exp" ] && [ -n "$ttl" ] && [ $(( exp - $(now) )) -lt $(( ttl / 2 )) ]; then
+      remote_op renew "$ttl" 0 >/dev/null && lease_write $(( $(now) + ttl ))
+    fi
+    [ "$QUIET" = 1 ] || ok "TV lock held by this lane"
+    exit 0
+  fi
+  if [ "$ADVISORY" = 1 ]; then
+    # Read-only callers (`tv-session.sh log`, `status`) take nothing and refuse nothing: fetching a
+    # log cannot disturb a running session. They still SAY who is on the set, because reading a log
+    # that another lane's app is writing is how a session gets graded as your own.
+    [ "$ACT" = held ] && { warn "the TV is held by another lane — this is somebody else's session:"; describe "$OWNER_BLK" >&2; }
+    exit 0
+  fi
+  if [ "$ACT" = held ]; then
+    bad "REFUSING: the television is held by another lane —"
+    describe "$OWNER_BLK" >&2
+    echo "  Two jobs on this set do not fail cleanly; they produce plausible WRONG data." >&2
+    echo "  Wait for it (tools/tv-lock.sh acquire --wait 540 --why '…'), or work host-side:" >&2
+    echo "  make check / make sim (the ui-sim skill runs N simulators at once)." >&2
+    exit 1
+  fi
+  # free or expired: take the short implicit lease.
+  new_token; WHY="${WHY:-implicit lease (an unattended TV command)}"; LABEL="${LABEL:-auto}"
+  if do_acquire "$AUTO_TTL_MIN" 0; then
+    # ALWAYS said out loud, `--quiet` or not: `--quiet` means "do not narrate the lease I already
+    # had", and taking a new one is a different event. Silently acquiring would leave an operator
+    # wondering for ten minutes why the set is held by a command that has already finished.
+    warn "nobody held the TV — took an implicit ${AUTO_TTL_MIN}m lease. For a session, take a real one: tools/tv-lock.sh acquire --why '…'"
+    exit 0
+  fi
+  bad "could not take the TV lock:"; describe "$OWNER_BLK" >&2; exit 1
+}
+
+cmd_with() {
+  parse_opts "$@"
+  set -- ${ARGS_REST[@]+"${ARGS_REST[@]}"}
+  [ $# -gt 0 ] || { echo "usage: tv-lock.sh with [--why …] -- <command>…" >&2; exit 2; }
+  need_host || exit 2
+
+  # Inheriting rather than nesting. A `with` inside a lane that ALREADY holds the set must not
+  # release it on the way out — the outer session would silently lose the television mid-task.
+  local inherited=0
+  if [ "${PLX_TV_LOCK_INHERITED:-0}" = 1 ]; then inherited=1
+  elif lease_load; then
+    RESP="$(remote_op status 0 0)"; parse_resp
+    [ "$(fld token "$OWNER_BLK")" = "$TOKEN" ] && inherited=1
+  fi
+
+  if [ "$inherited" = 0 ]; then
+    ( exec "$0" acquire ${WHY:+--why "$WHY"} ${LABEL:+--as "$LABEL"} \
+        ${TTL_OVERRIDE:+--ttl "$TTL_OVERRIDE"} --wait "$WAIT" ) || exit 1
+    lease_load || exit 1
+  fi
+
+  # Keep the lease warm for as long as the child runs. Without this a legitimately long job — the
+  # 21-case suite, a soak — expires under itself and the next lane steals the television mid-run.
+  local renewer=0
+  if [ "$inherited" = 0 ]; then
+    ( while sleep 240; do "$0" renew >/dev/null 2>&1 || exit 0; done ) & renewer=$!
+  fi
+  trap 'rc=$?; [ '"$renewer"' -gt 0 ] && kill '"$renewer"' 2>/dev/null; [ '"$inherited"' = 0 ] && "$0" release >/dev/null; exit $rc' EXIT INT TERM HUP
+
+  PLX_TV_LOCK_TOKEN="$TOKEN" PLX_TV_LOCK_INHERITED=1 "$@"
+}
+
+cmd_selftest() {
+  # The whole protocol, against a temp directory under a local `sh` — same REMOTE_BODY text the
+  # television runs. It cannot prove anything about ssh or busybox, and it proves everything about
+  # the decisions: who wins a contended acquire, that a live lease is not stealable, that an
+  # expired one is, that release is owner-scoped, that re-acquiring is a renew.
+  local d; d="$(mktemp -d)"; trap "rm -rf '$d'" EXIT
+  export PLX_TV_LOCK_LOCAL="$d"
+  REMOTE_LOCK="$d/plx-tv.lock"
+  local fails=0
+  t() {  # t <name> <expected act> ; RESP already set
+    parse_resp
+    if [ "$ACT" = "$2" ]; then printf '  \033[32m✓\033[0m %s (act=%s)\n' "$1" "$ACT"
+    else printf '  \033[31m✗\033[0m %s: expected %s, got %s\n' "$1" "$2" "${ACT:-none}"; fails=$((fails+1)); fi
+  }
+  echo "== tv-lock selftest (no television involved)"
+  # Switch lanes wholesale — token AND identity. Carrying one lane's label into the other's
+  # writes is how the "previous holder" evidence below ends up naming the wrong one.
+  lane() { TOKEN="$1"; LABEL="$2"; WHY="lane $2"; ACQUIRED_AT=$(now); }
+  lane aaa A
+  RESP="$(remote_op acquire 600 0)";  t "A takes a free lock"                acquired
+  RESP="$(remote_op status 0 0)";     t "status sees it held"                held
+  lane bbb B
+  RESP="$(remote_op acquire 600 0)";  t "B is refused while A's lease lives" held
+  RESP="$(remote_op release 0 0)";    t "B cannot release A's lock"          notmine
+  lane aaa A
+  RESP="$(remote_op acquire 600 0)";  t "A re-acquiring is a renew"          renewed
+  # Expire A's lease by writing one that ended in the past, then let B in.
+  RESP="$(remote_op acquire -600 0)" ; parse_resp
+  lane bbb B
+  RESP="$(remote_op acquire 600 0)";  t "B takes an EXPIRED lease"           stolen
+  if [ "$(fld label "$PREV_BLK")" = A ]; then printf '  \033[32m✓\033[0m it named the previous holder (A)\n'
+  else printf '  \033[31m✗\033[0m previous holder should be A, got %s\n' "$(fld label "$PREV_BLK")"; fails=$((fails+1)); fi
+  RESP="$(remote_op renew 600 0)";    t "B renews its own"                   renewed
+  lane aaa A
+  RESP="$(remote_op renew 600 0)";    t "A cannot renew what it lost"        notmine
+  lane ccc C
+  RESP="$(remote_op acquire 600 1)";  t "--force breaks a LIVE foreign lease" broken
+  RESP="$(remote_op release 0 0)";    t "owner releases"                     released
+  RESP="$(remote_op status 0 0)";     t "lock is free again"                 free
+  RESP="$(remote_op release 0 0)";    t "releasing nothing is not an error"  absent
+  # The partial-acquire window: a lock directory with no owner file is an acquire IN FLIGHT, and
+  # the grace path must not read it as a corpse and hand the set to two lanes at once.
+  mkdir -p "$REMOTE_LOCK"
+  TOKEN=ccc
+  RESP="$(remote_op acquire 600 0)";  t "an owner-less lock dir is taken, not a wedge" stolen
+  echo ""
+  [ "$fails" = 0 ] && { echo "selftest: all good"; return 0; }
+  echo "selftest: $fails FAILED"; return 1
+}
+
+case "${1:-}" in
+  acquire) shift; cmd_acquire "$@" ;;
+  release) shift; cmd_release "$@" ;;
+  renew)   shift; cmd_renew "$@" ;;
+  status)  shift; cmd_status "$@" ;;
+  require) shift; cmd_require "$@" ;;
+  with)    shift; cmd_with "$@" ;;
+  break)   shift; cmd_break "$@" ;;
+  selftest) shift; cmd_selftest ;;
+  *) sed -n '3,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2 ;;
+esac

--- a/tools/tv-session.sh
+++ b/tools/tv-session.sh
@@ -30,6 +30,12 @@
 #   --no-token        boot with no injected token (exercises the QR sign-in flow)
 #   --keep            do not clear existing triggers first (rarely what you want)
 #
+# THE TV LOCK: every subcommand that DRIVES the set (up, key, click, shot, down) requires the
+# television's lock and refuses when another lane holds it; `status` and `log` are read-only and
+# only name the holder. Take one for a whole session rather than letting each command take its own
+# 10-minute implicit lease — the gap between two of your own commands is exactly where another
+# job lands:  tools/tv-lock.sh acquire --why "…"  …  tools/tv-lock.sh release.
+#
 # WHY THIS EXISTS: every on-device task needs the same fragile ritual, and each step fails
 # silently in its own way — a sleeping TV makes every assertion read as a regression, a
 # stale binary means you are testing yesterday's build, a leftover trigger silently changes
@@ -152,6 +158,22 @@ tvq() { ssh "${SSH_OPTS[@]}" "root@$HOST" "$@" 2>/dev/null; }
 # path (which has none), so this normalises both to a plain space-separated list.
 app_pids() {
   tvq "fuser $APPDIR/plxnative" | tr -cs '0-9' ' ' | sed 's/^ *//; s/ *$//'
+}
+
+# ------------------------------------------------------------ the TV lock ----
+# One television, no OS-level mutex: two jobs on it do not fail cleanly, they produce plausible
+# WRONG data (an fps number measured while somebody else's binary was deployed underneath, a
+# capture of a screen the other job navigated away from). Every subcommand here that DRIVES the
+# set goes through the lock; the two read-only ones only say who is on it. tools/tv-lock.sh is the
+# mechanism and .claude/skills/tv-lock/SKILL.md is the workflow.
+LOCKTOOL="$REPO/tools/tv-lock.sh"
+require_lock() {  # $1 = what this session is for, for the holder read-out
+  [ -x "$LOCKTOOL" ] || return 0
+  TV="$HOST" "$LOCKTOOL" require --quiet --why "$1" || exit 1
+}
+advise_lock() {   # read-only: never takes the lock, never refuses — only names the holder
+  [ -x "$LOCKTOOL" ] || return 0
+  TV="$HOST" "$LOCKTOOL" require --advisory --quiet --why "$1" || true
 }
 
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
@@ -340,6 +362,10 @@ cmd_up() {
   stop_viewers
 
   echo "== bringing up the TV session ($screen) on $APPID [$FLAVOR]"
+  # FIRST, before anything is closed, cleared or deployed. `up` kills the running app and wipes
+  # every trigger under the runtime root — if another lane is mid-run, that is its session, and
+  # everything after this point would be measuring a television two jobs are steering.
+  require_lock "tv-session up --screen $screen [$FLAVOR]"
   ensure_awake  || exit 1
   ensure_installed || exit 1
   ensure_rundir || exit 1
@@ -492,6 +518,7 @@ cmd_up() {
 
 cmd_status() {
   echo "== session status: $APPID [$FLAVOR]"
+  advise_lock "tv-session status"
   ensure_awake || exit 1
   local pid; pid=$(app_pids)
   [ -n "$pid" ] && ok "app running (pid $pid)" || bad "app not running"
@@ -513,6 +540,7 @@ cmd_status() {
 
 cmd_key() {
   [ $# -gt 0 ] || { echo "usage: tv-session.sh key <token>..." >&2; exit 2; }
+  require_lock "tv-session key"
   # the app drains the FIFO each frame; time-box the write so a FIFO with no reader
   # (app not running) cannot wedge this shell
   for t in "$@"; do
@@ -527,11 +555,15 @@ cmd_click() {
 }
 
 cmd_shot() {
+  # A capture is a MEASUREMENT, not a peek: a shot taken during another lane's session is a
+  # picture of a screen that lane navigated to, and nothing about the image says so.
+  require_lock "tv-session shot"
   local out="${1:-$REPO/tv-shot.png}"
   "$REPO/tools/capture-screen.sh" "$out" DISPLAY
 }
 
 cmd_log() {
+  advise_lock "tv-session log"
   local pat="${1:-}"
   if [ -n "$pat" ]; then tvq "grep -E '$pat' $EVENTLOG"
   else tvq "cat $EVENTLOG"; fi
@@ -539,6 +571,10 @@ cmd_log() {
 
 cmd_down() {
   echo "== handing the TV back"
+  # `down` still needs the lock: it CLOSES the app and clears every trigger, which is the most
+  # destructive thing in this file if another lane is mid-run. Handing the television back to a
+  # human is `down` followed by `tools/tv-lock.sh release` — the skill spells that pair out.
+  require_lock "tv-session down"
   local had_url=0; [ -f "$REMOTE_URL_FILE" ] && had_url=1
   stop_viewers
   ok "streamer stopped"
@@ -561,5 +597,5 @@ case "${1:-}" in
   shot)   shift; cmd_shot "$@" ;;
   log)    shift; cmd_log "$@" ;;
   down)   shift; cmd_down ;;
-  *) sed -n '3,31p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2 ;;
+  *) sed -n '3,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2 ;;
 esac


### PR DESCRIPTION
There is one dev set, one app instance on it, and until now nothing kept two jobs off it but
whoever was sequencing the work. That failed the way it was always going to, and the damage is
never a clean failure — it is plausible **wrong data**: a `timeline_climb` that failed because the
other lane closed the app, an fps number measured while somebody else's binary was landing, a
capture of a screen the other job navigated to. None of those can be told from a real regression by
reading them.

## The mechanism

`tools/tv-lock.sh` holds a lease in a **directory on the television**. Three things about that are
load-bearing rather than incidental:

- `mkdir` is the only atomic create-if-absent primitive on this set's busybox userland;
- the lock lives on the device because the device *is* the resource — a host-side file cannot see
  the second worktree, the second Mac, or the colleague on the sofa;
- its name does **not** begin with `plxnative-`, because for the stable install the app's runtime
  root *is* `/tmp`, where that prefix marks a boot as automated and suppresses the who's-watching
  picker. A lock that changed which screen the app boots to would corrupt every session it was
  taken to protect. It is also outside the glob `make run` and `tests/run.py` clear, so a teardown
  cannot drop somebody's lease.

Every timestamp is the **host's**: pmlog's wall clock on this set runs about three hours off.

```sh
tools/tv-lock.sh status                             # who has it + the fuser/ssh pre-flight
tools/tv-lock.sh acquire --why "verify HUD change"  # --wait 540 queues instead of failing
tools/tv-lock.sh release
tools/tv-lock.sh with --why "fps suite" -- ./tests/run.py --fps   # released even on Ctrl-C
```

## Enforced at four layers, so there is no "I forgot" path

1. `tv-session.sh` — `up`/`key`/`click`/`shot`/`down` require it; `log`/`status` are read-only and
   only name the holder.
2. The Makefile — `deploy`/`run`/`run-stream`/`kill`/`install`/`uninstall` take `tv-lock-require`
   as a prerequisite, **last** in `deploy`'s list so a two-minute FFmpeg build does not happen
   while holding the set.
3. `tests/run.py` acquires where it commits to driving the TV and releases after the teardown,
   inheriting a lease this lane already holds; `capture-screen.sh` requires it too, because a
   capture is a measurement and nothing in the PNG says whose screen it was.
4. `.claude/hooks/tv-lock-guard.py`, a `PreToolUse` hook that refuses the way *around* all of the
   above: a raw `ssh root@…`, an `scp` into the app directory, a `sshpass` one-liner.

With nobody on the set a single command takes a short implicit lease rather than failing, so a lone
`make deploy` still works and still cannot collide. A session should take a real one, because the
gap between two of your own commands is exactly where another lane lands. A lane is a **checkout** —
which is also why the Makefile's `TV` now falls back to the main checkout's `.tv-host`: a linked
worktree has none, and worktrees are where the parallel agents live, so the lane most likely to
collide was the only one that could not ask who held the set.

## Verification

Both halves are testable without a television, and both were:

```
tools/tv-lock.sh selftest                     14/14 protocol assertions
python3 .claude/hooks/tv-lock-guard-test.py   36/36 classifier cases
make check                                    968 passed
```

Plus a live pass on the set: a second lane refused, the Makefile guard at 0.11 s on its
no-round-trip fast path, `with` inheriting a session lease without releasing it, `with` releasing on
SIGTERM, and `run.py`'s acquire → inherit → refuse → release path.

Half the guard's cases are **false positives on purpose**. That is its real failure mode: refusing
`pgrep -fl "…|make deploy"` — the pre-flight that asks whether anybody is on the television — or a
heredoc that documents the lock, teaches the reader to reach for the bypass. Both of those fired on
this branch's own author within two minutes of the hook going live; the quote-aware splitter and the
heredoc-body excision are what came of it.

Documentation: a new `tv-lock` skill, with pointers from `tv-session`, `ui-sim`, `crash-triage`,
`decompile-tv-lib`, `tests/README.md` and CLAUDE.md's testing section (whose "NOTHING ENFORCES
THIS" heading is finally out of date). The `NONE`/`NONE` blind-spot lesson added upstream is kept
in full — the lock does not close it, which is why `status` still runs that pre-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
