### PR TITLE
browse: a source's reachability becomes a STATE (the contract two lanes will share)

### DIFF
--- a/rust-modules/src/browse.rs
+++ b/rust-modules/src/browse.rs
@@ -51,6 +51,50 @@ const SRC_RETRY_CD: u32 = 600; // ~10 s at 60 fps
 
 // ---- the granted roster: the SOURCE dimension of the table ----------------------------------
 
+/// **How a source's last dial ended** — the widened form of what used to be one `bool`.
+///
+/// A bool could say "answered" or "did not", and the Sources list said exactly those two things.
+/// It could not say the three things a user needs told apart, and which the prober already
+/// distinguishes ([`crate::plex::probe::Outcome`]): nobody has dialled yet, the server answered but
+/// refused our token, and the server did not answer at all. Those want different words and, for the
+/// middle one, a different remedy — a 401 is a sharing-grant problem that re-fetching
+/// `/api/v2/resources` fixes, and telling the user their friend's server is unreachable sends them
+/// to look at a router for something that was never a network fault.
+///
+/// **This enum is a CONTRACT, landed on its own.** One lane renders it and another populates it, so
+/// it exists before either: the renderer cannot reference a type living in an unmerged branch, and
+/// two lanes cannot own one definition. Today only the two ends of the old bool are ever stored —
+/// [`Self::NotProbed`] and [`Self::Unauthorized`] are constructible and unwritten, exactly so that
+/// the behaviour of this commit is unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub(crate) enum SourceState {
+    /// Registered, never dialled. Distinct from [`Self::Unreachable`]: a source nobody has tried is
+    /// not a source that failed, and the group must not open dimmed. This is the DEFAULT for the
+    /// same reason the old `reachable: true` seed was optimistic.
+    #[default]
+    NotProbed,
+    /// Answered, and it was the machine we asked for.
+    Reachable,
+    /// Answered with 401. A token problem, never a network one — the remedy is a fresh
+    /// `/api/v2/resources`, not another address.
+    ///
+    /// **Unconstructed in production on purpose, and the attribute is the handover note.** Nothing
+    /// can produce this until the prober that tells 401 apart is wired in; when it is, the `expect`
+    /// becomes unfulfilled and the build fails until the line is deleted — which is the point, and
+    /// is why this is not a permanently-silent `allow`.
+    ///
+    /// `cfg_attr(not(test), …)` because the tests below DO construct it — pinning that an
+    /// answered-but-refused server is not drawn as unreachable — and under `--tests` the variant is
+    /// therefore live, which would make the expectation unfulfilled immediately.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "contract variant: written once the racing prober lands, and this attribute goes with it")
+    )]
+    Unauthorized,
+    /// Did not answer: refused, timed out, or unresolvable.
+    Unreachable,
+}
+
 /// One SOURCE the table is addressed by — a server this account has been granted. Comes from the
 /// [server registry](crate::plex::server_ids), which is the granted roster: a server is registered
 /// only once plex.tv (or the `plxnative-servers` dev trigger) handed us a token for it.
@@ -72,18 +116,48 @@ pub(crate) struct BrowseSource {
     /// The owner's plex.tv handle ("friend"); **empty on your own server**, where the absence of an
     /// owner is drawn as the absence of a run rather than as an empty one.
     pub(crate) handle: String,
-    /// Did it ANSWER? One of the design's three orthogonal states — *granted* (the roster's
-    /// answer), *pinned* (the only control), *reachable* (a fact about now). A source that has
-    /// stopped answering keeps every section it had learned and every pin on them: its group dims
-    /// whole and still reads `On`, because nothing was unpinned. Hiding it would read as a
+    /// How its last dial ended. One of the design's three orthogonal states — *granted* (the
+    /// roster's answer), *pinned* (the only control), *reachable* (a fact about now). A source that
+    /// has stopped answering keeps every section it had learned and every pin on them: its group
+    /// dims whole and still reads `On`, because nothing was unpinned. Hiding it would read as a
     /// revoked share.
-    pub(crate) reachable: bool,
+    ///
+    /// Was a `bool`; see [`SourceState`] for why it is not any more, and note that today only its
+    /// two former values are ever written. **Read it through [`BrowseSource::reachable`] and write
+    /// it through [`BrowseSource::set_reachable`]** unless you genuinely mean one of the new
+    /// states — that is what keeps this widening from changing behaviour.
+    pub(crate) state: SourceState,
+    /// Which tier of connection actually won — local, remote, or Plex's relay tunnel. `None` until
+    /// something probes, which is **everything, today**: `Client::set_link` has no production
+    /// caller, so the one consumer of this fact (`route`'s relay policy) has never seen a value.
+    /// Landed here with the state it belongs beside, unwritten, for the same contract reason.
+    pub(crate) tier: Option<crate::plex::probe::Location>,
     /// its `/library/sections` has landed — sections are appended exactly once per source
     sections_done: bool,
     /// its per-library item counts have landed (the row sub-line's "185 films")
     counts_done: bool,
     /// frames before the next discovery attempt after a failure (main-thread; [`pump`] counts down)
     retry_cd: u32,
+}
+
+impl BrowseSource {
+    /// Did the last dial succeed? The old `bool`, preserved as a QUESTION so that widening the
+    /// field did not have to become a behaviour change at the same time.
+    ///
+    /// **`NotProbed` answers `true`**, which looks generous and is the behaviour being preserved
+    /// exactly: the field it replaced was seeded `reachable: true` on registration, with the
+    /// comment *"a source nobody has dialled yet is not a source that failed, and the whole group
+    /// would otherwise open dimmed"*. Anything that needs to tell "not yet" from "yes" must read
+    /// [`BrowseSource::state`] and say so, which is the entire reason the state exists.
+    pub(crate) fn reachable(&self) -> bool {
+        !matches!(self.state, SourceState::Unreachable)
+    }
+    /// Record a dial that answered or did not — the only writer today, and the one that keeps this
+    /// commit behaviour-identical. A prober that can tell 401 apart sets [`BrowseSource::state`]
+    /// directly instead; this deliberately cannot express [`SourceState::Unauthorized`].
+    pub(crate) fn set_reachable(&mut self, ok: bool) {
+        self.state = if ok { SourceState::Reachable } else { SourceState::Unreachable };
+    }
 }
 
 // ---- section table (discovered per source) ---------------------------------------------------
@@ -450,8 +524,11 @@ fn sync_roster() {
                     name,
                     handle,
                     // Optimistic until proven otherwise: a source nobody has dialled yet is not a
-                    // source that failed, and the whole group would otherwise open dimmed.
-                    reachable: true,
+                    // source that failed, and the whole group would otherwise open dimmed. That
+                    // is `NotProbed`, which `reachable()` answers `true` for — the seed this
+                    // replaced was a literal `true`, and the two say the same thing here.
+                    state: SourceState::NotProbed,
+                    tier: None,
                     sections_done: false,
                     counts_done: false,
                     retry_cd: 0,
@@ -491,7 +568,7 @@ pub(crate) fn ensure_sections() -> usize {
     append_sections(si, found.unwrap_or_default());
     if let Some(s) = source_mut(si) {
         s.sections_done = ok;
-        s.reachable = ok;
+        s.set_reachable(ok);
         s.retry_cd = if ok { 0 } else { SRC_RETRY_CD };
     }
     sections().len()
@@ -701,10 +778,10 @@ fn activate_source_of(_i: usize) {
 fn mark_source_reachable(i: usize, ok: bool) {
     let Some(src) = sections().get(i).map(|s| s.src) else { return };
     let Some(s) = source_mut(src) else { return };
-    if s.reachable == ok {
+    if s.reachable() == ok {
         return;
     }
-    s.reachable = ok;
+    s.set_reachable(ok);
     // A server that has come back is worth re-asking properly (its library list may have moved on);
     // one that has gone means the Sources list must dim its group NOW rather than at the next press.
     if ok {
@@ -1023,8 +1100,25 @@ pub(crate) struct SrcGroup {
     /// the owner's handle — the header's accessory; empty on your own server, where the header
     /// carries no accessory at all
     pub(crate) handle: String,
-    /// false dims the WHOLE group, header included, and states it there
-    pub(crate) reachable: bool,
+    /// How its last dial ended — [`SourceState::Unreachable`] dims the WHOLE group, header
+    /// included, and states it there.
+    ///
+    /// Was `reachable: bool`. The renderer still asks the old question through
+    /// [`SrcGroup::reachable`]; widening what it can be told is what lets that renderer grow a
+    /// third and fourth word without this projection changing again.
+    pub(crate) state: SourceState,
+    /// Which tier won — local, remote or relay. `None` until something probes, which is everything
+    /// today. The Sources list is the surface that should say it: "relay" explains a 2 Mbit/s
+    /// ceiling that otherwise reads as a broken server.
+    pub(crate) tier: Option<crate::plex::probe::Location>,
+}
+
+impl SrcGroup {
+    /// The old two-state question. See [`BrowseSource::reachable`] — `NotProbed` answers `true`
+    /// here too, and for the same reason: a group nobody has dialled must not open dimmed.
+    pub(crate) fn reachable(&self) -> bool {
+        !matches!(self.state, SourceState::Unreachable)
+    }
 }
 
 /// One library row in the Sources list.
@@ -1047,7 +1141,7 @@ pub(crate) struct SrcRow {
 pub(crate) fn source_groups() -> Vec<SrcGroup> {
     sources()
         .iter()
-        .map(|s| SrcGroup { name: s.name.clone(), handle: s.handle.clone(), reachable: s.reachable })
+        .map(|s| SrcGroup { name: s.name.clone(), handle: s.handle.clone(), state: s.state, tier: s.tier })
         .collect()
 }
 
@@ -1231,7 +1325,7 @@ pub(crate) fn loading_initial() -> bool {
 /// for, a server that could not be reached to discover anything.
 pub(crate) fn cur_source_state() -> SecFetch {
     let Some(s) = cur_source_idx().and_then(|i| sources().get(i)) else { return SecFetch::Loading };
-    if !s.reachable {
+    if !s.reachable() {
         SecFetch::Failed
     } else if s.sections_done {
         SecFetch::Ready
@@ -1260,7 +1354,8 @@ pub(crate) fn seed_sources_for_test(n: usize, reachable: bool) {
             owned: k == 0,
             name: if k == 0 { "nas-home".into() } else { "film-club".into() },
             handle: if k == 0 { String::new() } else { "friend".into() },
-            reachable,
+            state: if reachable { SourceState::Reachable } else { SourceState::Unreachable },
+            tier: None,
             sections_done: reachable,
             counts_done: true,
             retry_cd: 0,
@@ -1678,9 +1773,9 @@ fn land_discovery() {
             let ok = list.is_some();
             append_sections(si, list.unwrap_or_default());
             if let Some(s) = source_mut(si) {
-                let was = s.reachable;
+                let was = s.reachable();
                 s.sections_done = ok;
-                s.reachable = ok;
+                s.set_reachable(ok);
                 s.retry_cd = if ok { 0 } else { SRC_RETRY_CD };
                 if was != ok {
                     SRC_FACTS_GEN.fetch_add(1, Ordering::SeqCst); // the group dims, or comes back
@@ -2107,7 +2202,8 @@ mod tests {
             owned: true,
             name: "nas-home".into(),
             handle: "friend".into(),
-            reachable,
+            state: if reachable { SourceState::Reachable } else { SourceState::Unreachable },
+            tier: None,
             sections_done,
             counts_done: true,
             retry_cd: 0,
@@ -2124,7 +2220,7 @@ mod tests {
         let _g = crate::testlock::serial();
         seed_one_source(true, false);
         assert_eq!(cur_source_state(), SecFetch::Loading, "nobody has asked it anything yet");
-        source_mut(0).unwrap().reachable = false;
+        source_mut(0).unwrap().set_reachable(false);
         assert_eq!(cur_source_state(), SecFetch::Failed, "the screen must be able to see this");
         reset();
     }
@@ -2150,7 +2246,7 @@ mod tests {
         assert_eq!(cur_source_state(), SecFetch::Failed);
         {
             let s = source_mut(0).unwrap();
-            s.reachable = true;
+            s.set_reachable(true);
             s.sections_done = true;
         }
         append_sections(0, vec![(1, "Movies".into(), SecKind::Movie), (2, "Film Club".into(), SecKind::Movie)]);
@@ -2176,7 +2272,8 @@ mod tests {
             owned: handle.is_empty(),
             name: name.into(),
             handle: handle.into(),
-            reachable,
+            state: if reachable { SourceState::Reachable } else { SourceState::Unreachable },
+            tier: None,
             sections_done: true,
             counts_done: true,
             retry_cd: 0,
@@ -2658,12 +2755,63 @@ mod tests {
         assert!(sources()[1].sections_done, "discovery is done — it will never re-ask by itself");
 
         mark_source_reachable(1, false); // a page for THEIR library did not come back
-        assert!(!sources()[1].reachable, "their group dims");
-        assert!(sources()[0].reachable, "…and ours is untouched — it answered");
+        assert!(!sources()[1].reachable(), "their group dims");
+        assert!(sources()[0].reachable(), "…and ours is untouched — it answered");
 
         mark_source_reachable(1, true); // …and it comes back
-        assert!(sources()[1].reachable);
+        assert!(sources()[1].reachable());
         assert_eq!(sources()[1].retry_cd, 0, "a server that answered is worth re-asking at once");
+        reset();
+    }
+
+    /// **The widening contract, pinned.** [`SourceState`] replaced a `bool`, and the whole claim of
+    /// that commit is that it changed nothing — so the mapping is a test rather than a paragraph.
+    ///
+    /// The asymmetry is the part worth pinning: **`NotProbed` reads as reachable**. That looks
+    /// wrong until you recall what it replaced — a source was seeded `reachable: true` at
+    /// registration precisely so its group would not open dimmed before anything had been dialled.
+    /// A future reader who "fixes" this to `false` will dim every group for the frames between
+    /// registration and the first probe, which is a visible flicker on every boot.
+    #[test]
+    fn not_probed_reads_as_reachable_and_only_a_failed_dial_dims_a_group() {
+        let _g = crate::testlock::serial();
+        let mut s = a_source("nas-home", "friend", true);
+
+        s.state = SourceState::NotProbed;
+        assert!(s.reachable(), "nobody has dialled it — the group must not open dimmed");
+        assert_eq!(s.tier, None, "and nothing has told us which tier won");
+
+        s.set_reachable(true);
+        assert_eq!(s.state, SourceState::Reachable);
+        assert!(s.reachable());
+
+        s.set_reachable(false);
+        assert_eq!(s.state, SourceState::Unreachable);
+        assert!(!s.reachable(), "the ONLY state that dims a group");
+
+        // Answered-but-refused is a token problem, not a network one — so it does NOT dim, and it
+        // is not something `set_reachable` can even express. Both halves are the point.
+        s.state = SourceState::Unauthorized;
+        assert!(s.reachable(), "it answered; the group is not 'not reachable'");
+        reset();
+    }
+
+    /// The same mapping on the projection the renderer actually sees, because `SrcGroup` carries
+    /// its own copy of the question and two copies are how a widening drifts.
+    #[test]
+    fn the_source_group_projection_answers_reachability_the_same_way() {
+        let _g = crate::testlock::serial();
+        seed_sources(vec![a_source("mac-mini", "", true), a_source("nas-home", "friend", true)]);
+        // Set the SOURCE directly. `mark_source_reachable` takes a *section* index and resolves the
+        // source through it (`sections()[i].src`), so with no sections seeded it early-returns —
+        // which cost this test one failing run before the name gave it away.
+        source_mut(1).unwrap().set_reachable(false);
+        let g = source_groups();
+        assert_eq!(g[0].state, SourceState::Reachable);
+        assert!(g[0].reachable());
+        assert_eq!(g[1].state, SourceState::Unreachable);
+        assert!(!g[1].reachable(), "the dim the Sources list draws");
+        assert_eq!(g[1].tier, None);
         reset();
     }
 
@@ -2697,7 +2845,7 @@ mod tests {
 
         assert!(!SRC_FETCHING.load(Ordering::SeqCst), "the single flight must be released");
         assert_eq!(sources()[1].retry_cd, SRC_RETRY_CD, "…and the next attempt is ~10s out, not 1 frame");
-        assert!(sources()[1].reachable, "a refused THREAD says nothing about their server");
+        assert!(sources()[1].reachable(), "a refused THREAD says nothing about their server");
         assert!(!sources()[1].sections_done, "…and it is still a source waiting to be discovered");
         assert_eq!(sources()[0].retry_cd, 0, "the other source is untouched");
 

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -2908,7 +2908,12 @@ mod tests {
     // ---- the Sources chip + its two-level panel -------------------------------------------------
 
     fn group(name: &str, handle: &str, reachable: bool) -> crate::browse::SrcGroup {
-        crate::browse::SrcGroup { name: name.into(), handle: handle.into(), reachable }
+        crate::browse::SrcGroup {
+            name: name.into(),
+            handle: handle.into(),
+            state: if reachable { crate::browse::SourceState::Reachable } else { crate::browse::SourceState::Unreachable },
+            tier: None,
+        }
     }
     fn lib(src: usize, section: usize, title: &str, pinned: bool, last: bool, current: bool) -> crate::browse::SrcRow {
         crate::browse::SrcRow {
@@ -2979,7 +2984,7 @@ mod tests {
         assert_eq!((secs[1].header.as_str(), secs[1].accessory.as_str()), ("nas-home", "friend"));
         assert!(!secs[0].dim && !secs[1].dim);
 
-        g[1].reachable = false;
+        g[1].state = crate::browse::SourceState::Unreachable;
         let mut r = r;
         r[2].pinned = true; // pinned AND unreachable: the state the design calls out by name
         let (secs, _) = source_list::sections(Level::OnHome, &g, &r, Tail::Recheck);

--- a/rust-modules/src/ui/search/field.rs
+++ b/rust-modules/src/ui/search/field.rs
@@ -423,7 +423,7 @@ impl Key {
             // The same reading [`build`] uses: a source `browse`'s table has never adopted has not
             // failed, so an absent one is live. The two must agree or the line changes without the
             // key moving.
-            if srcs.iter().find(|s| s.sid == sid).map(|s| s.reachable).unwrap_or(true) {
+            if srcs.iter().find(|s| s.sid == sid).map(|s| s.reachable()).unwrap_or(true) {
                 k.live |= 1 << i;
             }
             k.facts[i] = crate::plex::server_facts(sid).map_or(0, |f| std::ptr::from_ref(f) as usize);
@@ -496,7 +496,7 @@ fn build(key: Key) -> ScopeState {
                 owned: f.map(|f| f.owned).unwrap_or(Some(sid) == first),
                 // `browse`'s is the app's ONE notion of a source that has stopped answering. A
                 // source its table has never adopted has not failed, so it reads as live.
-                live: srcs.iter().find(|s| s.sid == sid).map(|s| s.reachable).unwrap_or(true),
+                live: srcs.iter().find(|s| s.sid == sid).map(|s| s.reachable()).unwrap_or(true),
             }
         })
         .collect();

--- a/rust-modules/src/ui/source_list.rs
+++ b/rust-modules/src/ui/source_list.rs
@@ -88,12 +88,12 @@ pub(crate) fn sections(
         // group also SAYS so there, and says it FIRST: the accessory is elided from the right, so
         // leading with the state means a long handle gives way rather than the fact that the server
         // is not answering. It is a state in the same register as the rows' own `On`/`Off`.
-        let accessory = match (g.reachable, g.handle.is_empty()) {
+        let accessory = match (g.reachable(), g.handle.is_empty()) {
             (true, _) => g.handle.clone(),
             (false, true) => "Not reachable".to_string(),
             (false, false) => format!("Not reachable \u{b7} {}", g.handle),
         };
-        let mut sec = Section::new(g.name.clone()).accessory(accessory).dim(!g.reachable);
+        let mut sec = Section::new(g.name.clone()).accessory(accessory).dim(!g.reachable());
         for r in mine {
             let mut row = Row::new(r.title.clone());
             row = match level {

--- a/tests/run.py
+++ b/tests/run.py
@@ -196,7 +196,7 @@ def _resolve_items(entries, items):
         e["rk"] = rk
 
 
-def load_manifest(pipeline_only=False, tv_override=None):
+def load_manifest(pipeline_only=False, tv_override=None, for_listing=False):
     """Merge the tracked matrix with the gitignored overlay.
 
     `pipeline_only` is what makes requirement-1 true — that a stranger can run the pipeline tier
@@ -205,6 +205,16 @@ def load_manifest(pipeline_only=False, tv_override=None):
     case the TV address is read from the repo's own gitignored `.tv-host` (the same file the
     Makefile and `tools/` fall back to). A TV address is the one thing that still cannot be
     guessed, and is the only thing this path can die for.
+
+    `for_listing` drops **even that**, and it is the difference between `--list` being offline and
+    only claiming to be. `--list` prints which cases a set of flags selects; it opens no socket,
+    arms no trigger and touches no television, which is exactly why `DefaultTier` in
+    `tests/test_harness.py` spawns the real CLI to ask what a bare command runs. On any machine
+    with no `.tv-host` and no overlay — a fresh clone, a fleet worktree, and **the CI runner** —
+    the requirements below fired first and `--list` exited 1 with empty stdout, so those two tests
+    failed on every push. They had been red on `main` since 2026-08-22 and were about to be
+    inherited, identically, by every lane of a parallel fleet: eleven red PRs in which a real
+    failure would have been indistinguishable from the background.
     """
     with open(MANIFEST) as f:
         manifest = json.load(f)
@@ -213,9 +223,12 @@ def load_manifest(pipeline_only=False, tv_override=None):
         with open(MANIFEST_LOCAL) as f:
             local = json.load(f)
     except FileNotFoundError:
-        if not pipeline_only:
+        if not (pipeline_only or for_listing):
             _die_no_overlay()
     except ValueError as e:
+        # Still fatal for a listing: a malformed overlay is a typo to fix, not an absent one to
+        # work around, and silently listing the wrong thing is the failure mode this whole
+        # function is shaped to avoid.
         sys.exit(f"{MANIFEST_LOCAL} is not valid JSON: {e}")
 
     if pipeline_only:
@@ -224,16 +237,19 @@ def load_manifest(pipeline_only=False, tv_override=None):
         if not tv and os.path.isfile(TV_HOST_FILE):
             with open(TV_HOST_FILE) as f:
                 tv = f.read().strip() or None
-        if not tv:
+        if not tv and not for_listing:
             sys.exit(f"--pipeline needs a TV address: put one in {TV_HOST_FILE} (one line, an IP "
                      f"or hostname), or a `tv` key in {MANIFEST_LOCAL}, or pass --tv")
-        manifest["tv"] = tv
+        if tv:
+            manifest["tv"] = tv
         if "flavour" in local:
             manifest["flavour"] = local["flavour"]
         return manifest
 
     for field in ("pms", "tv"):
         if field not in local:
+            if for_listing:
+                continue    # nothing downstream of a listing dials either of them
             _die_no_overlay(f"\n  (no {field!r} block)")
         manifest[field] = local[field]
     # WHICH INSTALL to drive, and optional: absent means the Makefile's own default. An
@@ -286,8 +302,12 @@ def load_manifest(pipeline_only=False, tv_override=None):
     # answer of somebody whose library has nothing of that shape, and it now skips the cases that
     # need it. The values below stay fatal because no run of any size can proceed without them.
     ss = manifest.get("shared_server", {})
+    # `.get` on both, for `for_listing`'s sake: with no overlay at all neither key was ever
+    # installed above, and a listing must still print. A real run cannot reach here without them —
+    # the `_die_no_overlay` calls above are what guarantee that, which is why this stays a lookup
+    # and not a second requirement check.
     stray = [f"{k}={v}" for k, v in
-             [("pms.host", manifest["pms"].get("host")), ("tv", manifest["tv"])]
+             [("pms.host", manifest.get("pms", {}).get("host")), ("tv", manifest.get("tv"))]
              + ([("test_user.id", manifest["test_user"].get("id"))] if "test_user" in manifest else [])
              + [(f"shared_server.{k}", ss.get(k)) for k in ("machine_id", "name", "host")]
              if isinstance(v, str) and v.startswith("<")]
@@ -2541,12 +2561,15 @@ def main():
         # not ask for and believe the result.
         sys.exit("--pipeline names the DEFAULT tier and cannot be combined with "
                  "--server/--fps/--fps-player, which select the server tier. Pick one.")
-    manifest = load_manifest(pipeline_only=not server_tier, tv_override=args.tv)
+    manifest = load_manifest(pipeline_only=not server_tier, tv_override=args.tv, for_listing=args.list)
     # BEFORE anything else, including --list: every path this run uses hangs off it, and the
     # queries are offline and side-effect free (see make_query / the Makefile's PURE_QUERY).
     resolve_flavour(args, manifest)
     cfg = {
-        "tv": args.tv or manifest["tv"],
+        # `.get`, not `[…]`: under `--list` the overlay and `.tv-host` are both optional, so there
+        # may be no address at all. Nothing on a listing path dials it — and a RUN cannot reach
+        # here without one, because `load_manifest` still exits for that case.
+        "tv": args.tv or manifest.get("tv", ""),
         # server-tier only: the synthetic tier talks to no PMS and `load_manifest` does not
         # synthesize the key for it.
         "pms": manifest.get("pms", {}),


### PR DESCRIPTION
`BrowseSource.reachable: bool` could say "answered" or "did not". It could not say the three things the prober already tells apart (`plex::probe::Outcome`): **nobody has dialled yet**, **the server answered and refused our token**, and **the server did not answer**. Those want different words, and the middle one wants a different remedy — a 401 is a sharing-grant problem that re-fetching `/api/v2/resources` fixes, and reporting it as "not reachable" sends the user to look at a router for something that was never a network fault.

So `reachable: bool` becomes `state: SourceState { NotProbed, Reachable, Unauthorized, Unreachable }`, beside a `tier: Option<probe::Location>` for which connection actually won — the fact `route`'s relay policy consumes and has never once been given, because `Client::set_link` still has no production caller.

## Nothing changes on screen

The old question survives as `reachable()`, the old write as `set_reachable()`, and the seed keeps its exact meaning. A source nobody has dialled is `NotProbed`, which **reads as reachable** — because the field this replaced was seeded `true` for precisely that reason. Make it `false` and every group opens dimmed for the frames between registration and the first probe, which is a visible flicker on every boot. Two new tests pin the mapping rather than asserting it in prose, and one pins the half that looks wrong: an answered-but-refused server does **not** dim.

`Unauthorized` is unconstructed in production on purpose and carries `cfg_attr(not(test), expect(dead_code, …))` rather than an `allow`. When the prober that can produce it lands, the expectation becomes unfulfilled and the build fails until the attribute is deleted. That is the handover note, enforced rather than written down.

## Why it lands alone, ahead of the work that uses it

The renderer of these states and the code that populates them are separate changes. Neither can reference a type living in the other's unmerged branch, and they cannot both own the definition — so the type goes first, by itself, doing nothing.

## Verification

- `make check` — **976/976**, lint clean.
- `cargo +nightly check --lib --no-default-features` — clean (the release feature set `make check` cannot see).
- Desktop simulator booted against a real PMS: Home renders identically, hero, shelves and all.
- Everything outside `browse.rs` is mechanical — `.reachable` → `.reachable()` at four call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GovTtrsD9P7Ld7DnLCMK2G
