### PR TITLE
search: the character that arrives is the character that was pressed

### DIFF
--- a/rust-modules/src/textinput.rs
+++ b/rust-modules/src/textinput.rs
@@ -65,6 +65,22 @@
 //! `com.webos.service.ime/*` methods, all in ACGs this app does not hold — it is granted
 //! `["public"]`), and a physical USB or Bluetooth keyboard (`/dev/input` is not mounted into our
 //! jail; `remote.rs` documents the general case).
+//!
+//! ## Text that ARRIVES correctly and DRAWS as boxes (measured 2026-08-23)
+//!
+//! This module is byte-transparent and the tests below pin that — a full-width `＼`, a CJK run and
+//! a Hangul syllable all reach the query as themselves. **They then render as `.notdef` boxes**,
+//! because `pkg/appfont*.ttf` is a SUBSET: 2853 codepoints, Latin + Cyrillic + Greek, with no CJK,
+//! no Hangul and no full-width forms (`tools/cut-inter.py` cuts it; `text.rs` has no per-glyph
+//! fallback — its `DROIDSANS` path is a whole-font last resort for a MISSING file, not a chain).
+//!
+//! So a reader debugging "my search shows boxes" can stop here: the text arrived, and the gap is
+//! the font, one layer down. It is recorded in this module because this is where that question
+//! gets asked first, and because it is the half of LG checklist rows #15/#16 that no amount of
+//! correctness in this file can answer — the rows are about what is ON THE PANEL, and a Korean or
+//! Japanese query is unreadable in the field, in the "No results for …" line, and anywhere else the
+//! query is echoed. Fixing it is a font decision (a wider cut, or a real fallback chain), not a
+//! text-input one, and it is not in this module's gift.
 #![allow(dead_code)]
 
 use crate::app::SDL_WINDOW_INPUT_FOCUS;
@@ -386,9 +402,72 @@ fn decode_text_at(ev: &[u8], off: usize) -> String {
     // NUL-terminated INSIDE a fixed array: the terminator is the length, and everything after it
     // is whatever the last, longer commit left behind.
     let n = field.iter().position(|&b| b == 0).unwrap_or(field.len());
+    // The two edges of a codepoint the fixed array may have CUT — see `drop_cut_tail`. The tail
+    // rule is conditional on the array being FULL (`n == TEXT_CAP`), which is the signature of a
+    // cut; the head rule is unconditional, because no UTF-8 string may begin with a continuation
+    // byte under any circumstances. Deliberately NOT `n == field.len()`, which is also true when
+    // the CALLER's buffer ran out before `text[32]` did — a short buffer is the reader's limit,
+    // not the panel's, and there is nothing to say the panel cut anything at all.
+    let text = drop_orphan_head(&field[..n]);
+    let text = if n == TEXT_CAP { drop_cut_tail(text) } else { text };
     // Lossy, never `from_utf8`: a single bad byte would otherwise discard the whole commit — and
     // an IME that emits one is a keystroke the user typed, not an attack.
-    String::from_utf8_lossy(&field[..n]).into_owned()
+    String::from_utf8_lossy(text).into_owned()
+}
+
+/// Drop a trailing UTF-8 sequence that is well-formed so far but CUT SHORT by the end of the
+/// buffer. Everything else — a lone continuation byte, an overlong or out-of-range lead, a
+/// surrogate — is left for `from_utf8_lossy` to answer with U+FFFD, because a replacement character
+/// is the only visible signal that something arrived broken and it must not be swallowed.
+///
+/// **This is LG checklist row #16** (`docs/lg-self-checklist.md` §2), which asks that the character
+/// which arrives be the character that was pressed. `text[32]` is a fixed array, so a commit that
+/// fills it is cut at a BYTE, and that cut lands mid-codepoint for any query that is not pure
+/// ASCII. Decoded lossily, the surviving half becomes a `` the user never typed, in their search
+/// field — exactly the substitution the row is about. Nothing can recover the character (its other
+/// half is not in this event), so the honest answer is the text that WAS whole.
+///
+/// **The classification is `std`'s, not ours.** `Utf8Error::error_len() == None` is precisely
+/// "valid so far, ended mid-sequence", and `valid_up_to()` is where to cut — where a hand-rolled
+/// lead-byte width table accepts `0xC0`, `0xF5..=0xF7` and surrogate pairs as merely "incomplete"
+/// and deletes real corruption without a trace. Only the LAST sequence is offered to it (walk back
+/// at most four bytes to the first non-continuation byte; no sequence is longer), so an interior
+/// error earlier in the commit cannot suppress the tail rule.
+///
+/// **Belt-and-braces for a case this project has not settled.** Stock SDL2 fills `text[32]` with
+/// `SDL_utf8strlcpy`, which truncates on a character boundary and always terminates — so on stock
+/// SDL this branch is unreachable, and `encode_event` cuts on a boundary too, which is why nothing
+/// the simulator or the `txt:` token can drive reaches it either. Whether **LG's fork** does the
+/// same is a question for the television's own `libSDL2`, not for a header or another client:
+/// `.claude/skills/decompile-tv-lib/` is how the `+16 inputSource` offset above was settled, and it
+/// is how this would be. Until then the branch costs one comparison and cannot make a correct
+/// commit wrong.
+fn drop_cut_tail(b: &[u8]) -> &[u8] {
+    for back in 1..=b.len().min(4) {
+        let i = b.len() - back;
+        if b[i] & 0xC0 == 0x80 {
+            continue; // a continuation byte — the sequence it belongs to starts further back
+        }
+        return match std::str::from_utf8(&b[i..]) {
+            Err(e) if e.error_len().is_none() => &b[..i],
+            _ => b,
+        };
+    }
+    b // nothing but continuation bytes: garbage, and `from_utf8_lossy`'s to answer
+}
+
+/// The other edge of the same cut: drop a leading run of continuation bytes.
+///
+/// If the panel really does split a codepoint at `text[32]`, the half [`drop_cut_tail`] discards
+/// arrives at the START of the NEXT commit — orphaned, with its lead byte in the event before it.
+/// Left alone those bytes are one U+FFFD each, which is the row-#16 substitution again, one
+/// character later; dropping the head is what makes the rule whole rather than one-sided.
+///
+/// Unconditional, and safe to be: **no UTF-8 string may begin with a continuation byte**, so this
+/// can only ever remove bytes that were already unreadable — never a character the user typed.
+fn drop_orphan_head(b: &[u8]) -> &[u8] {
+    let n = b.iter().take_while(|&&c| c & 0xC0 == 0x80).count();
+    &b[n..]
 }
 
 // ---------------------------------------------------------------------------------------
@@ -452,11 +531,129 @@ mod tests {
     fn invalid_utf8_is_replaced_rather_than_panicking() {
         let s = decode_text_at(&ev_with(16, b"a\xffb"), 16);
         assert_eq!(s, "a\u{fffd}b");
-        // A lone continuation byte, and a truncated multi-byte sequence cut by the array's end.
-        assert_eq!(decode_text_at(&ev_with(16, b"\x80"), 16), "\u{fffd}");
-        let mut ev = ev_with(16, &[b'y'; TEXT_CAP]);
-        ev[16 + TEXT_CAP - 1] = 0xe2; // the head of a 3-byte codepoint, with no room for its tail
-        assert!(decode_text_at(&ev, 16).ends_with('\u{fffd}'));
+        // A bad byte in the MIDDLE keeps its replacement whatever surrounds it — it is neither
+        // edge of a cut, so neither trim rule can claim it. (A LEADING continuation byte is the
+        // orphan case and IS dropped; `a_commit_orphaned_from_its_lead_byte_is_dropped_rather_
+        // than_replaced` owns that, and `\x80` alone belongs to it rather than here.)
+        assert_eq!(decode_text_at(&ev_with(16, b"x\x80y"), 16), "x\u{fffd}y");
+        assert_eq!(decode_text_at(&ev_with(16, b"x\xc0y"), 16), "x\u{fffd}y");
+    }
+
+    /// **Row #16: a codepoint the fixed array CUT must not arrive as a character nobody typed.**
+    /// `text[32]` has no room for the tail of a sequence that starts at its last byte, so a lossy
+    /// decode puts a `` in the user's query — the exact substitution the checklist row is about.
+    /// The whole prefix is kept; only the half codepoint goes.
+    #[test]
+    fn a_codepoint_cut_by_the_end_of_the_field_is_dropped_not_replaced() {
+        // Each width of lead byte, cut at every point that leaves it incomplete.
+        for (lead, whole) in [(0xc3u8, "é"), (0xe5, "千"), (0xf0, "🎬")] {
+            let need = whole.len();
+            for kept in 1..need {
+                let mut raw = vec![b'y'; TEXT_CAP - kept];
+                raw.extend_from_slice(&whole.as_bytes()[..kept]);
+                assert_eq!(raw.len(), TEXT_CAP);
+                let got = decode_text_at(&ev_with(16, &raw), 16);
+                assert_eq!(got, "y".repeat(TEXT_CAP - kept), "lead {lead:#x}, {kept} of {need} bytes");
+                assert!(!got.contains('\u{fffd}'), "a cut must not invent a character");
+            }
+            // …and the same codepoint that FITS is untouched, which is what proves the rule cuts
+            // only what was actually truncated.
+            let mut raw = vec![b'y'; TEXT_CAP - need];
+            raw.extend_from_slice(whole.as_bytes());
+            assert_eq!(decode_text_at(&ev_with(16, &raw), 16), format!("{}{whole}", "y".repeat(TEXT_CAP - need)));
+        }
+    }
+
+    /// A TERMINATED commit is as long as the panel meant it to be, so a malformed tail inside one
+    /// is genuine garbage and keeps the defensive replacement — the cut rule must not swallow it.
+    /// Neither may a SHORT BUFFER be read as a cut: that is the caller's limit, not the panel's.
+    #[test]
+    fn a_bad_tail_before_a_terminator_still_replaces_rather_than_vanishing() {
+        // `ab` + a bare 3-byte lead + NUL: nothing cut this, the byte is simply wrong.
+        assert_eq!(decode_text_at(&ev_with(16, b"ab\xe5\0"), 16), "ab\u{fffd}");
+        // …and a buffer that ends mid-codepoint is the READER running out, so the tail rule stays
+        // off and the bad byte is still reported.
+        assert_eq!(decode_text_at(&ev_with(16, "é".as_bytes())[..17], 16), "\u{fffd}");
+    }
+
+    /// **A byte no cut could have produced keeps its replacement.** The rule is "valid so far,
+    /// ended mid-sequence" and nothing looser — a hand-rolled lead-byte width table calls all of
+    /// these merely incomplete and deletes them, which turns real corruption from the panel's IME
+    /// into a silent shortening with no signal at all. `std::str::from_utf8` draws the line.
+    #[test]
+    fn corruption_that_is_not_a_cut_is_reported_rather_than_deleted() {
+        for (name, tail) in [
+            ("overlong lead", &[0xC0u8][..]),
+            ("out-of-range lead", &[0xF5][..]),
+            ("never-a-lead byte", &[0xFF][..]),
+            ("surrogate half", &[0xED, 0xA0][..]),
+        ] {
+            let mut raw = vec![b'y'; TEXT_CAP - tail.len()];
+            raw.extend_from_slice(tail);
+            let got = decode_text_at(&ev_with(16, &raw), 16);
+            assert!(got.contains('\u{fffd}'), "{name} must survive as a replacement, got {got:?}");
+        }
+    }
+
+    /// The other edge of the same cut: a commit ORPHANED from its lead byte — the remainder of a
+    /// codepoint the previous event was cut inside — must not arrive as one U+FFFD per byte, which
+    /// is the row-#16 substitution again, one character later.
+    #[test]
+    fn a_commit_orphaned_from_its_lead_byte_is_dropped_rather_than_replaced() {
+        // "🎬" is F0 9F 8E AC; cut after F0, the next commit opens with its three tail bytes.
+        assert_eq!(decode_text_at(&ev_with(16, b"\x9f\x8e\xacstar"), 16), "star");
+        // …and a commit that is nothing BUT an orphaned remainder yields nothing, rather than one
+        // replacement character per byte.
+        assert_eq!(decode_text_at(&ev_with(16, b"\x80"), 16), "");
+        // …and a commit that legitimately STARTS with a multi-byte character is untouched.
+        assert_eq!(decode_text_at(&ev_with(16, "🎬star".as_bytes()), 16), "🎬star");
+    }
+
+    /// **Capital and small letters transfer as themselves.** The panel's Shift/Caps is resolved on
+    /// the television — it commits the CASED character — so the app's whole obligation is to carry
+    /// the bytes through without touching them, and this is what proves it does. (A decoder that
+    /// normalised case would be invisible until someone searched for a title that differs only by
+    /// it.) Deliberately cites no checklist row number: `docs/lg-self-checklist.md` records no such
+    /// row, and a number this repo cannot corroborate does not belong in a permanent comment.
+    #[test]
+    fn letter_case_transfers_exactly_as_the_panel_committed_it() {
+        for s in ["A", "a", "Wallace", "WALLACE", "wallace", "WaLlAcE", "Ç", "ç", "Ä", "ä"] {
+            assert_eq!(decode_text_at(&ev_with(16, s.as_bytes()), 16), s);
+            assert_eq!(decode_text_at(&encode_event(s), TEXT_OFF), s);
+        }
+    }
+
+    /// **Row #16, its own worked example.** The checklist names the full-width `＼` (U+FF3C) and
+    /// asks that it not arrive as a backslash — the substitution a keyboard stack makes when it
+    /// folds full-width forms to ASCII, and the one a byte-oriented decoder makes when it reads one
+    /// of the three bytes of a full-width form on its own.
+    ///
+    /// The `lookalike` column is not a second assertion (the equality above already implies it);
+    /// it is the table saying what each row is FOR, so the next reader can tell a deliberate pair
+    /// from an arbitrary one. The rest are the characters a VKB commonly substitutes or a layer
+    /// below eats — the shell and URL metacharacters, and the quote pair a keyboard "smartens".
+    #[test]
+    fn a_full_width_character_is_not_folded_to_its_ascii_lookalike() {
+        for (typed, _lookalike) in [
+            ("＼", "\\"), // U+FF3C FULLWIDTH REVERSE SOLIDUS — the row's own example
+            ("￥", "\\"), // U+FFE5, the same key on a JP panel, and the same wrong answer
+            ("／", "/"),
+            ("：", ":"),
+            ("　", " "),  // U+3000 IDEOGRAPHIC SPACE
+            ("“", "\""),
+            ("’", "'"),
+            ("－", "-"),
+        ] {
+            let got = decode_text_at(&ev_with(16, typed.as_bytes()), 16);
+            assert_eq!(got, typed, "the character pressed must be the character that arrives");
+            assert_eq!(decode_text_at(&encode_event(typed), TEXT_OFF), typed);
+        }
+        // The ASCII originals still arrive as themselves — nothing here rewrites in either
+        // direction. `\` is the one the row calls out, and the rest are what a URL layer or a
+        // shell would eat if anything on the path were not byte-transparent.
+        for s in ["\\", "/", "&", "%", "+", "#", "?", "=", "\"", "'", "<", ">", " ", "\t"] {
+            assert_eq!(decode_text_at(&ev_with(16, s.as_bytes()), 16), s);
+        }
     }
 
     /// A buffer that ends before (or inside) the text field is an answer, not a fault. `SDL_Event`

--- a/rust-modules/src/ui/search/field.rs
+++ b/rust-modules/src/ui/search/field.rs
@@ -26,13 +26,14 @@
 //!
 //! ## The two pieces of arithmetic worth extracting
 //!
-//! [`run_layout`] and [`scope_text`] are **pure**, and host-tested below, because both are the kind
-//! of thing that is wrong by a few pixels or one word and invisible in a screenshot. They are not
-//! the whole risk, though — [`draw`] and [`draw_scope`] carry the composition (the fill branch, the
-//! scissor pair and three placements), and that is where a defect hides from both the tests and the
-//! eye. The registry projection the scope line is written from is no longer part of that: it is
-//! [`with_scope`], built once per change and shared with [`super::empty`] — see the section comment
-//! above it for what that fixed.
+//! [`run_layout`], [`run_and_head`] and [`scope_text`] are **pure**, and host-tested below, because
+//! each is the kind of thing that is wrong by a few pixels, one word or one byte and invisible in a
+//! screenshot — and [`run_and_head`]'s failure is not cosmetic at all, since a slice cut off a char
+//! boundary panics inside the SDL event loop. They are not the whole risk, though — [`draw`] and
+//! [`draw_scope`] carry the composition (the fill branch, the scissor pair and three placements),
+//! and that is where a defect hides from both the tests and the eye. The registry projection the
+//! scope line is written from is no longer part of that: it is [`with_scope`], built once per change
+//! and shared with [`super::empty`] — see the section comment above it for what that fixed.
 #![allow(dead_code)]
 
 use crate::ui::label::Label;
@@ -105,18 +106,11 @@ pub(crate) fn draw(p: Painter, v: &View) {
 
     let inner = Rect::new(FIELD.x + PAD_X, FIELD.y, FIELD.w - PAD_X * 2.0, FIELD.h);
     // Verbatim — `search::query` keeps the trailing space precisely because this is what draws it.
-    // Truncated at a NUL first: keyboard input cannot contain one, but `enter` is also fed by a
-    // boot trigger that reads a FILE, and `CString::new` failing there would blank the capsule
-    // while leaving the Rust string non-empty — a field that refuses to show its own text.
-    let q = crate::search::query();
-    let q = &q[..q.find('\0').unwrap_or(q.len())];
+    // The two cuts [`run_and_head`] makes (the NUL, and the caret back to a char boundary) are
+    // argued there.
+    let (q, head) = run_and_head(crate::search::query(), v.caret);
     let cq = CString::new(q).unwrap_or_default();
     let run_w = crate::text::text_width(cq.as_ptr(), theme::size::BODY, 0);
-    // How far into the run the insertion point sits: the width of the text BEFORE it. `v.caret` is
-    // already clamped to a char boundary of the live query by `super::caret`, but this slice is
-    // taken from the NUL-truncated copy above, so it is re-bounded here rather than trusted —
-    // `enter` is fed by a file, and a panic in a draw is the app.
-    let head = &q[..v.caret.min(q.len())];
     let ch = CString::new(head).unwrap_or_default();
     let caret_w = crate::text::text_width(ch.as_ptr(), theme::size::BODY, 0);
     let (run_dx, caret_dx) = run_layout(run_w, caret_w, inner.w, v.editing);
@@ -150,6 +144,45 @@ pub(crate) fn draw(p: Painter, v: &View) {
     p.clip_clear();
 
     draw_scope(p);
+}
+
+/// The run this capsule DRAWS, and the slice of it that sits before the insertion point — the two
+/// slices [`draw`] measures, CUT once so the two cuts can never drift apart. (They are still
+/// MEASURED separately, which is a different thing and not fixed here: `head` is shaped on its own,
+/// so a kern pair straddling the insertion point is applied to the run and not to the head, and the
+/// bar can sit a pixel or so off where the next glyph lands. Inter's `kern` is deliberately kept —
+/// `tools/cut-inter.py`, and the root `CLAUDE.md` calls it load-bearing — so this is real, but it
+/// is a sub-pixel placement question that only a panel can judge, and `text_width` cannot be
+/// reached from the host suite at all.)
+///
+/// Pure, and the third thing in this file that is (see the module doc), because **every expression
+/// in it is a slice and every one of them is in a DRAW**: a bad index here does not mis-place a
+/// pixel, it panics inside the SDL event loop and takes the app down — the class `remote.rs` lost
+/// the app to once already, off a multi-byte separator.
+///
+/// Two cuts, and neither may be assumed away:
+///
+/// 1. **At the first NUL.** Keyboard input cannot contain one, and `super::mount` already filters
+///    every control character out of the boot trigger's seed — so this is the BELT over that brace,
+///    not the only guard, and neither may be deleted on the strength of the other. It is kept
+///    because the failure it prevents is silent and total: `CString::new` refuses a string with an
+///    interior NUL, so the capsule would blank while the Rust string stayed non-empty — a field
+///    refusing to show its own text — and the caret would be placed against the wrong length.
+/// 2. **The caret, back to a CHAR BOUNDARY of the run** — not merely `min(len)`, which is the shape
+///    this was written as and the reason it is now a function. `min` bounds the LENGTH and says
+///    nothing about the boundary, so it is only sound while the incoming offset is already a
+///    boundary of *this* slice. `super::caret` does clamp against the live query, so nothing in the
+///    tree reaches the bad case today — but the two strings are not the same string whenever the
+///    query holds a NUL, the guarantee is one another module owns, and the comment that used to
+///    stand here claimed the re-bound as though it had been done. A defence that is documented and
+///    absent is worse than one that is neither.
+fn run_and_head(q: &str, caret: usize) -> (&str, &str) {
+    let run = &q[..q.find('\0').unwrap_or(q.len())];
+    let mut c = caret.min(run.len());
+    while c > 0 && !run.is_char_boundary(c) {
+        c -= 1;
+    }
+    (run, &run[..c])
 }
 
 /// Is the one-character hint on? Exactly one character SHORT of the minimum, never at zero (an
@@ -624,6 +657,50 @@ mod tests {
             let (_, caret) = run_layout(2000.0, c, box_w, true);
             assert!((0.0..=avail).contains(&caret), "caret at {c} drew at {caret}, outside the field");
         }
+    }
+
+    // ---- the two slices the draw measures ------------------------------------------------------
+
+    /// The ordinary case, and the one that carries the whole point of the caret: the head is the
+    /// text BEFORE the insertion point, so its width is where the bar stands.
+    #[test]
+    fn the_head_is_the_text_before_the_insertion_point() {
+        assert_eq!(run_and_head("wallace", 0), ("wallace", ""));
+        assert_eq!(run_and_head("wallace", 3), ("wallace", "wal"));
+        assert_eq!(run_and_head("wallace", 7), ("wallace", "wallace"));
+        // A trailing space is part of the run — `search::query` keeps it because this draws it.
+        assert_eq!(run_and_head("wallace ", 8), ("wallace ", "wallace "));
+        assert_eq!(run_and_head("", 0), ("", ""));
+    }
+
+    /// **A caret is a BYTE offset, and half the characters a television's keyboard can commit are
+    /// not one byte wide.** Splitting one panics — inside a DRAW, inside the SDL event loop, which
+    /// is the app. Every offset into a multi-byte run is exercised here, including the ones that
+    /// land mid-codepoint, because `super::caret` clamps against the LIVE query while this cuts the
+    /// NUL-truncated copy, and the two are not the same string.
+    #[test]
+    fn a_caret_inside_a_multi_byte_character_never_splits_it() {
+        for q in ["суббота", "千と千尋", "Amélie", "🎬🎬", "aé千🎬z"] {
+            for c in 0..=q.len() + 4 {
+                let (run, head) = run_and_head(q, c);
+                assert_eq!(run, q);
+                assert!(q.starts_with(head), "the head must be a prefix of the run: {head:?}");
+                // it lands on the boundary at or below the asked-for offset, never above it
+                assert!(head.len() <= c.min(q.len()));
+                assert!(c.min(q.len()) - head.len() < 4, "…and never backs up past one character");
+            }
+        }
+    }
+
+    /// The run is cut at the first NUL — `super::enter`'s seed is read from a FILE, so a control
+    /// byte is reachable — and a caret past that cut lands at its end rather than out of range.
+    #[test]
+    fn a_nul_cuts_the_run_and_the_caret_lands_inside_what_is_left() {
+        assert_eq!(run_and_head("wal\0lace", 3), ("wal", "wal"));
+        assert_eq!(run_and_head("wal\0lace", 8), ("wal", "wal"), "a caret past the cut clamps to it");
+        assert_eq!(run_and_head("\0wallace", 4), ("", ""));
+        // …and the clamp still lands on a character boundary, not merely inside the length.
+        assert_eq!(run_and_head("су\0ббота", 99), ("су", "су"));
     }
 
     /// The degenerate box (a field narrower than its own caret) must not produce a negative


### PR DESCRIPTION
## What this is

Lane **b8** of the LG Content Store submission fleet: the keyboard rows of LG's App Self
Checklist. Two real defects on the text-entry seam, both invisible until somebody types something
that is not ASCII, plus the host coverage those rows ask for and one finding that no amount of
correctness in this code can answer.

**Scope of the claim, stated up front: this does NOT mark any checklist row.** The rows are about
the **LG Virtual Keyboard on a television**, and this app receives native SDL events rather than
taking the browser/input-field path LG's `develop/*` pages document — so the acceptance criterion
is a device session. The recipe is at the bottom. Everything below the fold here is host-gradeable
editor logic, which is what a host tier can honestly own.

---

## The two defects

### 1. The field's caret slice claimed a char-boundary re-bound it did not do

`ui/search/field.rs`'s draw cut the text before the insertion point as:

```rust
let head = &q[..v.caret.min(q.len())];
```

…under a comment saying it was *"re-bounded here rather than trusted"*. It was not. `min` bounds
the **length** and says nothing about the **boundary**, so the expression is only sound while the
incoming offset is already a char boundary of *that* slice — and it is not the same slice the caret
was clamped against, because `q` here has first been truncated at any NUL. A documented-but-absent
defence is worse than neither, and the failure mode is not cosmetic: this is a slice in a **draw**,
inside the SDL event loop, so it panics the app.

It is now the pure `run_and_head`, which makes both cuts (the NUL, and the caret back to a real
boundary) in one place. Its test drives **every byte offset** of five multi-byte runs
(Cyrillic, CJK, Latin-with-accents, emoji, mixed) and asserts the head is always a prefix that
never backs up past one character.

Proven to catch it — with the boundary walk removed, the new test fails exactly as predicted:

```
end byte index 1 is not a char boundary; it is inside 'с' (bytes 0..2 of string)
```

### 2. A codepoint cut by the end of `text[32]` arrived as a character nobody typed — row **16**

`SDL_TextInputEvent` carries an inline **fixed 32-byte array**, so a commit that fills it is cut at
a *byte*. For any query that is not pure ASCII that cut lands mid-codepoint, and
`from_utf8_lossy` turns the surviving half into a **U+FFFD** — a `` in the user's search field
that they never pressed. That is precisely the substitution row 16 is about.

Both edges are trimmed now:

* the **cut tail**, when the array was actually full (`n == TEXT_CAP` — deliberately *not*
  `n == field.len()`, which is also true when the *caller's* buffer ran out, and a short buffer is
  the reader's limit rather than evidence the panel cut anything);
* the **orphaned head** a following commit would open with, since no UTF-8 string may begin with a
  continuation byte — dropping it can only ever remove bytes that were already unreadable.

The classification is `std::str::from_utf8`'s `error_len().is_none()` (*"valid so far, ended
mid-sequence"*), **not** a hand-rolled lead-byte width table. That distinction is load-bearing: a
width table calls an overlong lead, an out-of-range lead and a surrogate half merely "incomplete"
and deletes real corruption without a trace, where a replacement character is the only visible
signal that something arrived broken. A test pins all four staying reported.

**This branch is belt-and-braces and its doc says so.** Stock SDL2 fills the array with
`SDL_utf8strlcpy`, which truncates on a character boundary and always terminates — so on stock SDL
it is unreachable, and `encode_event` cuts on a boundary too, which is why neither the simulator nor
the `txt:` token can drive it. **Whether LG's fork does the same is a question for the television's
own `libSDL2`**, not for a header or another client; `.claude/skills/decompile-tv-lib/` is how the
`+16 inputSource` offset was settled and is how this would be. Until then it costs one comparison
and cannot make a correct commit wrong.

---

## What was already right, and is now graded

Cursor movement — the half of the checklist that asks *"does the text cursor move with the `<` and
`>` buttons"* — **already worked** and is device-measured (`SDLK_LEFT`/`SDLK_RIGHT`, wcodes 80/79,
alongside backspace 42 and Clear all 156). `ui/search/mod.rs` handles all four and its tests already
step a Cyrillic query character-by-character. Nothing there needed changing, and I did not touch
that file.

New host coverage for what the rows name and nothing graded:

* **capital/small letter transfer** — the panel resolves Shift/Caps and commits the cased
  character, so the app's whole obligation is byte-transparency;
* **the row's own worked example** — full-width `＼` (U+FF3C) is not folded to `\`, plus `￥ ／ ： 　
  “ ’ －` and the ASCII metacharacters a URL or shell layer would otherwise eat.

+9 tests. **985 pass**, `make check` green (clippy gate included).

---

## Simulator evidence

Driven entirely through the remote FIFO's **scalar tokens** — never a synthetic `SDL_TEXTINPUT`,
which SIGSEGVs inside the Mac's sdl2-compat/SDL3 shim.

| | |
|---|---|
| `ok` — caret at the end | `суббота⎸` |
| `ok left left left` | `субб⎸ота` — three whole 2-byte characters, not three bytes |
| `ok left left left backspace` | `суб⎸ота` — one whole character removed mid-string |

Identical before and after the change (these paths were already correct; the fixes are for the
edge cases the simulator cannot reach). Screenshots were taken inside the caret's blink-ON phase —
`BLINK_MS` is 530 ms and `set_caret` restarts the phase on every edit, so a later grab photographs
an empty slot.

---

## Findings handed on — NOT fixed here

**1. The bundled font cannot draw CJK, Hangul or full-width forms. This is checklist row 22
("a query in a language the app does not support"), and it will read to a reviewer as a failure of
15/16/17 too.**

Measured: `pkg/appfont*.ttf` carries **2853 codepoints** — Latin, Cyrillic, Greek — with
**no** CJK, **no** Hangul and **no** full-width forms, and `text.rs` has no per-glyph fallback (its
`DROIDSANS` path is a whole-font last resort for a *missing file*, not a chain). So the text arrives
perfectly and draws as `.notdef` boxes, in the field, in the "No results for …" line, and anywhere
else the query is echoed. Seeding the field with `＼￥／：“千と千尋` renders one box per character
except the curly quote.

This matters more than its row number suggests: **LG is a Korean company and the reviewer is likely
to type Hangul.** Fixing it is a font decision (a wider cut in `tools/cut-inter.py`, or a real
fallback chain) and is not in this lane's gift. Recorded in `textinput.rs`'s module doc, because
"my search shows boxes" is a question that gets asked at this seam first.

**2. `ui/search/empty.rs` has the same NUL hazard, failing worse.** Its `draw` builds the "No
results for …" statement and does `let Ok(c) = CString::new(statement) else { return };` — an
interior NUL silently returns *before drawing the header as well*, leaving a blank band. Two
modules, two failure modes, one invariant; the cut arguably belongs once, in `search::set_query`.
Not my file.

**3. Three hand-rolled copies of `str::floor_char_boundary`** now exist (`search/mod.rs::caret`,
`textinput::encode_event`, `field::run_and_head`). Consolidating means touching a file this lane
does not own.

**4. Checklist numbering.** This lane was briefed on rows **15, 16, 17**.
`docs/lg-self-checklist.md` records **16** and **17** but has **no row 15 anywhere**. I trusted the
file: the code comment covering capital/small-letter transfer deliberately cites no row number, and
says why. Worth reconciling against the actual LG document.

**5. Sub-pixel caret placement.** `head` is measured as a standalone string, so a kern pair
straddling the insertion point is applied to the run but not to the head and the bar can sit ~1px
off. Pre-existing, unchanged, and only a panel can judge it — `text_width` cannot be reached from
the host suite. Recorded on `run_and_head`.

**6. `docs/search.md` still says the caret is solid and does not blink**, citing `field.rs`, which
has since reversed. Left alone — a sibling lane is editing that file.

---

## The device recipe — what rows 16 and 17 still need

Requires the TV lock (`tools/tv-lock.sh`; the `tv-lock` skill is the workflow). Substitute your own
values for every placeholder.

```sh
make FLAVOR=debug deploy TV=<tv-ip>
RUN=$(make -s print-rundir FLAVOR=debug)
```

**Reach the field.** Boot into Search with the panel raised:

```sh
ssh root@<tv-ip> "printf 'star' > $RUN/plxnative-search"
make FLAVOR=debug run TV=<tv-ip> RUN_SECS=60
```

Then press **OK** on the capsule to raise the television's own keyboard. Confirm from the event log
that it actually rose — `keyboard: start support=1 focus=1`. **`focus=0` means the panel silently
never appeared** and every observation below is void.

**Row 16 — character fidelity.** With the panel up, type each of these and read the field:

* `\` (the item's own example), then the **full-width `＼`** off the panel's symbol page;
* `& % + # ? = " ' < >` — the URL and shell metacharacters;
* a **Hangul** syllable and a **CJK** run — expect `.notdef` boxes per the finding above, and
  record that as row 22 rather than as a text-input fault;
* a capital/small pair via Shift/Caps.

The app logs every commit, so the string it received is checkable independently of what is drawn:

```sh
make -s print-eventlog FLAVOR=debug | xargs -I{} ssh root@<tv-ip> "grep -E 'text src=|keyboard:' {}"
```

That distinction is the whole point of the row: **"what arrived" and "what is on the panel" are two
different questions**, and this change only settles the first.

**Row 16 — the cut case specifically.** Type a **>31-byte non-ASCII** query (≈16 CJK characters, or
a long Cyrillic phrase) so the commit fills `text[32]`. Expect no `` anywhere in the field. If the
television's SDL cuts on a boundary the way stock SDL2 does, this passes trivially and the branch
added here was never entered — which is the outcome to record either way.

**Row 15's cursor half.** With a multi-byte query in the field, press the panel's `◀`/`▶` and
confirm the caret steps one **character** at a time and clamps at both ends; then `backspace`
mid-string and confirm a whole character goes.

**Row 17 — linked buttons.** Press **Voice Search** and each of its siblings on the panel. What is
unknown is not whether they are handled — they are the television's own — but whether invoking one
disturbs our session: the recorded reopen wedge (moonlight-tv#435) means the panel may be a one-way
door on some firmwares, so check that text still commits **after** returning from voice, and that
`keyboard: start` / `keyboard: stop` pair up in the log rather than a `start` going silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GovTtrsD9P7Ld7DnLCMK2G
