### PR TITLE
transport: an Origin is what a server's address IS, parsed from a URL and never rebuilt from one

### DIFF
--- a/docs/plex-api-design.md
+++ b/docs/plex-api-design.md
@@ -1,5 +1,19 @@
 # Plex API layer — typed Rust design (`rust-modules/src/plex/`)
 
+> **Banner (2026-08-23): the ADDRESS shape below is superseded.** This is the design note as
+> written, sketches and all, and it is kept that way rather than rewritten. One thing in it has
+> since changed and would mislead: a server's address is no longer a `(host, port)` pair. It is a
+> **`plex::Origin`** — scheme + host + port — and it is **parsed from a URL, never assembled from an
+> address**, because the host a `plex.direct` certificate is issued for is the hostname plex.tv
+> sends in `Connection.uri` while `Connection.address` is the dotted quad behind it. So read
+> §3.1's `Client { host, port }`, §3.3's `StreamUrl { host, port, path }` and rule 9 ("Numeric host,
+> no DNS") as the state of the world before `rust-modules/src/plex/origin.rs`, whose module doc is
+> the current account — including the bracket invariant (`host()` is bare for the resolver,
+> `authority()` brackets a v6 literal for a URL) that the old pair could not express at all.
+> `Client::host()`/`port()` and `StreamUrl::host()`/`port()` still answer exactly what rule 9 says,
+> as views on the origin; the transport constraint below it is unchanged — the socket still does no
+> name resolution and no TLS.
+
 Goal: **replace every hand-built Plex path/query string in the app with one typed method per
 operation.** After this lands, no module outside `plex/` ever writes `format!("/library/…")`,
 `&X-Plex-Token=`, `%2F`, or `http://host:port/…`. The catalog (`docs/plex-api-catalog.md`) is

--- a/docs/plex-api-migration.md
+++ b/docs/plex-api-migration.md
@@ -68,7 +68,8 @@ Line numbers are as of the current tree. All paths below are relative to `rust-m
 
 ### Prerequisite wiring (not one of the 5 files, but required first)
 
-**DONE** — `plex::install(host, port, token)` is called in the boot/login paths (`app.rs`,
+**DONE** — `plex::install` (which took `(host, port, token)` when this was written and takes
+`(&Origin, token)` since `plex/origin.rs`) is called in the boot/login paths (`app.rs`,
 `auth.rs`) before the first PMS read. Remaining follow-ons when the playback layer migrates:
 
 - `route::CFG` keeps only `demo_url` (host/port/token move to the client; `route::config()` callers

--- a/docs/shared-servers.md
+++ b/docs/shared-servers.md
@@ -314,7 +314,9 @@ from "the unwatched angle", which `23f28ce6` replaced with the white tick over a
    over a WAN link measured at 38.8 Mbit/s. Expect this, not direct play, to be the common case —
    and it argues for a remote-aware bitrate policy well before relay does (step 9).
 2. ~~**The harness cannot grade any of this yet.**~~ **ANSWERED** (§9): `/tmp/plxnative-servers`
-   carries a JSON array of ADDITIONAL servers — host, port, machineIdentifier and the token to trust
+   carries a JSON array of ADDITIONAL servers — host, port, an optional `"scheme"` (`http`, the
+   default, or `https` — the only way to put a TLS origin through the registry without an account
+   that has one), machineIdentifier and the token to trust
    them with — beside the unchanged `/tmp/plxnative-token`, and `run.py` resolves the second token
    from `/api/v2/resources` so no new secret is stored. One limitation stands and is not a bug to
    fix: there is **no managed-user token for someone else's server**, so a case that PLAYS from a

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -3855,8 +3855,12 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
         // Install the PMS client (the read layer AND the playback path) as the CURRENT server,
         // then fetch the catalog. Used by the boot gate and again when a login resolves; a later
         // call for the same address just swaps the token (profile switch).
-        let install_pms = |host: &str, port: c_int, token: &str| {
-            crate::plex::install(host, port, token); // a (re)install is a login / profile switch
+        // Takes an ORIGIN and not a `(host, port)` pair: the pair cannot say `https`, and the host
+        // a certificate is issued for is the `plex.direct` NAME rather than the address behind it
+        // (`plex::origin`). Every origin this boot builds is still `http://`, because that is all
+        // `crate::stream` speaks.
+        let install_pms = |origin: &crate::plex::Origin, token: &str| {
+            crate::plex::install(origin, token); // a (re)install is a login / profile switch
             // Every additional server this boot was handed credentials for joins the REGISTRY
             // beside it — the granted roster `browse` addresses its section table by. Registration
             // is not activation: `install` above has already made the session's own server current,
@@ -3869,7 +3873,11 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
             // the roster across a switch — and it must precede `activate_server`, whose refetch is
             // what turns a newly registered source into shelves and section tabs.
             for s in crate::dev::servers().unwrap_or_default().iter().filter(|s| s.usable()) {
-                let id = crate::plex::register(&s.machine_id, &s.host, s.port as c_int, &s.token);
+                // `usable()` IS `origin().is_some()`, so this `else` cannot be taken; it is a
+                // `continue` rather than an `expect` because an injected server has never been
+                // allowed to cost more than itself.
+                let Some(origin) = s.origin() else { continue };
+                let id = crate::plex::register_origin(&s.machine_id, &origin, &s.token);
                 // the roster's own answer about this server: a handle means someone else's.
                 crate::plex::describe_server(id, &s.name, &s.handle, s.handle.is_empty());
             }
@@ -3911,14 +3919,16 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
             log("boot: /tmp/plxnative-login — starting QR login");
             BootTo::Login
         } else if !dev_token.is_empty() {
-            install_pms(&host_s, pms_port, &dev_token);
+            // `Origin::http` names the assumption out loud: the host and port compiled into the
+            // C shim are a plaintext address, with no scheme to read off them.
+            install_pms(&crate::plex::Origin::http(&host_s, pms_port), &dev_token);
             BootTo::Home
         } else if session.can_go_local() {
             if session.home_users.len() > 1 && (!automated_boot() || pick_user.is_some()) {
                 // Who's watching first. Only the read client is installed here (the avatars proxy
                 // through the PMS photo transcoder); the catalog fetch + playback config happen in
                 // take_ready once a profile is picked — done now they'd be thrown out on a switch.
-                crate::plex::install(&session.server.address, session.server.port as i32, session.pms_token());
+                crate::plex::install(&session.server.origin(), session.pms_token());
                 crate::plex::session::set_current(Some(session.user.clone()));
                 // seeds the persisted roster + refreshes it online. `Picker::Boot` is what makes
                 // BACK out of this picker refuse to reinstate a PIN-protected profile — nobody has
@@ -3948,7 +3958,7 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                 // OWNER's record whoever was actually signed in. (`auth::take_ready`, the other
                 // way into Home, already sets it before its own `install_pms` for this reason.)
                 crate::plex::session::set_current(Some(session.user.clone()));
-                install_pms(&session.server.address, session.server.port as c_int, session.pms_token());
+                install_pms(&session.server.origin(), session.pms_token());
                 log("boot: stored session — local server (offline-capable)");
                 BootTo::Home
             }
@@ -5858,7 +5868,7 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
             // route (Login while creating/waiting/discovering/error, Profiles while picking/switching).
             if matches!(route, Route::Login | Route::Profiles) {
                 if let Some(c) = crate::auth::take_ready() {
-                    install_pms(&c.host, c.port, &c.token);
+                    install_pms(&c.origin, &c.token);
                     // the fourth store an identity change must not survive, beside the
                     // `browse`/`pms`/`person` resets `install_pms` performs: a new user must never
                     // be able to walk BACK into the previous one's pages. Reset at the CALL SITE

--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -10,6 +10,7 @@
 #![allow(dead_code)]
 use crate::plex::account::{AccountClient, HomeUser, Resource};
 use crate::plex::probe::{self, Candidate, Outcome, ProbePlan, Scheme};
+use crate::plex::Origin;
 use crate::plex::session::{self, ServerRef, Session, SourceRef, UserRef};
 use std::sync::Mutex;
 
@@ -110,8 +111,11 @@ impl UserTile {
 
 /// PMS credentials the main loop installs once the flow resolves.
 pub struct ReadyCreds {
-    pub host: String,
-    pub port: i32,
+    /// **Where the primary server is** — an [`Origin`], not a `(host, port)` pair, because the
+    /// pair cannot say `https` and the host a certificate is issued for is not the address behind
+    /// it (`plex::origin`). Read straight off the stored [`session::ServerRef`], which is the
+    /// value discovery wrote and the one `can_go_local` gates.
+    pub origin: Origin,
     pub token: String,
 }
 
@@ -308,11 +312,7 @@ pub fn take_ready() -> Option<ReadyCreds> {
             session::set_current(Some(c.session.user.clone())); // drives the Home profile chip
             Some((
                 c.session.sources.clone(),
-                ReadyCreds {
-                    host: c.session.server.address.clone(),
-                    port: c.session.server.port as i32,
-                    token: c.session.pms_token().to_owned(),
-                },
+                ReadyCreds { origin: c.session.server.origin(), token: c.session.pms_token().to_owned() },
             ))
         } else {
             None
@@ -476,10 +476,12 @@ fn login_thread() {
     }
     // Install the PMS client now (server/owner token) so the who's-watching avatars can proxy
     // through the server's photo transcoder. The per-user token is swapped in on profile pick.
-    let (addr, port, stok) =
-        with_ctl(|c| (c.session.server.address.clone(), c.session.server.port, c.session.server.token.clone()));
-    crate::plex::install(&addr, port as i32, &stok);
-    log(&format!("auth: PMS client installed {addr}:{port}"));
+    let (origin, stok) = with_ctl(|c| (c.session.server.origin(), c.session.server.token.clone()));
+    crate::plex::install(&origin, &stok);
+    // The AUTHORITY, not the base URL: byte-identical to the `{addr}:{port}` this line always
+    // printed for the http/IPv4 origins the app has today, and correct for a v6 literal, which
+    // that format could not spell at all.
+    log(&format!("auth: PMS client installed {}", origin.authority()));
 
     // 4) Plex Home roster → who's-watching, or straight in if there's a single user. The roster is
     // kept on the session so it persists with the creds — the boot picker and every later
@@ -786,9 +788,22 @@ fn resolve_roster(resources: &[Resource], dial: &dyn Fn(&str, i32) -> (i32, Vec<
                     name: plan.name.clone(),
                     shared_by: plan.source_title.clone().unwrap_or_default(),
                     owned: plan.owned,
-                    // The address that ANSWERED, never the first advertised — and it got here only
-                    // by being dialable, which is what keeps a v6 literal or a hostname out of the
-                    // session file.
+                    // **The ORIGIN is parsed from the candidate's URL, never rebuilt from its
+                    // address.** For every candidate this transport can dial today the two agree
+                    // exactly — `dial_target` accepts only a plain-http IPv4 literal, whose URL
+                    // `probe::candidates` synthesized as `http://{address}:{port}` — so nothing
+                    // about the current behaviour moves. They stop agreeing the moment an https
+                    // candidate can be accepted: plex.tv advertises the `plex.direct` NAME in
+                    // `uri` while `address` stays the quad behind it, and the certificate is
+                    // issued for the name, so a session file that stored the address would fail
+                    // TLS validation on every real share (`plex::origin`).
+                    //
+                    // Empty when the URL somehow is not an origin — `SourceRef::origin` then falls
+                    // back to the legacy address pair, which is the same answer this line used to
+                    // give unconditionally.
+                    origin: c.origin().map(|o| o.base()).unwrap_or_default(),
+                    // The address that ANSWERED, never the first advertised. Kept as the
+                    // DIAGNOSTIC half — what `describe` prints and the Sources panel says.
                     address: c.address,
                     port: c.port,
                     // That server's OWN grant. Our own server's token gets a 401 from a share, so
@@ -853,6 +868,9 @@ fn discover_and_store(ac: &AccountClient) -> Discovery {
         address: p.address.clone(),
         port: if p.port != 0 { p.port } else { 32400 },
         token: p.token.clone(),
+        // Carried across from the roster entry, so the primary and its `sources` twin can never
+        // disagree about where the same server is. `reconcile_primary` keeps them together later.
+        origin: p.origin.clone(),
     };
     with_ctl(|c| {
         c.session.server = server;
@@ -974,16 +992,20 @@ fn reconcile_primary(server: &mut ServerRef, found: &[SourceRef]) -> bool {
         return false;
     }
     let Some(s) = found.iter().find(|s| s.machine_id == server.machine_id && s.usable()) else { return false };
-    if server.address == s.address && server.port == s.port && server.token == s.token {
+    if server.address == s.address && server.port == s.port && server.token == s.token && server.origin == s.origin {
         return false;
     }
-    if server.address != s.address || server.port != s.port {
+    if server.address != s.address || server.port != s.port || server.origin != s.origin {
         // The machine name and the address, never the token and never the machine id — the same
         // line `SourceRef::describe` draws.
         log(&format!("auth: primary {:?} now answers at {}:{}", server.name, s.address, s.port));
     }
     server.address = s.address.clone();
     server.port = s.port;
+    // The origin moves with the address for the same reason the token does: it came out of the
+    // same answer. Leaving it behind would keep dialling the old one, which is the bug this
+    // whole function exists to close, one field further in.
+    server.origin = s.origin.clone();
     // The token moves with the address because it came from the same answer: this is the OWNER's
     // per-(user, server) grant, which is exactly what `ServerRef::token` means (and the refresh
     // above only runs for the owner). `pms_token()` still prefers a switched profile's own token.
@@ -1004,7 +1026,11 @@ fn install_roster(sources: &[SourceRef], primary: Option<usize>) -> usize {
     let order = registration_order(sources);
     for &i in &order {
         let s = &sources[i];
-        let id = crate::plex::register(&s.machine_id, &s.address, s.port as i32, &s.token);
+        // `registration_order` already filtered on `usable()`, which IS `origin().is_some()` —
+        // so this `else` is unreachable today and is a `continue` rather than an `expect` because
+        // a roster entry has never been allowed to cost more than itself (`de_soft_vec`).
+        let Some(origin) = s.origin() else { continue };
+        let id = crate::plex::register_origin(&s.machine_id, &origin, &s.token);
         // …and say WHOSE it is. Registering without this was the bug that made the whole shared-
         // source feature invisible on the only path a real user takes: `ServerFacts` stayed unset,
         // so every source read as owned with no handle, and each surface then correctly drew
@@ -1515,6 +1541,36 @@ mod tests {
         assert_eq!(d.seen(), vec!["192.168.0.10:32400", "203.0.113.9:31234"]);
     }
 
+    /// **Each roster entry's ORIGIN comes from the candidate's URL, not from its address.**
+    ///
+    /// It is the same value today — `dial_target` accepts only a plain-http IPv4 literal, whose URL
+    /// `probe::candidates` synthesized as `http://{address}:{port}` — and that equality is the
+    /// whole no-behaviour-change claim, so it is asserted rather than assumed. It stops being an
+    /// equality the moment an https candidate can be accepted: plex.tv advertises the `plex.direct`
+    /// NAME in `uri` while `address` stays the quad behind it, so a roster rebuilt from `address`
+    /// would store an origin no certificate matches.
+    #[test]
+    fn each_reached_entry_records_the_origin_its_url_named() {
+        let d = Dialled::new(vec![
+            ("192.168.0.10", 200, identity_json("aaaa1111")),
+            ("203.0.113.9", 200, identity_json("bbbb2222")),
+        ]);
+        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &|h, p| d.dial(h, p)) else {
+            panic!("both servers answer")
+        };
+
+        assert_eq!(roster[0].origin, "http://192.168.0.10:32400");
+        assert_eq!(roster[1].origin, "http://203.0.113.9:31234");
+        // …and it is a parseable origin, so the registry gets one rather than the legacy fallback
+        for s in &roster {
+            let o = s.origin().expect("a reached entry is dialable");
+            assert_eq!(o.base(), s.origin, "the stored string round-trips");
+            assert!(!o.is_tls(), "nothing this transport can accept is TLS yet");
+            // the equality that makes this a behaviour-preserving change today
+            assert_eq!((o.host(), o.port() as i64), (s.address.as_str(), s.port));
+        }
+    }
+
     /// The three ways discovery can come to nothing are three different things to say, and the one
     /// that used to be said for all of them ("No local Plex server found on this network") was the
     /// old policy talking rather than a description of what happened.
@@ -1552,6 +1608,10 @@ mod tests {
         assert!(!roster[0].owned, "the primary is a share here, and that is the point");
     }
 
+    /// A roster entry in the **LEGACY shape** — no stored `origin`, which is what every session
+    /// file on every television written before that field carries. `..Default::default()` is what
+    /// leaves it empty, so these fixtures also stand as the compatibility case: everything they
+    /// assert about registration and re-keying runs through `SourceRef::origin`'s fallback.
     fn source(machine_id: &str, owned: bool, token: &str) -> SourceRef {
         SourceRef {
             machine_id: machine_id.into(),
@@ -1561,6 +1621,7 @@ mod tests {
             address: "10.0.0.1".into(),
             port: 32400,
             token: token.into(),
+            ..Default::default()
         }
     }
 
@@ -1616,6 +1677,7 @@ mod tests {
         assert!(retoken(&anon, &[resource(r#"{"provides":"server","accessToken":"x"}"#)]).is_empty());
     }
 
+    /// The primary in the **LEGACY shape** — see [`source`] above.
     fn primary(machine_id: &str, address: &str, port: i64, token: &str) -> ServerRef {
         ServerRef {
             name: "Mac mini".into(),
@@ -1623,6 +1685,7 @@ mod tests {
             address: address.into(),
             port,
             token: token.into(),
+            ..Default::default()
         }
     }
 
@@ -1682,6 +1745,7 @@ mod tests {
                 address: "192.168.0.10".into(),
                 port: 32400,
                 token: "tok-own".into(),
+                ..Default::default()
             },
             user: UserRef { uuid: uuid.into(), title: "stored".into(), token: "tok-user".into(), ..Default::default() },
             home_users: vec![

--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -478,10 +478,10 @@ fn login_thread() {
     // through the server's photo transcoder. The per-user token is swapped in on profile pick.
     let (origin, stok) = with_ctl(|c| (c.session.server.origin(), c.session.server.token.clone()));
     crate::plex::install(&origin, &stok);
-    // The AUTHORITY, not the base URL: byte-identical to the `{addr}:{port}` this line always
-    // printed for the http/IPv4 origins the app has today, and correct for a v6 literal, which
-    // that format could not spell at all.
-    log(&format!("auth: PMS client installed {}", origin.authority()));
+    // `log_form`, not `base()`: byte-identical to the `{addr}:{port}` this line always printed
+    // for a plaintext origin (so an archived log stays comparable), and the whole URL as soon as
+    // the scheme is worth saying. See `Origin::log_form`.
+    log(&format!("auth: PMS client installed {}", origin.log_form()));
 
     // 4) Plex Home roster → who's-watching, or straight in if there's a single user. The roster is
     // kept on the session so it persists with the creds — the boot picker and every later
@@ -551,7 +551,14 @@ fn poll_for_token(ac: &AccountClient, id: i64, expires_in: i64) -> Option<String
 /// user to two different places.
 enum Reach {
     /// This address answered `/identity` **as the server we asked for**.
-    At(Candidate),
+    ///
+    /// Two values, and the split is the point: the [`Origin`] is **what was actually dialled**, and
+    /// so the only thing the roster may record as this server's address; the [`Candidate`] is kept
+    /// beside it for the DIAGNOSTIC fields (`address`, `port`) that the log and the Sources panel
+    /// say. Deriving the record from `Candidate::url` while the dial came from `Candidate::address`
+    /// left exactly one gap — a plex.tv `uri` whose port disagrees with `port` would be verified at
+    /// one and written down as the other — and this pairing closes it by construction.
+    At(Candidate, Origin),
     /// A 401. A TOKEN problem, not a reachability one: the `accessToken` is per (user, server) and
     /// carries the sharing grant, so every other address of this server answers identically and
     /// trying them buys nothing. Reporting "can't reach nas-home" here would send the user to look
@@ -613,13 +620,22 @@ fn dialable(c: &Candidate) -> bool {
 /// out-of-range `i64` into a plausible port (its doc has the arithmetic). A candidate whose port
 /// cannot be dialled is refused here for the same reason a hostname is: it is a connection this
 /// client cannot open, not a server that failed to answer.
-fn dial_target(c: &Candidate) -> Option<i32> {
-    (c.scheme == Scheme::Http && is_ipv4_literal(&c.address)).then(|| probe::dial_port(c.port)).flatten()
+fn dial_target(c: &Candidate) -> Option<Origin> {
+    let o = c.origin()?;
+    // Both schemes, and they are not redundant: `probe::scheme_of` calls anything that is not
+    // `http://` https (it is a RANKING axis and errs toward "cannot dial"), while `Origin::parse`
+    // refuses only a scheme it does not know. Requiring both keeps this gate exactly as narrow as
+    // it has always been.
+    let plaintext = c.scheme == Scheme::Http && o.scheme() == Scheme::Http;
+    (plaintext && is_ipv4_literal(o.host())).then_some(o)
 }
 
 /// Four decimal octets and nothing else — the exact address shape `stream.rs` can turn into a
 /// `sockaddr_in`. Anything else (a hostname, a v6 literal, a five-part typo) would be handed to
 /// `http_open` only to be rejected there after a `CString` round trip.
+///
+/// Asked of the ORIGIN's host, not of [`Candidate::address`]: the origin is what gets dialled and
+/// what gets recorded, and for an advertised `uri` the address is a different string.
 fn is_ipv4_literal(a: &str) -> bool {
     let mut parts = 0;
     for p in a.split('.') {
@@ -726,11 +742,13 @@ fn get_identity(host: &str, port: i32) -> (i32, Vec<u8>) {
 fn probe_server(plan: &ProbePlan, dial: &dyn Fn(&str, i32) -> (i32, Vec<u8>)) -> Reach {
     let mut tried = 0;
     for c in plan.candidates.iter() {
-        let Some(port) = dial_target(c) else { continue };
+        let Some(origin) = dial_target(c) else { continue };
         tried += 1;
-        let (status, body) = dial(&c.address, port);
+        // The ORIGIN's host and port — the same value handed back in `Reach::At`, so what answered
+        // and what the roster records cannot be two different addresses.
+        let (status, body) = dial(origin.host(), origin.port());
         match classify(status, &body, &plan.machine_id) {
-            Outcome::Reachable => return Reach::At(c.clone()),
+            Outcome::Reachable => return Reach::At(c.clone(), origin),
             Outcome::Unauthorized => {
                 log(&format!("auth: '{}' answered 401 at {} — a token problem, not the network", plan.name, c.address));
                 return Reach::Refused;
@@ -782,26 +800,22 @@ fn resolve_roster(resources: &[Resource], dial: &dyn Fn(&str, i32) -> (i32, Vec<
     for r in servers {
         let plan = probe::plan(r);
         match probe_server(&plan, dial) {
-            Reach::At(c) => {
+            Reach::At(c, origin) => {
                 let s = SourceRef {
                     machine_id: plan.machine_id.clone(),
                     name: plan.name.clone(),
                     shared_by: plan.source_title.clone().unwrap_or_default(),
                     owned: plan.owned,
-                    // **The ORIGIN is parsed from the candidate's URL, never rebuilt from its
-                    // address.** For every candidate this transport can dial today the two agree
-                    // exactly — `dial_target` accepts only a plain-http IPv4 literal, whose URL
-                    // `probe::candidates` synthesized as `http://{address}:{port}` — so nothing
-                    // about the current behaviour moves. They stop agreeing the moment an https
-                    // candidate can be accepted: plex.tv advertises the `plex.direct` NAME in
-                    // `uri` while `address` stays the quad behind it, and the certificate is
-                    // issued for the name, so a session file that stored the address would fail
-                    // TLS validation on every real share (`plex::origin`).
-                    //
-                    // Empty when the URL somehow is not an origin — `SourceRef::origin` then falls
-                    // back to the legacy address pair, which is the same answer this line used to
-                    // give unconditionally.
-                    origin_url: c.origin().map(|o| o.base()).unwrap_or_default(),
+                    // **The origin that ANSWERED** — `probe_server` hands back the very value it
+                    // dialled, so what is written down here has been verified and not merely
+                    // derived. It comes from the candidate's URL (`dial_target` → `Candidate::origin`)
+                    // and never from `Candidate::address`: plex.tv advertises the `plex.direct` NAME
+                    // in `uri` while `address` stays the quad behind it, and the certificate is
+                    // issued for the name, so a session file that stored the address would fail TLS
+                    // validation on every real server (`plex::origin`). Today the two agree — the
+                    // only candidates this transport dials are plain-http IPv4 ones — and the
+                    // roster test asserts that equality rather than trusting it.
+                    origin_url: origin.base(),
                     // The address that ANSWERED, never the first advertised. Kept as the
                     // DIAGNOSTIC half — what `describe` prints and the Sources panel says.
                     address: c.address,
@@ -996,7 +1010,15 @@ fn reconcile_primary(server: &mut ServerRef, found: &[SourceRef]) -> bool {
     {
         return false;
     }
-    if server.address != s.address || server.port != s.port || server.origin_url != s.origin_url {
+    // The line says the server MOVED, so it must not fire when only the stored origin was
+    // LEARNED. A primary written before that field existed carries an empty one, so the first boot
+    // after the upgrade populates it beside an identical address, port and token — a write, and not
+    // news. Logging it would read as DHCP churn in the file this project treats as its primary
+    // evidence surface, on every existing install, exactly once, which is the worst kind of false
+    // positive: unreproducible afterwards.
+    let learned_origin = server.origin_url.is_empty() && !s.origin_url.is_empty();
+    let moved = server.address != s.address || server.port != s.port || (server.origin_url != s.origin_url && !learned_origin);
+    if moved {
         // The machine name and the address, never the token and never the machine id — the same
         // line `SourceRef::describe` draws.
         log(&format!("auth: primary {:?} now answers at {}:{}", server.name, s.address, s.port));
@@ -1304,7 +1326,10 @@ mod tests {
         ]);
 
         match probe_server(&plan, &|h, p| d.dial(h, p)) {
-            Reach::At(c) => assert_eq!((c.address.as_str(), c.port), ("203.0.113.9", 31234)),
+            Reach::At(c, o) => {
+                assert_eq!((c.address.as_str(), c.port), ("203.0.113.9", 31234));
+                assert_eq!(o.base(), "http://203.0.113.9:31234", "the origin handed back is the one dialled");
+            }
             _ => panic!("the second address answers as the right machine: {:?}", d.seen()),
         }
         assert_eq!(d.seen(), vec!["198.51.100.7:31234", "203.0.113.9:31234"]);
@@ -1347,34 +1372,43 @@ mod tests {
         assert_eq!(plan.candidates.len(), 6, "policy kept three connections, two candidates each");
 
         let d = Dialled::new(vec![("203.0.113.9", 200, identity_json("bbbb2222"))]);
-        assert!(matches!(probe_server(&plan, &|h, p| d.dial(h, p)), Reach::At(_)));
+        assert!(matches!(probe_server(&plan, &|h, p| d.dial(h, p)), Reach::At(..)));
         let seen = d.seen();
         assert!(!seen.iter().any(|s| s.starts_with("172.20")), "the owner's LAN address: {seen:?}");
         assert!(!seen.iter().any(|s| s.contains("example.internal")), "no DNS in this transport: {seen:?}");
         assert!(!seen.iter().any(|s| s.contains("plex.direct")), "no TLS in this transport: {seen:?}");
 
-        // the rule itself, stated on the candidates
-        let http_v4 = |a: &str| Candidate {
-            url: format!("http://{a}:32400"),
+        // The rule itself, stated on the candidates. The fixture builds `url` the way
+        // `probe::candidates` does — from the SAME address and port — because that consistency is
+        // the property `dial_target` now relies on: it reads the origin off the URL, which is also
+        // what gets recorded, so a fixture whose url and port disagree would assert nothing real.
+        let http_v4 = |a: &str, port: i64| Candidate {
+            url: format!("http://{}:{port}", if a.contains(':') { format!("[{a}]") } else { a.to_string() }),
             scheme: Scheme::Http,
             location: probe::Location::Remote,
             address: a.into(),
-            port: 32400,
-            ipv6: false,
+            port,
+            ipv6: a.contains(':'),
         };
-        assert!(dialable(&http_v4("203.0.113.9")));
-        assert!(!dialable(&Candidate { scheme: Scheme::Https, ..http_v4("203.0.113.9") }));
-        assert!(!dialable(&http_v4("media.example.internal")));
-        assert!(!dialable(&http_v4("2001:db8::1")));
-        assert!(!dialable(&http_v4("203.0.113")), "three octets is not an address");
-        assert!(!dialable(&http_v4("203.0.113.999")), "999 is not an octet");
+        let at = |a: &str| http_v4(a, 32400);
+        assert!(dialable(&at("203.0.113.9")));
+        assert!(!dialable(&Candidate { scheme: Scheme::Https, ..at("203.0.113.9") }), "no TLS in this transport");
+        assert!(!dialable(&at("media.example.internal")), "no resolver in this transport");
+        assert!(!dialable(&at("2001:db8::1")), "a v6 literal needs a socket this app does not open");
+        assert!(!dialable(&at("203.0.113")), "three octets is not an address");
+        assert!(!dialable(&at("203.0.113.999")), "999 is not an octet");
 
         // …and the PORT is part of "can this transport dial it". `4_294_999_696 as i32` is 32400,
-        // so without the range check `probe::dial_port` applies, a nonsense answer from plex.tv
-        // would have been dialled at the most ordinary port there is.
-        assert!(!dialable(&Candidate { port: 4_294_999_696, ..http_v4("203.0.113.9") }));
-        assert!(!dialable(&Candidate { port: 0, ..http_v4("203.0.113.9") }));
-        assert_eq!(dial_target(&http_v4("203.0.113.9")), Some(32400), "the predicate and the socket agree");
+        // so without the range check `probe::dial_port` applies — in `Origin::parse` now, one layer
+        // down from where it used to be — a nonsense answer from plex.tv would have been dialled at
+        // the most ordinary port there is.
+        assert!(!dialable(&http_v4("203.0.113.9", 4_294_999_696)));
+        assert!(!dialable(&http_v4("203.0.113.9", 0)));
+
+        // **The predicate hands back the ORIGIN, and it is the one `probe_server` dials and
+        // `resolve_roster` records.** One value, so the address that answered and the address
+        // written down cannot be two different things.
+        assert_eq!(dial_target(&at("203.0.113.9")), Some(crate::plex::Origin::http("203.0.113.9", 32400)));
     }
 
     /// A candidate whose port cannot be dialled is SKIPPED, exactly as a hostname is — the next
@@ -1399,7 +1433,7 @@ mod tests {
         );
 
         let d = Dialled::new(vec![("203.0.113.9", 200, identity_json("bbbb2222"))]);
-        assert!(matches!(probe_server(&plan, &|h, p| d.dial(h, p)), Reach::At(_)), "the good one still answers");
+        assert!(matches!(probe_server(&plan, &|h, p| d.dial(h, p)), Reach::At(..)), "the good one still answers");
         assert!(
             !d.seen().iter().any(|s| s.starts_with("192.0.2.55")),
             "the wrapping candidate was never dialled: {:?}",
@@ -1440,7 +1474,10 @@ mod tests {
         ]);
 
         match probe_server(&plan, &|h, p| d.dial(h, p)) {
-            Reach::At(c) => assert_eq!(c.address, "192.168.0.10", "a v6 literal is not dialable here"),
+            Reach::At(c, o) => {
+                assert_eq!(c.address, "192.168.0.10", "a v6 literal is not dialable here");
+                assert_eq!(o.host(), "192.168.0.10", "…and the origin recorded is that same address");
+            }
             _ => panic!("the LAN IPv4 answers: {:?}", d.seen()),
         }
         assert_eq!(d.seen(), vec!["192.168.0.10:32400"], "the v6 addresses are never even tried");

--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -801,7 +801,7 @@ fn resolve_roster(resources: &[Resource], dial: &dyn Fn(&str, i32) -> (i32, Vec<
                     // Empty when the URL somehow is not an origin — `SourceRef::origin` then falls
                     // back to the legacy address pair, which is the same answer this line used to
                     // give unconditionally.
-                    origin: c.origin().map(|o| o.base()).unwrap_or_default(),
+                    origin_url: c.origin().map(|o| o.base()).unwrap_or_default(),
                     // The address that ANSWERED, never the first advertised. Kept as the
                     // DIAGNOSTIC half — what `describe` prints and the Sources panel says.
                     address: c.address,
@@ -870,7 +870,7 @@ fn discover_and_store(ac: &AccountClient) -> Discovery {
         token: p.token.clone(),
         // Carried across from the roster entry, so the primary and its `sources` twin can never
         // disagree about where the same server is. `reconcile_primary` keeps them together later.
-        origin: p.origin.clone(),
+        origin_url: p.origin_url.clone(),
     };
     with_ctl(|c| {
         c.session.server = server;
@@ -992,10 +992,11 @@ fn reconcile_primary(server: &mut ServerRef, found: &[SourceRef]) -> bool {
         return false;
     }
     let Some(s) = found.iter().find(|s| s.machine_id == server.machine_id && s.usable()) else { return false };
-    if server.address == s.address && server.port == s.port && server.token == s.token && server.origin == s.origin {
+    if server.address == s.address && server.port == s.port && server.token == s.token && server.origin_url == s.origin_url
+    {
         return false;
     }
-    if server.address != s.address || server.port != s.port || server.origin != s.origin {
+    if server.address != s.address || server.port != s.port || server.origin_url != s.origin_url {
         // The machine name and the address, never the token and never the machine id — the same
         // line `SourceRef::describe` draws.
         log(&format!("auth: primary {:?} now answers at {}:{}", server.name, s.address, s.port));
@@ -1005,7 +1006,7 @@ fn reconcile_primary(server: &mut ServerRef, found: &[SourceRef]) -> bool {
     // The origin moves with the address for the same reason the token does: it came out of the
     // same answer. Leaving it behind would keep dialling the old one, which is the bug this
     // whole function exists to close, one field further in.
-    server.origin = s.origin.clone();
+    server.origin_url = s.origin_url.clone();
     // The token moves with the address because it came from the same answer: this is the OWNER's
     // per-(user, server) grant, which is exactly what `ServerRef::token` means (and the refresh
     // above only runs for the owner). `pms_token()` still prefers a switched profile's own token.
@@ -1559,12 +1560,12 @@ mod tests {
             panic!("both servers answer")
         };
 
-        assert_eq!(roster[0].origin, "http://192.168.0.10:32400");
-        assert_eq!(roster[1].origin, "http://203.0.113.9:31234");
+        assert_eq!(roster[0].origin_url, "http://192.168.0.10:32400");
+        assert_eq!(roster[1].origin_url, "http://203.0.113.9:31234");
         // …and it is a parseable origin, so the registry gets one rather than the legacy fallback
         for s in &roster {
             let o = s.origin().expect("a reached entry is dialable");
-            assert_eq!(o.base(), s.origin, "the stored string round-trips");
+            assert_eq!(o.base(), s.origin_url, "the stored string round-trips");
             assert!(!o.is_tls(), "nothing this transport can accept is TLS yet");
             // the equality that makes this a behaviour-preserving change today
             assert_eq!((o.host(), o.port() as i64), (s.address.as_str(), s.port));

--- a/rust-modules/src/dev.rs
+++ b/rust-modules/src/dev.rs
@@ -268,7 +268,12 @@ impl DevServer {
         if self.machine_id.chars().nth(8).is_some() {
             mid.push_str("..");
         }
-        format!("name={:?} handle={:?} {}:{} mid={}", self.name, self.handle, self.host, self.port, mid)
+        // The origin's `log_form`, not `{host}:{port}`: this trigger's whole reason for having a
+        // `scheme` field is to put a TLS origin through the registry headlessly, and a description
+        // that cannot say which one it injected is the `[[silent-instrument-trap]]` again. It is
+        // byte-identical for the plaintext servers every overlay writes today.
+        let where_ = self.origin().map(|o| o.log_form()).unwrap_or_else(|| format!("{}:{}", self.host, self.port));
+        format!("name={:?} handle={:?} {where_} mid={mid}", self.name, self.handle)
     }
 
     /// A short, stable, NON-reversible tag for a shared server — enough to tell two shares apart in

--- a/rust-modules/src/dev.rs
+++ b/rust-modules/src/dev.rs
@@ -211,6 +211,20 @@ pub(crate) struct DevServer {
     pub(crate) host: String,
     #[serde(default = "default_port")]
     pub(crate) port: i64,
+    /// `"http"` (the default) or `"https"` — the scheme this server is reached at.
+    ///
+    /// **This is how an https origin is exercised headlessly**, without a plex.tv account that has
+    /// one and without a television that can reach it: write `"scheme": "https"` here and the
+    /// whole control plane below `plex::register_origin` sees a TLS origin. Everything the origin
+    /// model changed is otherwise invisible from outside the app, because every real origin today
+    /// is `http://`.
+    ///
+    /// A value that is neither fails the WHOLE trigger to deserialize, which
+    /// [`parse_servers`] turns into a logged error rather than a silently dropped server —
+    /// deliberately: a typo'd scheme that quietly meant `http` would be a run grading the thing it
+    /// was armed to test as working.
+    #[serde(default)]
+    pub(crate) scheme: crate::plex::Scheme,
     /// This identity's per-(user,server) access token **for this server**. A shared server is a
     /// separate authority: the account token gets a 401 from it, which is the whole reason one
     /// `plxnative-token` cannot express two servers. A SECRET — never logged.
@@ -276,7 +290,20 @@ impl DevServer {
     /// every server that passes this with `s.port as c_int`, and this file is a hand-written JSON
     /// blob under `/tmp` — an out-of-range `i64` wraps in that cast into a port nobody wrote down.
     pub(crate) fn usable(&self) -> bool {
-        !self.host.is_empty() && !self.token.is_empty() && crate::plex::probe::dial_port(self.port).is_some()
+        !self.token.is_empty() && self.origin().is_some()
+    }
+
+    /// **Where this server is** — the [`crate::plex::Origin`] to register it at, `None` when the
+    /// trigger did not write enough to dial.
+    ///
+    /// The port goes through `probe::dial_port` for the reason [`DevServer::usable`] gives: this
+    /// is a hand-written JSON blob under `/tmp`, and `port as i32` wraps an out-of-range `i64`
+    /// into a plausible-looking one.
+    pub(crate) fn origin(&self) -> Option<crate::plex::Origin> {
+        if self.host.is_empty() {
+            return None;
+        }
+        crate::plex::probe::dial_port(self.port).map(|p| crate::plex::Origin::new(self.scheme, &self.host, p))
     }
 }
 
@@ -563,6 +590,36 @@ mod tests {
         let got = super::read("devtest-empty");
         let _ = std::fs::remove_file(p);
         assert_eq!(got.as_deref(), Some(""), "an empty trigger must not read as absent");
+    }
+
+    /// **How an https origin is exercised without a plex.tv account that has one.** The
+    /// `plxnative-servers` trigger is the only surface that can inject a server the app did not
+    /// discover, so it is also the only way any lane or the integrator can put a TLS origin
+    /// through `plex::register_origin` headlessly.
+    ///
+    /// The default is `http`, because that is what every server this app has ever talked to is and
+    /// what every overlay written before this field meant.
+    #[test]
+    fn a_dev_server_scheme_defaults_to_http_and_can_be_told_https() {
+        let one = |json: &str| super::parse_servers(json).expect("parses").pop().expect("one server");
+
+        let plain = one(r#"{"machine_id":"m","host":"10.0.0.2","port":32400,"token":"t"}"#);
+        assert_eq!(plain.scheme, crate::plex::Scheme::Http, "an overlay that says nothing means http");
+        assert_eq!(plain.origin().expect("dialable").base(), "http://10.0.0.2:32400");
+
+        let tls = one(r#"{"machine_id":"m","host":"nas.hash.plex.direct","port":32400,"token":"t","scheme":"https"}"#);
+        assert!(tls.origin().expect("dialable").is_tls());
+        assert_eq!(tls.origin().unwrap().base(), "https://nas.hash.plex.direct:32400");
+        assert!(tls.usable());
+
+        // A scheme this app does not speak fails the WHOLE trigger, loudly — the caller logs the
+        // parse error. Silently meaning `http` would be a run grading the very thing it was armed
+        // to test as working.
+        assert!(super::parse_servers(r#"{"host":"h","token":"t","scheme":"ftp"}"#).is_err());
+
+        // and the port narrowing still applies: an out-of-range one costs the server, not the run
+        let wrapped = one(r#"{"machine_id":"m","host":"10.0.0.2","port":4294999696,"token":"t"}"#);
+        assert!(wrapped.origin().is_none() && !wrapped.usable(), "32400 is what that number wraps to");
     }
 
     /// The wire format the harness writes: a JSON ARRAY of servers, and — because a human arming

--- a/rust-modules/src/player/engine.rs
+++ b/rust-modules/src/player/engine.rs
@@ -636,7 +636,12 @@ pub(crate) fn start_bufferfeed(mt: &MainThread) -> bool {
 
     if stream {
         let su = crate::plex::StreamUrl::parse(&url); // the typed layer's URL splitter
-        let (host, port, path) = (su.host, su.port, su.path);
+        // `host()` is the origin's BARE host — a v6 literal arrives here unbracketed, which is
+        // what `stream.rs` needs and is not what the URL carried. The scheme is deliberately
+        // dropped: this transport speaks cleartext only, so an https target would fail at the
+        // socket rather than be silently downgraded here.
+        let (host, port) = (su.host().to_owned(), su.port());
+        let path = su.path;
         log(&format!("stream: host={host} port={port} path={}", &path[..path.len().min(80)]));
         // Two-lane feed: the demuxer routes es=1 video to aq_video and es=2 audio to
         // aq_audio, each with its own cap + feeder.

--- a/rust-modules/src/player/engine.rs
+++ b/rust-modules/src/player/engine.rs
@@ -636,10 +636,20 @@ pub(crate) fn start_bufferfeed(mt: &MainThread) -> bool {
 
     if stream {
         let su = crate::plex::StreamUrl::parse(&url); // the typed layer's URL splitter
+        // **REFUSED rather than downgraded.** `crate::stream` speaks cleartext to a numeric
+        // address and nothing else, so handing it an https target's host and port would open a
+        // plaintext connection to a TLS port — a hang or a garbage response, with nothing in the
+        // log saying why. A `Client` registered at an https origin can already produce one of
+        // these (`direct_play_url`/`transcode_start_url` copy the client's origin, and
+        // `/tmp/plxnative-servers` can inject `"scheme":"https"`), so this is reachable today and
+        // not a guard against the future. The transport lane deletes this branch when it can honour
+        // the scheme.
+        if su.origin.is_tls() {
+            log(&format!("stream: REFUSED — {} needs TLS and this transport has none", su.origin.log_form()));
+            return false;
+        }
         // `host()` is the origin's BARE host — a v6 literal arrives here unbracketed, which is
-        // what `stream.rs` needs and is not what the URL carried. The scheme is deliberately
-        // dropped: this transport speaks cleartext only, so an https target would fail at the
-        // socket rather than be silently downgraded here.
+        // what `stream.rs` needs and is not what the URL carried.
         let (host, port) = (su.host().to_owned(), su.port());
         let path = su.path;
         log(&format!("stream: host={host} port={port} path={}", &path[..path.len().min(80)]));

--- a/rust-modules/src/plex/CLAUDE.md
+++ b/rust-modules/src/plex/CLAUDE.md
@@ -30,11 +30,27 @@ token gets a **401** from it, and its section key `1` is a different library fro
 
 `client()` and `client_opt()` still mean what they always did, they just mean **the CURRENT
 server** now — which is why nothing outside `plex/` changed when the `OnceLock<Client>` singleton
-became a table. `client_for(id)` is the multi-server addition; `register(machine_id, host, port,
-token)` puts a server in the table; `install(host, port, token)` is the SESSION path (boot, QR
-login, profile switch) and always retargets. Slots are keyed on `machineIdentifier` because that is
-the only identity that survives a server changing address — and a `register` that has *learned* an
-id **adopts** an address-only slot instead of adding a second one for the same machine.
+became a table. `client_for(id)` is the multi-server addition; `register_origin(machine_id,
+&Origin, token)` puts a server in the table; `install(&Origin, token)` is the SESSION path (boot, QR
+login, profile switch) and always retargets.
+
+**A server's address is an `Origin` — scheme + host + port — and it is PARSED FROM A URL, never
+assembled from an address.** `origin.rs` is the type and the reasoning; the short version is that
+plex.tv advertises a server's TLS origin as the `plex.direct` HOSTNAME (`Connection.uri`) while
+`Connection.address` stays the dotted quad behind it, and the certificate is issued for the name —
+so a control plane carrying only an address can never validate one, however much TLS is added
+underneath it. `probe::Candidate::origin()` is the one derivation, and `Candidate::address` survives
+only as what a log and the Sources panel SAY. Two invariants come with it: `Origin::host()` is
+**always unbracketed** (it is the `getaddrinfo` node) while `Origin::authority()` **always**
+brackets a v6 literal (it is URL serialization) — confusing the two makes URL construction keep
+looking right while name resolution quietly stops working. `register(machine_id, host, port, token)`
+and `Origin::http(host, port)` still exist and are honest about what they mean: **every caller of
+either is a place that still assumes cleartext**, which is what makes them the grep for the TLS
+work. Today they all are, because `stream.rs` speaks nothing else.
+
+Slots are keyed on `machineIdentifier` because that is the only identity that survives a server
+changing address — and a registration that has *learned* an id **adopts** an address-only slot
+instead of adding a second one for the same machine.
 
 Three design choices carry the weight, and each is a prevented bug rather than a preference:
 

--- a/rust-modules/src/plex/CLAUDE.md
+++ b/rust-modules/src/plex/CLAUDE.md
@@ -46,7 +46,11 @@ brackets a v6 literal (it is URL serialization) — confusing the two makes URL 
 looking right while name resolution quietly stops working. `register(machine_id, host, port, token)`
 and `Origin::http(host, port)` still exist and are honest about what they mean: **every caller of
 either is a place that still assumes cleartext**, which is what makes them the grep for the TLS
-work. Today they all are, because `stream.rs` speaks nothing else.
+work. Today they all are, because `stream.rs` speaks nothing else — with one caller that has an
+origin and throws it away: `ui/alt_sources.rs`'s dev-only `stand_in_slot`, which registers a
+stand-in from `c.host()`/`c.port()` and should say `register_origin(&…, c.origin(), &token)`. It is
+one line and it is not in the origin unit's ownership, so it is written down here rather than
+silently left.
 
 Slots are keyed on `machineIdentifier` because that is the only identity that survives a server
 changing address — and a registration that has *learned* an id **adopts** an address-only slot

--- a/rust-modules/src/plex/client.rs
+++ b/rust-modules/src/plex/client.rs
@@ -1,4 +1,4 @@
-//! The `Client` (immutable host/port/token + identity) and the four centralisation
+//! The `Client` (immutable origin/token + identity) and the four centralisation
 //! choke points every op file routes through:
 //!   * `with_token` — the ONLY place `X-Plex-Token` is appended.
 //!   * `enc` / `QueryBuilder` — the ONLY place a value is percent-encoded (via
@@ -15,6 +15,7 @@
 //! Client` is handed out live next door in [`super::servers`] — this file is the type, that
 //! file is the table.
 use super::models::{Envelope, MediaContainer};
+use super::origin::Origin;
 use super::probe::Location;
 use super::servers::ServerId;
 use std::sync::atomic::{AtomicU32, AtomicU8, Ordering::Relaxed};
@@ -24,7 +25,9 @@ const ACCEPT_JSON: &str = "Accept: application/json\r\n";
 
 /// Immutable after construction (apart from the token + its generation, both interior-mutable).
 /// Cheap to share by `&ref` across threads (poster workers, the timeline reporter, the detail
-/// loader all read it). `host` is a numeric dotted-quad — the raw socket does no DNS.
+/// loader all read it). Its address is an [`Origin`] — see the field, and `origin.rs` for why a
+/// `(host, port)` pair could not be the whole of one. Every origin today is `http://` at a numeric
+/// dotted quad, because that is all the raw socket in `crate::stream` speaks: no DNS, no TLS.
 pub struct Client {
     /// This client's slot in the [server registry](super::servers) — a stable handle for the
     /// life of the process, which is what lets a caller name a server without holding a
@@ -35,8 +38,19 @@ pub struct Client {
     /// token)` has only an address to go on, and a later `register` that learns the id adopts
     /// that slot rather than adding a second one for the same server.
     pub(super) machine_id: String,
-    pub(super) host: String,      // e.g. "192.0.2.10" (numeric; passed straight to http_get/http_open)
-    pub(super) port: i32,         // 32400
+    /// **WHERE this server is** — scheme, host and port as one value ([`Origin`]).
+    ///
+    /// It was a `host: String` + `port: i32` pair, and the pair could not say `https`. That was
+    /// not a missing feature so much as a trap: plex.tv advertises a server's TLS origin as the
+    /// `plex.direct` HOSTNAME while its `address` stays the dotted quad behind it, so a client
+    /// carrying only an address can never validate a certificate however much TLS is added
+    /// underneath it. The origin is PARSED from what plex.tv sent — see
+    /// [`super::probe::Candidate::origin`].
+    ///
+    /// Today every one of these is `http://` at a numeric IPv4 address, because that is all
+    /// `crate::stream` speaks. [`Client::host`] and [`Client::port`] still answer exactly what
+    /// they always did, which is why the ~30 call sites below this layer did not move.
+    pub(super) origin: Origin,
     // X-Plex-Token value. Interior-mutable because the token changes at runtime after boot: it's
     // installed once we've logged in, and swapped when the user switches Plex Home profile (same
     // server, different per-user token). Read in exactly one place (`with_token`).
@@ -131,12 +145,11 @@ impl Client {
     /// a registry that constructs a `Client` per server and re-points slots. The registry does
     /// that read once per registration instead, so this constructor touches no filesystem and no
     /// global but the generation counter.
-    pub(super) fn new(id: ServerId, machine_id: &str, host: &str, port: i32, token: &str, client_id: &str) -> Client {
+    pub(super) fn new(id: ServerId, machine_id: &str, origin: Origin, token: &str, client_id: &str) -> Client {
         Client {
             id,
             machine_id: machine_id.to_owned(),
-            host: host.to_owned(),
-            port,
+            origin,
             token: RwLock::new(token.to_owned()),
             client_id: client_id.to_owned(),
             product: super::identity::PRODUCT.into(),
@@ -177,11 +190,18 @@ impl Client {
     pub fn token_gen(&self) -> u32 {
         self.token_gen.load(Relaxed)
     }
+    /// The host to DIAL — never bracketed, even for a v6 literal (see [`Origin::host`]). Unchanged
+    /// in meaning and in bytes from when this was a plain field.
     pub fn host(&self) -> &str {
-        &self.host
+        self.origin.host()
     }
     pub fn port(&self) -> i32 {
-        self.port
+        self.origin.port()
+    }
+    /// **Where this server is, whole** — the value to pass on rather than re-deriving a pair from
+    /// [`Client::host`] and [`Client::port`], which cannot carry the scheme.
+    pub fn origin(&self) -> &Origin {
+        &self.origin
     }
     /// This client's registry slot — pass it to [`super::servers::client_for`] to get back a
     /// `&'static Client` from anywhere.
@@ -198,7 +218,7 @@ impl Client {
     /// until someone does, [`Client::link`] is `None` and playback policy is unrestricted.
     ///
     /// **ORDER MATTERS: register the address FIRST, then set the link on the client you get back**
-    /// (`let id = register(mid, host, port, tok); client_for(id).unwrap().set_link(l);`). A
+    /// (`let id = register_origin(mid, &o, tok); client_for(id).unwrap().set_link(l);`). A
     /// `register` whose address differs RE-POINTS the slot — it publishes a fresh `Client`, which
     /// starts at `LINK_UNKNOWN` — so a tier set before that call is simply gone, and the policy
     /// silently reverts to unrestricted. That reset is deliberate rather than a wart: an address
@@ -219,13 +239,13 @@ impl Client {
     /// GET → parse the `{ "MediaContainer": … }` envelope into the flat container.
     pub(super) fn get_json(&self, path_no_token: &str) -> Option<MediaContainer> {
         let path = self.with_token(path_no_token);
-        let body = crate::stream::http_get(&self.host, self.port, &path, Some(ACCEPT_JSON))?;
+        let body = crate::stream::http_get(self.host(), self.port(), &path, Some(ACCEPT_JSON))?;
         serde_json::from_slice::<Envelope>(&body).ok().map(|e| e.media_container)
     }
 
     /// GET raw bytes (image transcode / sidecar sub) — caller decodes.
     pub(super) fn get_bytes(&self, path_no_token: &str) -> Option<Vec<u8>> {
-        crate::stream::http_get(&self.host, self.port, &self.with_token(path_no_token), None)
+        crate::stream::http_get(self.host(), self.port(), &self.with_token(path_no_token), None)
     }
 
     /// GET raw bytes for a path this server ALREADY BUILT — the one entry point that does **not**
@@ -242,12 +262,12 @@ impl Client {
     /// The token is therefore in the CALLER's string. It must not be logged — the poster store
     /// logs no keys, and neither may anything else that holds one.
     pub(crate) fn fetch_built(&self, path_with_token: &str) -> Option<Vec<u8>> {
-        crate::stream::http_get(&self.host, self.port, path_with_token, None)
+        crate::stream::http_get(self.host(), self.port(), path_with_token, None)
     }
 
     /// GET whose body is discarded (transcode decision / stop registration side effects).
     pub(super) fn get_void(&self, path_no_token: &str) {
-        let _ = crate::stream::http_get(&self.host, self.port, &self.with_token(path_no_token), None);
+        let _ = crate::stream::http_get(self.host(), self.port(), &self.with_token(path_no_token), None);
     }
 
     /// [`Client::get_void`], but reporting whether the request actually reached the server and came
@@ -256,12 +276,12 @@ impl Client {
     /// timed-out connect as much as a rejected status, which is the distinction that matters here:
     /// a share that is asleep answers nothing at all.
     pub(super) fn get_ok(&self, path_no_token: &str) -> bool {
-        crate::stream::http_get(&self.host, self.port, &self.with_token(path_no_token), None).is_some()
+        crate::stream::http_get(self.host(), self.port(), &self.with_token(path_no_token), None).is_some()
     }
 
     /// PUT (no body) — returns the HTTP status (all `select_streams` reads).
     pub(super) fn put(&self, path_no_token: &str) -> i32 {
-        crate::stream::http_put(&self.host, self.port, &self.with_token(path_no_token))
+        crate::stream::http_put(self.host(), self.port(), &self.with_token(path_no_token))
     }
 
     /// POST whose body carries nothing to read — /:/timeline (spec verb; params ride the query
@@ -277,13 +297,13 @@ impl Client {
     /// timeline is the only body-less POST in the layer, so a twin that dropped the outcome would
     /// be a method with no callers.
     pub(super) fn post_ok(&self, path_no_token: &str) -> bool {
-        crate::stream::http_post(&self.host, self.port, &self.with_token(path_no_token), None).is_some()
+        crate::stream::http_post(self.host(), self.port(), &self.with_token(path_no_token), None).is_some()
     }
 
     /// POST → parse the `{ "MediaContainer": … }` envelope — /playQueues (the returned ids).
     pub(super) fn post_json(&self, path_no_token: &str) -> Option<MediaContainer> {
         let path = self.with_token(path_no_token);
-        let body = crate::stream::http_post(&self.host, self.port, &path, Some(ACCEPT_JSON))?;
+        let body = crate::stream::http_post(self.host(), self.port(), &path, Some(ACCEPT_JSON))?;
         serde_json::from_slice::<Envelope>(&body).ok().map(|e| e.media_container)
     }
 
@@ -357,40 +377,49 @@ impl QueryBuilder {
 // ---- StreamUrl — the streaming return type ----
 
 /// A built playback target for the raw demux/cue sockets. NOT a fetched response — the player
-/// passes these three fields straight to `crate::stream::http_open`. Range headers for seeks
+/// passes its origin and path straight to `crate::stream::http_open`. Range headers for seeks
 /// are added by the player as `http_open`'s `extra`, never by this layer. `path` includes the
 /// `?query&X-Plex-Token`.
 pub struct StreamUrl {
-    pub host: String,
-    pub port: i32,
+    /// Where the bytes come from ([`Origin`]) — copied from the [`Client`] that built this, so a
+    /// stream target can never disagree with the control plane about which scheme, host and port
+    /// it means.
+    pub origin: Origin,
     pub path: String,
 }
 
 impl StreamUrl {
-    /// The full `http://host:port/path?…` form — what `route` stores as the playback URL
+    /// The full `{scheme}://{authority}{path}` form — what `route` stores as the playback URL
     /// (the engine later splits it back with [`StreamUrl::parse`]).
+    ///
+    /// Byte-identical to the `format!("http://{host}:{port}{path}")` it replaced for every origin
+    /// this app builds today, and correct for the two shapes that spelling could not express: an
+    /// https origin, and a v6 literal (which must be BRACKETED in a URL and BARE at the resolver
+    /// — see [`Origin`]).
     pub fn to_url(&self) -> String {
-        format!("http://{}:{}{}", self.host, self.port, self.path)
+        format!("{}{}", self.origin.base(), self.path)
     }
 
-    /// Parse an EXTERNAL full URL (the /tmp/plxnative-url override) back into parts —
-    /// replaces `player::engine::parse_stream_url` (same behavior: default port 32400).
+    /// Parse an EXTERNAL full URL (the `/tmp/plxnative-url` override) back into parts —
+    /// replaces `player::engine::parse_stream_url`.
+    ///
+    /// **Total**, because its caller has no failure path: a garbage override has to come back as
+    /// *something* to fail on at `http_open`. That is why it goes through [`super::origin::split`]
+    /// rather than [`Origin::parse`] — the defaults are the ones this function has always had (no
+    /// scheme means `http`, no port means 32400), and an undialable port becomes the default
+    /// instead of wrapping into one nobody wrote down.
     pub fn parse(url: &str) -> StreamUrl {
-        let s = url.strip_prefix("http://").unwrap_or(url);
-        let he = s.find(|c| c == ':' || c == '/').unwrap_or(s.len());
-        let (host, rest) = (s[..he].to_string(), &s[he..]);
-        if let Some(r) = rest.strip_prefix(':') {
-            let pe = r.find('/').unwrap_or(r.len());
-            let port = r[..pe].parse().unwrap_or(32400);
-            let path = if pe < r.len() { r[pe..].into() } else { "/".into() };
-            StreamUrl { host, port, path }
-        } else {
-            StreamUrl {
-                host,
-                port: 32400,
-                path: if rest.is_empty() { "/".into() } else { rest.into() },
-            }
-        }
+        let (origin, path) = super::origin::split(url);
+        StreamUrl { origin, path: if path.is_empty() { "/".into() } else { path.into() } }
+    }
+
+    /// The host to DIAL — bare, never bracketed. `crate::stream` takes this; a URL takes
+    /// [`StreamUrl::to_url`].
+    pub fn host(&self) -> &str {
+        self.origin.host()
+    }
+    pub fn port(&self) -> i32 {
+        self.origin.port()
     }
 }
 
@@ -399,7 +428,7 @@ mod tests {
     use super::*;
 
     fn a_client(machine: &str, token: &str) -> Client {
-        Client::new(ServerId::from_raw(3), machine, "10.0.0.1", 32400, token, "cid-42")
+        Client::new(ServerId::from_raw(3), machine, Origin::http("10.0.0.1", 32400), token, "cid-42")
     }
 
     /// A `Client` is one server's identity plus its token, and every piece of it now arrives
@@ -410,6 +439,7 @@ mod tests {
     fn a_client_carries_the_identity_it_was_built_with() {
         let c = a_client("mach-A", "tok-a");
         assert_eq!((c.host(), c.port()), ("10.0.0.1", 32400));
+        assert_eq!(c.origin().base(), "http://10.0.0.1:32400", "…and those two are one value now");
         assert_eq!(c.machine_id(), "mach-A");
         assert_eq!(c.id(), ServerId::from_raw(3));
         // the token choke point picks the right separator either way
@@ -421,7 +451,7 @@ mod tests {
             .build()
             .contains("X-Plex-Client-Identifier=cid-42"));
         // a client built outside the registry says so rather than claiming slot 0
-        assert!(!Client::new(ServerId::UNSET, "", "1.2.3.4", 32400, "t", "cid").id().is_set());
+        assert!(!Client::new(ServerId::UNSET, "", Origin::http("1.2.3.4", 32400), "t", "cid").id().is_set());
     }
 
     /// A fresh client knows nothing about how it is reached, and says so rather than guessing a
@@ -455,5 +485,65 @@ mod tests {
         assert_eq!(a.with_token("/x"), "/x?X-Plex-Token=tok-a2");
         assert_ne!(a.token_gen(), ga, "the swapped client's generation moved");
         assert_eq!(b.token_gen(), gb, "the other client's did not");
+    }
+
+    /// **A client's ORIGIN is the whole address; `host()`/`port()` are views on it.** Those two
+    /// accessors are what ~30 call sites below this layer read, so they must keep answering
+    /// exactly what they did as plain fields — including for the shapes the pair could not spell.
+    #[test]
+    fn a_clients_host_and_port_are_views_on_its_origin() {
+        let tls = Origin::parse("https://nas.hash.plex.direct:32400").expect("parses");
+        let c = Client::new(ServerId::UNSET, "m", tls, "t", "cid");
+        assert_eq!(c.host(), "nas.hash.plex.direct", "the NAME a certificate is validated against");
+        assert_eq!(c.port(), 32400);
+        assert!(c.origin().is_tls());
+
+        // a v6 origin: bare at the resolver, bracketed in a URL. `host()` is the resolver's half.
+        let v6 = Client::new(ServerId::UNSET, "m", Origin::http("2001:db8::1", 32400), "t", "cid");
+        assert_eq!(v6.host(), "2001:db8::1");
+        assert_eq!(v6.origin().authority(), "[2001:db8::1]:32400");
+    }
+
+    /// `StreamUrl`'s two halves answer two different questions: [`StreamUrl::to_url`] is what
+    /// `route` STORES (a URL string) and [`StreamUrl::host`] is what `crate::stream` DIALS. The
+    /// engine really does round-trip the stored string through [`StreamUrl::parse`], so that trip
+    /// is graded rather than assumed — and the `to_url` bytes are pinned, because a change there
+    /// is a change to every playback URL in the app.
+    #[test]
+    fn a_stream_url_round_trips_through_the_string_route_stores() {
+        let su = StreamUrl { origin: Origin::http("10.0.0.1", 32400), path: "/library/parts/9?X-Plex-Token=t".into() };
+        assert_eq!(su.to_url(), "http://10.0.0.1:32400/library/parts/9?X-Plex-Token=t");
+
+        let back = StreamUrl::parse(&su.to_url());
+        assert_eq!((back.host(), back.port()), ("10.0.0.1", 32400));
+        assert_eq!(back.path, su.path);
+        assert_eq!(back.to_url(), su.to_url());
+    }
+
+    /// The two shapes `StreamUrl` could not previously express. Nothing calls it with either yet —
+    /// they are here so the transport lane inherits a splitter that is already right, and so the
+    /// v6 case cannot regress to the old reading, which took `[` as the entire host.
+    #[test]
+    fn a_stream_url_understands_https_and_a_bracketed_v6_literal() {
+        let s = StreamUrl::parse("https://nas.hash.plex.direct:32400/video/x?a=1");
+        assert!(s.origin.is_tls());
+        assert_eq!((s.host(), s.port(), s.path.as_str()), ("nas.hash.plex.direct", 32400, "/video/x?a=1"));
+        assert_eq!(s.to_url(), "https://nas.hash.plex.direct:32400/video/x?a=1");
+
+        let v6 = StreamUrl::parse("http://[2001:db8::1]:32400/p");
+        assert_eq!(v6.host(), "2001:db8::1", "the resolver never sees the brackets");
+        assert_eq!(v6.to_url(), "http://[2001:db8::1]:32400/p", "…and the URL always carries them");
+    }
+
+    /// The defaults `player::engine::parse_stream_url` had and this inherited: no scheme means
+    /// http, no port means 32400, and no path at all means `/` — a bare host is a request for the
+    /// server's root, not for the empty string. The `/tmp/plxnative-url` override is written by
+    /// hand, so all three are reachable.
+    #[test]
+    fn a_stream_url_keeps_the_defaults_the_override_trigger_relies_on() {
+        let bare = StreamUrl::parse("192.0.2.10");
+        assert_eq!((bare.host(), bare.port(), bare.path.as_str()), ("192.0.2.10", 32400, "/"));
+        assert_eq!(StreamUrl::parse("192.0.2.10/x").port(), 32400);
+        assert_eq!(StreamUrl::parse("http://192.0.2.10:8020/f.mkv").port(), 8020);
     }
 }

--- a/rust-modules/src/plex/library.rs
+++ b/rust-modules/src/plex/library.rs
@@ -216,7 +216,7 @@ impl Client {
     pub fn direct_play_url(&self, part_key: &str, session: &str) -> StreamUrl {
         let q = QueryBuilder::new(part_key).str("X-Plex-Session-Identifier", session);
         let path = self.playback_identity(q).build();
-        StreamUrl { host: self.host.clone(), port: self.port, path: self.with_token(&path) }
+        StreamUrl { origin: self.origin.clone(), path: self.with_token(&path) }
     }
 }
 

--- a/rust-modules/src/plex/mod.rs
+++ b/rust-modules/src/plex/mod.rs
@@ -44,6 +44,13 @@ pub(crate) mod serverinfo;
 pub(crate) mod account;
 pub(crate) mod session;
 
+// WHERE a server is, as one value: scheme + host + port, parsed from a URL and never assembled
+// from an address. The type every layer below the transport passes instead of a bare
+// `(host, port)` pair — read its module doc before adding a call site, in particular the bracket
+// invariant that keeps `host()` (the resolver's node) and `authority()` (URL serialization) from
+// being confused for one another.
+pub(crate) mod origin;
+
 // Which of a server's advertised addresses are worth dialling, and in what order. PURE policy over
 // an `account::Resource` — no socket, no thread — so the rules that decide reachability are gradeable
 // on the host, which is the only tier that can grade them at all: the failures they prevent are an
@@ -63,14 +70,19 @@ pub(crate) mod discover;
 // The re-exports are the public surface the call sites import.
 #[allow(unused_imports)]
 pub use client::{Client, StreamUrl};
+// WHERE a server is, as one value. `Origin` is what `register_origin`/`install` take and what a
+// `Client` carries; `Scheme` is re-exported beside it because `dev::DevServer` deserializes one
+// straight out of the `plxnative-servers` trigger.
+#[allow(unused_imports)]
+pub use origin::{Origin, Scheme};
 // The registry surface. `client`/`client_opt`/`install` keep the exact signatures they had as
 // singleton accessors, so every call site outside `plex/` reads unchanged; `client_for`,
 // `register`, `set_current` and `ServerId` are the multi-server additions.
 #[allow(unused_imports)]
 pub use servers::{
     client, client_for, client_opt, count as server_count, current as current_server, describe as describe_server,
-    describe_name as describe_server_name, facts as server_facts, ids as server_ids, install, register, same_item,
-    set_current, ServerFacts, ServerId, MAX_SERVERS,
+    describe_name as describe_server_name, facts as server_facts, ids as server_ids, install, register, register_origin,
+    same_item, set_current, ServerFacts, ServerId, MAX_SERVERS,
 };
 // Sign-out. `pub(crate)` like the function itself: retiring the whole table is `auth::sign_out`'s
 // to call and nothing else's — a caller that merely wants to stop using a server wants

--- a/rust-modules/src/plex/origin.rs
+++ b/rust-modules/src/plex/origin.rs
@@ -1,0 +1,375 @@
+//! **Where a server is, as one value: scheme + host + port.** The type every layer below the
+//! transport passes around instead of a bare `(host, port)` pair.
+//!
+//! ## Why this type exists at all
+//!
+//! This app can currently reach exactly one shape of server: **plaintext HTTP at a numeric IPv4
+//! address**. `stream.rs` builds a `sockaddr_in` out of four decimal octets and speaks cleartext;
+//! there is no resolver and no TLS in it. So `(host, port)` was a complete description of a server,
+//! and every layer — the registry, the session file, the login flow, the stream URLs — carried
+//! those two values and nothing else.
+//!
+//! It is not a complete description of the servers plex.tv actually advertises, and the gap is not
+//! cosmetic. [`super::probe`] builds ranked candidates from an account's `/api/v2/resources`, and
+//! the one field that says where a candidate really is is [`Candidate::url`](super::probe::Candidate::url)
+//! — **not** `Candidate::address`. plex.tv advertises the `plex.direct` HOSTNAME in `uri` while
+//! `address` stays the dotted quad hiding behind it, and `probe`'s own doc says outright that
+//! "https to the bare IP fails validation by design": the certificate is issued for
+//! `203-0-113-9.hash.plex.direct`, so a TLS connection made to `203.0.113.9` fails hostname
+//! validation however well the packets flow. An origin rebuilt from `address` therefore *looks*
+//! like it speaks TLS and cannot: it is exactly the bug this type is here to make unwriteable.
+//!
+//! **So an `Origin` is PARSED from a URL, never assembled from an address.** [`Origin::parse`] is
+//! the front door, [`super::probe::Candidate::origin`] is the one that matters, and
+//! [`Origin::http`] is the deliberately-named plaintext constructor — every remaining caller of
+//! *that* is a place that still assumes cleartext, and `Origin::http(` is the grep that finds them.
+//!
+//! ## The bracket rule, which is an invariant and not a detail
+//!
+//! A v6 address appears in two different spellings and they are not interchangeable:
+//!
+//! * **`getaddrinfo` takes the BARE literal** — `::1`. Hand it `[::1]` and resolution fails.
+//! * **A URL takes the BRACKETED form** — `[::1]:32400`. Without the brackets the port colon is
+//!   indistinguishable from an address group, and `http://::1:32400` names nothing.
+//!
+//! [`Origin::host`] is therefore **always unbracketed** (it is the resolver's node argument) and
+//! [`Origin::authority`] is **always bracket-correct** (it is URL serialization). Anything that
+//! dials calls `host()`; anything that builds a URL calls `authority()` or [`Origin::base`]. The
+//! round trip `http://[::1]:32400` → `host() == "::1"` → `authority() == "[::1]:32400"` →
+//! `base() == "http://[::1]:32400"` is pinned by a test, because the failure mode without it is
+//! silent: URL construction keeps looking right while name resolution quietly stops working.
+//!
+//! ## This is a PMS origin parser, not a general URL parser
+//!
+//! Two deliberate narrowings, both because every origin in this app is a Plex server's:
+//!
+//! * **The default port is 32400**, not 80/443. It is what `StreamUrl::parse` has always defaulted
+//!   to, and a PMS with no port in its URL is a PMS on the default port.
+//! * **Only `http` and `https` are recognised.** [`Origin::parse`] refuses anything else rather
+//!   than inventing a meaning for it.
+use super::probe::dial_port;
+
+/// Which transport an origin names. Lives here rather than in [`super::probe`] because it is a
+/// property of an ORIGIN; probe merely *ranks* it, and re-exports this type for that.
+///
+/// **Ordered best-first FOR THIS APP, which is not best-first in general**, and the derived `Ord`
+/// *is* that preference: `stream.rs` speaks plain HTTP to a dotted quad with no DNS and no TLS, so
+/// an https `plex.direct` origin cannot be dialled at all until the curl control plane lands
+/// (`docs/shared-servers.md` §5 step 6). Ranking https below http keeps
+/// [`super::probe::candidates`]'s order equal to what can actually connect today; when TLS exists,
+/// swapping these two declarations is the whole change.
+///
+/// `Default` is [`Scheme::Http`] — the scheme this app has always spoken, and what a session file
+/// or a dev trigger written before schemes existed meant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Scheme {
+    #[default]
+    Http,
+    Https,
+}
+
+impl Scheme {
+    /// The wire spelling, and the one used to serialize an origin.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Scheme::Http => "http",
+            Scheme::Https => "https",
+        }
+    }
+    /// Does this scheme require a TLS handshake — and therefore a certificate whose name must
+    /// match [`Origin::host`]?
+    pub fn is_tls(self) -> bool {
+        self == Scheme::Https
+    }
+}
+
+/// The port a PMS origin means when its URL names none. See the module doc: 32400, not 80/443.
+pub const DEFAULT_PORT: i32 = 32400;
+
+/// **One server's address, completely.** Scheme, host and port — no path, no query, no trailing
+/// slash. See the module doc for the bracket invariant on [`Origin::host`] vs [`Origin::authority`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Origin {
+    scheme: Scheme,
+    /// **Always UNBRACKETED**, even for a v6 literal — this is the `getaddrinfo` node argument.
+    host: String,
+    /// Always `1..=65535`: every constructor here goes through [`dial_port`] or takes an
+    /// already-narrowed `i32`, so nothing downstream has to re-check it.
+    port: i32,
+}
+
+impl Origin {
+    /// Build an origin from parts. `host` may arrive bracketed (that is what
+    /// [`super::probe`]'s `host_of` returns) and is stored bare regardless.
+    pub fn new(scheme: Scheme, host: &str, port: i32) -> Origin {
+        Origin { scheme, host: unbracket(host).to_owned(), port }
+    }
+
+    /// The **plaintext** constructor, named so that it is greppable.
+    ///
+    /// Every call is a place that still assumes cleartext — the legacy `(host, port)` registry
+    /// entry points, the compiled-in PMS host, a session file with no stored origin. That is
+    /// correct today (there is no TLS transport) and each one is a line the TLS lane has to
+    /// revisit, which is why they are spelled `Origin::http(` rather than
+    /// `Origin::new(Scheme::Http, …)`.
+    pub fn http(host: &str, port: i32) -> Origin {
+        Origin::new(Scheme::Http, host, port)
+    }
+
+    /// Parse an origin out of a URL — **the front door**, and the only way an https origin can
+    /// ever come into existence, because the hostname TLS validates against exists nowhere but the
+    /// URL (module doc).
+    ///
+    /// `None` when there is no host, when the scheme is one this app does not speak, or when a
+    /// port is written and is not dialable ([`dial_port`]). A path is ignored: an origin is the
+    /// prefix, and [`split`] is the entry point for a caller that wants the rest of the URL too.
+    ///
+    /// A MISSING scheme is read as `http`. That is not laxity for its own sake — it is what
+    /// `StreamUrl::parse` has always done with the `/tmp/plxnative-url` override, and this
+    /// function replaced that parser.
+    pub fn parse(url: &str) -> Option<Origin> {
+        let p = Parts::of(url);
+        (p.scheme_known && !p.host.is_empty() && !p.port_bad)
+            .then(|| Origin::new(p.scheme, p.host, p.port.unwrap_or(DEFAULT_PORT)))
+    }
+
+    pub fn scheme(&self) -> Scheme {
+        self.scheme
+    }
+    /// Does reaching this origin need a TLS handshake? The one question a transport asks.
+    pub fn is_tls(&self) -> bool {
+        self.scheme.is_tls()
+    }
+    /// **The resolver's node argument — never bracketed**, even for a v6 literal. Also the name a
+    /// TLS certificate must match. See the module doc.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+    pub fn port(&self) -> i32 {
+        self.port
+    }
+    /// **URL serialization — `host:port`, bracketing a v6 literal.** The other half of the
+    /// bracket invariant: this is what goes in a URL, `host()` is what goes to the resolver.
+    pub fn authority(&self) -> String {
+        if is_v6_literal(&self.host) {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+    /// `"{scheme}://{authority}"` — no trailing slash, no path. Round-trips through
+    /// [`Origin::parse`], and is the form persisted in the session file.
+    pub fn base(&self) -> String {
+        format!("{}://{}", self.scheme.as_str(), self.authority())
+    }
+}
+
+/// Split a URL into its origin and the rest of it (path + query, `""` when there is none).
+///
+/// **Total**, unlike [`Origin::parse`], because its caller is `StreamUrl::parse` — which turns the
+/// `/tmp/plxnative-url` override into something to dial and has no failure path to take. Every
+/// degenerate input therefore yields *something*: a missing scheme reads as `http`, an unknown one
+/// is discarded rather than mistaken for a host, and a port that is absent or undialable becomes
+/// [`DEFAULT_PORT`] rather than wrapping into a port nobody wrote down (which is
+/// [`dial_port`]'s reason for existing, one step downstream).
+pub fn split(url: &str) -> (Origin, &str) {
+    let p = Parts::of(url);
+    (Origin::new(p.scheme, p.host, p.port.unwrap_or(DEFAULT_PORT)), p.path)
+}
+
+/// The HOST of a URL, **bare** — a borrowed view for a caller that only wants to look at the host
+/// and has no use for an owned [`Origin`].
+///
+/// Its one caller is [`super::probe`]'s ranking, which asks whether a candidate's host is a numeric
+/// literal or a name that needs resolving — and it must ask that of the URL's host and **not** of
+/// [`Candidate::address`](super::probe::Candidate::address), which is the dotted quad hiding behind
+/// a `plex.direct` NAME. This lives here so that there is exactly one reading of a URL in the
+/// codebase; probe used to carry a second copy of it.
+pub fn url_host(url: &str) -> &str {
+    Parts::of(url).host
+}
+
+/// The raw reading of a URL, before any policy is applied to it. Two callers with two different
+/// tolerances ([`Origin::parse`] refuses what [`split`] papers over), so the reading and the
+/// judgement are separate.
+struct Parts<'a> {
+    scheme: Scheme,
+    /// `false` when the URL named a scheme that is neither `http` nor `https`.
+    scheme_known: bool,
+    /// Unbracketed already.
+    host: &'a str,
+    /// `None` when the URL wrote no port at all.
+    port: Option<i32>,
+    /// `true` when a port WAS written and is not dialable — the case that must not silently
+    /// become [`DEFAULT_PORT`] for a caller that can refuse.
+    port_bad: bool,
+    path: &'a str,
+}
+
+impl<'a> Parts<'a> {
+    fn of(url: &'a str) -> Parts<'a> {
+        let (scheme, scheme_known, rest) = match url.split_once("://") {
+            Some(("http", r)) => (Scheme::Http, true, r),
+            Some(("https", r)) => (Scheme::Https, true, r),
+            // A scheme we do not speak. The authority is still readable, so `split` can go on;
+            // `parse` refuses on `scheme_known`.
+            Some((_, r)) => (Scheme::Http, false, r),
+            None => (Scheme::Http, true, url),
+        };
+        // The authority ends at the first `/` — everything from there is the path. A `?` with no
+        // `/` before it is not a shape any URL this app builds takes, and treating it as part of
+        // the host would be no worse than treating it as a path.
+        let (auth, path) = match rest.find('/') {
+            Some(i) => (&rest[..i], &rest[i..]),
+            None => (rest, ""),
+        };
+        // A bracketed v6 literal carries its own colons, so the port separator is the one AFTER
+        // the closing bracket — this is exactly the reading `probe::host_of` does, except that it
+        // keeps the brackets (an authority) where we drop them (a resolver node).
+        let (host, port_txt) = match auth.strip_prefix('[').and_then(|r| r.split_once(']')) {
+            Some((h, after)) => (h, after.strip_prefix(':')),
+            None => match auth.split_once(':') {
+                Some((h, p)) => (h, Some(p)),
+                None => (auth, None),
+            },
+        };
+        // `dial_port`, not a bare `parse::<i32>()`: this is the same narrowing every advertised
+        // port in this layer goes through, and it is what stops `4294999696` from wrapping to a
+        // plausible-looking 32400.
+        let port = port_txt.and_then(|t| t.parse::<i64>().ok()).and_then(dial_port);
+        Parts {
+            scheme,
+            scheme_known,
+            host,
+            port,
+            port_bad: port_txt.is_some_and(|t| !t.is_empty()) && port.is_none(),
+            path,
+        }
+    }
+}
+
+/// Strip the brackets a URL authority puts around a v6 literal, if they are there.
+fn unbracket(host: &str) -> &str {
+    host.strip_prefix('[').and_then(|r| r.strip_suffix(']')).unwrap_or(host)
+}
+
+/// Is this bare host a v6 literal — i.e. does it need bracketing before it can carry a port?
+/// A colon cannot appear in a hostname or in a dotted quad, so one colon is the whole test.
+fn is_v6_literal(host: &str) -> bool {
+    host.contains(':')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The bracket invariant, as a round trip.** `host()` is the resolver's node and is bare;
+    /// `authority()` is URL serialization and is bracketed; `base()` reproduces the input exactly.
+    ///
+    /// Without this the failure is silent in the worst direction: every URL the app *builds* keeps
+    /// looking correct while `getaddrinfo` is handed `[::1]` and quietly resolves nothing.
+    #[test]
+    fn a_v6_origin_is_bare_for_the_resolver_and_bracketed_for_a_url() {
+        let o = Origin::parse("http://[::1]:32400").expect("a bracketed v6 origin parses");
+        assert_eq!(o.host(), "::1", "the getaddrinfo node is NEVER bracketed");
+        assert_eq!(o.authority(), "[::1]:32400", "…and a URL authority always is");
+        assert_eq!(o.base(), "http://[::1]:32400", "so the round trip is byte-identical");
+        assert_eq!(o.port(), 32400);
+
+        // and the same holds for an origin built from parts, whichever spelling the caller has
+        assert_eq!(Origin::http("[2001:db8::1]", 32400), Origin::http("2001:db8::1", 32400));
+        assert_eq!(Origin::http("2001:db8::1", 32400).authority(), "[2001:db8::1]:32400");
+        assert_eq!(Origin::http("2001:db8::1", 32400).base(), "http://[2001:db8::1]:32400");
+    }
+
+    /// A v4 origin is the case every line of this app takes today, and it must serialize to
+    /// exactly the bytes it always has — no brackets, no default port appearing from nowhere.
+    #[test]
+    fn a_v4_origin_round_trips_unchanged() {
+        let o = Origin::parse("http://192.0.2.10:32400").expect("parses");
+        assert_eq!((o.scheme(), o.host(), o.port()), (Scheme::Http, "192.0.2.10", 32400));
+        assert_eq!(o.authority(), "192.0.2.10:32400");
+        assert_eq!(o.base(), "http://192.0.2.10:32400");
+        assert!(!o.is_tls());
+    }
+
+    /// **The whole reason this type is parsed and not assembled**: an https `plex.direct` origin
+    /// keeps the NAME, which is what the certificate is issued for. Rebuilding it from the dotted
+    /// quad behind that name gives a URL that connects and fails validation.
+    #[test]
+    fn an_https_origin_keeps_the_name_tls_validates_against() {
+        let o = Origin::parse("https://203-0-113-9.hash.plex.direct:31234").expect("parses");
+        assert_eq!(o.scheme(), Scheme::Https);
+        assert!(o.is_tls());
+        assert_eq!(o.host(), "203-0-113-9.hash.plex.direct");
+        assert_eq!(o.base(), "https://203-0-113-9.hash.plex.direct:31234");
+    }
+
+    /// The defaults, each one a behaviour `StreamUrl::parse` has always had and must keep.
+    #[test]
+    fn a_missing_scheme_is_http_and_a_missing_port_is_the_pms_default() {
+        let o = Origin::parse("192.0.2.10").expect("a bare host is an origin");
+        assert_eq!((o.scheme(), o.host(), o.port()), (Scheme::Http, "192.0.2.10", DEFAULT_PORT));
+        assert_eq!(Origin::parse("https://nas.example.com").unwrap().port(), DEFAULT_PORT);
+    }
+
+    /// A path is not part of an origin — `base()` never grows one, whatever came in.
+    #[test]
+    fn a_path_is_not_part_of_the_origin() {
+        assert_eq!(Origin::parse("http://192.0.2.10:32400/library/sections?x=1").unwrap().base(), "http://192.0.2.10:32400");
+        assert_eq!(Origin::parse("http://192.0.2.10:32400/").unwrap().base(), "http://192.0.2.10:32400");
+    }
+
+    /// What [`Origin::parse`] refuses. Each of these has a caller that would otherwise dial
+    /// something nobody named.
+    #[test]
+    fn parse_refuses_what_cannot_be_dialled() {
+        assert_eq!(Origin::parse(""), None, "no host at all");
+        assert_eq!(Origin::parse("http://"), None);
+        assert_eq!(Origin::parse("ftp://h:21"), None, "a scheme this app does not speak");
+        // The port narrowing that `dial_port` exists for: plex.tv and the session file both
+        // string-encode numbers, so an out-of-range one is a shape that really arrives — and
+        // `4_294_999_696 as i32` is 32400, a port nobody advertised.
+        assert_eq!(Origin::parse("http://192.0.2.10:4294999696"), None);
+        assert_eq!(Origin::parse("http://192.0.2.10:0"), None);
+        assert_eq!(Origin::parse("http://192.0.2.10:70000"), None);
+        assert_eq!(Origin::parse("http://192.0.2.10:abc"), None);
+    }
+
+    /// [`split`] is the TOTAL sibling — its caller has no failure path — so the same inputs that
+    /// [`Origin::parse`] refuses still come back as something, with the port defaulted rather than
+    /// wrapped.
+    #[test]
+    fn split_is_total_and_hands_back_the_path() {
+        let (o, p) = split("http://192.0.2.10:32400/video/:/transcode/universal/start.mkv?a=1");
+        assert_eq!(o.base(), "http://192.0.2.10:32400");
+        assert_eq!(p, "/video/:/transcode/universal/start.mkv?a=1");
+
+        assert_eq!(split("192.0.2.10").0.base(), "http://192.0.2.10:32400");
+        assert_eq!(split("192.0.2.10").1, "", "no path is an empty path, not a slash");
+        assert_eq!(split("http://192.0.2.10:70000/x").0.port(), DEFAULT_PORT, "undialable → the default");
+        assert_eq!(split("https://[2001:db8::1]:8443/y").0.base(), "https://[2001:db8::1]:8443");
+        assert_eq!(split("https://[2001:db8::1]:8443/y").1, "/y");
+    }
+
+    /// [`url_host`] is the borrowed reading `probe`'s ranking uses, and it must give the URL's own
+    /// host — the `plex.direct` NAME — not the address behind it.
+    #[test]
+    fn url_host_reads_the_urls_own_host_without_scheme_or_port() {
+        assert_eq!(url_host("http://203.0.113.9:31234"), "203.0.113.9");
+        assert_eq!(url_host("https://media.example.internal:31234"), "media.example.internal");
+        assert_eq!(url_host("http://[2001:db8::1]:32400"), "2001:db8::1", "the port is not a v6 group");
+        assert_eq!(url_host("https://203-0-113-9.hash2.plex.direct:31234"), "203-0-113-9.hash2.plex.direct");
+    }
+
+    /// The scheme's wire spelling is what `base()` is built from and what a dev trigger writes,
+    /// so it is pinned rather than left to a `Debug` derive.
+    #[test]
+    fn a_scheme_knows_its_wire_spelling_and_whether_it_needs_tls() {
+        assert_eq!((Scheme::Http.as_str(), Scheme::Https.as_str()), ("http", "https"));
+        assert!(!Scheme::Http.is_tls() && Scheme::Https.is_tls());
+        assert_eq!(Scheme::default(), Scheme::Http, "the scheme this app has always spoken");
+        assert!(Scheme::Http < Scheme::Https, "probe RANKS on this order — http is what can be dialled today");
+    }
+}

--- a/rust-modules/src/plex/origin.rs
+++ b/rust-modules/src/plex/origin.rs
@@ -94,8 +94,14 @@ pub struct Origin {
     scheme: Scheme,
     /// **Always UNBRACKETED**, even for a v6 literal — this is the `getaddrinfo` node argument.
     host: String,
-    /// Always `1..=65535`: every constructor here goes through [`dial_port`] or takes an
-    /// already-narrowed `i32`, so nothing downstream has to re-check it.
+    /// The port to dial.
+    ///
+    /// **Read this as "the transport's argument", not as "a validated port".** [`Origin::parse`]
+    /// narrows through [`dial_port`], so anything read out of a URL is in `1..=65535` — but
+    /// [`Origin::new`] and [`Origin::http`] take the caller's `i32` as given, and one caller has an
+    /// `i64` from a file to cast first: `session::ServerRef::origin`'s legacy fallback, which is
+    /// total by design and gated by `Session::can_go_local` instead (its doc says why). The
+    /// narrowing lives in [`dial_port`] and at the gates, not in this field.
     port: i32,
 }
 
@@ -165,6 +171,30 @@ impl Origin {
     pub fn base(&self) -> String {
         format!("{}://{}", self.scheme.as_str(), self.authority())
     }
+
+    /// **How an origin is written in the EVENT LOG** — the authority alone for a plaintext origin,
+    /// the whole base URL for anything else.
+    ///
+    /// The asymmetry is not cosmetic and it is not indecision. The log has said `host:port` since
+    /// before origins existed, and it is the file users paste into issues and the surface every
+    /// headless lane grades a run by — so a plaintext registration must keep reading exactly as it
+    /// always has, or every archived log becomes incomparable with a current one.
+    ///
+    /// The other half is the `[[silent-instrument-trap]]` this project has already paid for once:
+    /// `dev::DevServer`'s `scheme` field exists *specifically* so a lane with no TLS server of its
+    /// own can put an https origin through the registry, and an instrument that cannot see the one
+    /// thing it was armed to test is worse than no instrument. Printing the authority for both
+    /// would make an https run byte-identical to an http one.
+    ///
+    /// It carries no path, no query and no token — the same redaction the address-only lines it
+    /// replaces already observed.
+    pub fn log_form(&self) -> String {
+        if self.scheme == Scheme::Http {
+            self.authority()
+        } else {
+            self.base()
+        }
+    }
 }
 
 /// Split a URL into its origin and the rest of it (path + query, `""` when there is none).
@@ -203,8 +233,14 @@ struct Parts<'a> {
     host: &'a str,
     /// `None` when the URL wrote no port at all.
     port: Option<i32>,
-    /// `true` when a port WAS written and is not dialable — the case that must not silently
-    /// become [`DEFAULT_PORT`] for a caller that can refuse.
+    /// `true` when a `:` was written and what follows it is not a dialable port — the case that
+    /// must not silently become [`DEFAULT_PORT`] for a caller that can refuse.
+    ///
+    /// **An EMPTY port counts.** `http://192.0.2.10:` is a truncated write or a half-finished hand
+    /// edit, not a request for the default, and reading it as one is exactly the "dial a port
+    /// nobody wrote down" outcome [`dial_port`] exists to prevent. RFC 3986 would let an empty port
+    /// mean the default; this is a PMS origin parser reading a file that can be corrupt, and the
+    /// two want opposite answers.
     port_bad: bool,
     path: &'a str,
 }
@@ -246,7 +282,7 @@ impl<'a> Parts<'a> {
             scheme_known,
             host,
             port,
-            port_bad: port_txt.is_some_and(|t| !t.is_empty()) && port.is_none(),
+            port_bad: port_txt.is_some() && port.is_none(),
             path,
         }
     }
@@ -338,6 +374,11 @@ mod tests {
         assert_eq!(Origin::parse("http://192.0.2.10:0"), None);
         assert_eq!(Origin::parse("http://192.0.2.10:70000"), None);
         assert_eq!(Origin::parse("http://192.0.2.10:abc"), None);
+        // an EMPTY port is a port that WAS written — a truncated write, not a request for the
+        // default. Reading it as 32400 is the same "port nobody wrote down" this list exists for.
+        assert_eq!(Origin::parse("http://192.0.2.10:"), None);
+        // …while a URL that writes no `:` at all really does mean the default
+        assert_eq!(Origin::parse("http://192.0.2.10").unwrap().port(), DEFAULT_PORT);
     }
 
     /// [`split`] is the TOTAL sibling — its caller has no failure path — so the same inputs that
@@ -352,8 +393,20 @@ mod tests {
         assert_eq!(split("192.0.2.10").0.base(), "http://192.0.2.10:32400");
         assert_eq!(split("192.0.2.10").1, "", "no path is an empty path, not a slash");
         assert_eq!(split("http://192.0.2.10:70000/x").0.port(), DEFAULT_PORT, "undialable → the default");
+        assert_eq!(split("http://192.0.2.10:/x").0.port(), DEFAULT_PORT, "…and so does an empty one, here");
+        assert_eq!(split("http://192.0.2.10:/x").1, "/x");
         assert_eq!(split("https://[2001:db8::1]:8443/y").0.base(), "https://[2001:db8::1]:8443");
         assert_eq!(split("https://[2001:db8::1]:8443/y").1, "/y");
+    }
+
+    /// **The event log's spelling**: unchanged for the plaintext origins it has always carried,
+    /// and legible the moment a scheme is worth saying. Both halves matter — see [`Origin::log_form`].
+    #[test]
+    fn the_log_form_is_the_bare_authority_for_http_and_the_whole_url_for_anything_else() {
+        assert_eq!(Origin::http("192.0.2.10", 32400).log_form(), "192.0.2.10:32400", "byte-identical to the old line");
+        assert_eq!(Origin::parse("https://nas.hash.plex.direct:32400").unwrap().log_form(), "https://nas.hash.plex.direct:32400");
+        // a v6 literal is bracketed either way — it is a URL authority, not a resolver node
+        assert_eq!(Origin::http("2001:db8::1", 32400).log_form(), "[2001:db8::1]:32400");
     }
 
     /// [`url_host`] is the borrowed reading `probe`'s ranking uses, and it must give the URL's own

--- a/rust-modules/src/plex/origin.rs
+++ b/rust-modules/src/plex/origin.rs
@@ -100,8 +100,10 @@ pub struct Origin {
 }
 
 impl Origin {
-    /// Build an origin from parts. `host` may arrive bracketed (that is what
-    /// [`super::probe`]'s `host_of` returns) and is stored bare regardless.
+    /// Build an origin from parts. `host` may arrive **either** spelling — bare or bracketed —
+    /// because a caller holding a v6 address has usually just read it out of a URL authority; it
+    /// is stored bare regardless, which is the invariant [`Origin::host`] promises. Unbalanced
+    /// brackets are left alone rather than half-stripped.
     pub fn new(scheme: Scheme, host: &str, port: i32) -> Origin {
         Origin { scheme, host: unbracket(host).to_owned(), port }
     }
@@ -225,8 +227,9 @@ impl<'a> Parts<'a> {
             None => (rest, ""),
         };
         // A bracketed v6 literal carries its own colons, so the port separator is the one AFTER
-        // the closing bracket — this is exactly the reading `probe::host_of` does, except that it
-        // keeps the brackets (an authority) where we drop them (a resolver node).
+        // the closing bracket. `probe` used to carry its own copy of this reading, which returned
+        // the BRACKETED spelling — right for an authority, wrong for the resolver node this
+        // produces, and precisely the confusion the module doc's bracket rule exists to end.
         let (host, port_txt) = match auth.strip_prefix('[').and_then(|r| r.split_once(']')) {
             Some((h, after)) => (h, after.strip_prefix(':')),
             None => match auth.split_once(':') {

--- a/rust-modules/src/plex/probe.rs
+++ b/rust-modules/src/plex/probe.rs
@@ -42,6 +42,11 @@
 //! The racing itself (parallel dial, first good wins, cancel the rest) lands with the transport
 //! work; it belongs above this file, which stays a function of the resource alone.
 use super::account::{Connection, Resource};
+use super::origin::{url_host, Origin};
+/// `Scheme` lives in [`super::origin`] — it is a property of an ORIGIN, and this module only
+/// RANKS it (see the third sort key in [`candidates`]). Re-exported so `probe::Scheme` keeps
+/// resolving for every caller that reads it as a ranking axis.
+pub use super::origin::Scheme;
 
 /// Where an address sits relative to us. The ranking axis every Plex client agrees on, ordered
 /// best-first by declaration so the derived `Ord` *is* the preference.
@@ -55,17 +60,6 @@ pub enum Location {
     Relay,
 }
 
-/// Ordered best-first for THIS app, which is not the same as best-first in general: `stream.rs`
-/// speaks plain HTTP to a dotted quad with no DNS and no TLS (`stream.rs:239-253`), so an https
-/// `plex.direct` origin cannot be dialled at all until the curl control plane lands
-/// (`docs/shared-servers.md` §5 step 6). Ranking https below http keeps the order equal to what can
-/// actually connect today; when TLS exists, swapping these two declarations is the whole change.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Scheme {
-    Http,
-    Https,
-}
-
 /// One address worth dialling. `url` is a bare origin — scheme, host, port, no trailing slash and
 /// no path — so a prober appends `/identity` and a client keeps it as its base.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,11 +67,36 @@ pub struct Candidate {
     pub url: String,
     pub scheme: Scheme,
     pub location: Location,
-    /// The raw host as plex.tv gave it: a dotted quad, a v6 literal, or a hostname. Kept beside
-    /// `url` because the current transport wants host and port, not a URL.
+    /// The raw host as plex.tv gave it: a dotted quad, a v6 literal, or a hostname.
+    ///
+    /// **DIAGNOSTIC METADATA — never what a connection is built from.** It is what the event log
+    /// and the Sources panel say, and it is what today's cleartext `dial` is handed because
+    /// `stream.rs` takes an address and not a URL. It is emphatically *not* the host a TLS
+    /// certificate is validated against: see [`Candidate::origin`], and [`candidates`] below for
+    /// why the two differ.
     pub address: String,
     pub port: i64,
     pub ipv6: bool,
+}
+
+impl Candidate {
+    /// **Where this candidate actually is — parsed from [`Candidate::url`].**
+    ///
+    /// The one derivation in this file that must never be short-cut through
+    /// [`Candidate::address`]. plex.tv advertises the `plex.direct` HOSTNAME in `uri` while
+    /// `address` stays the dotted quad behind it, and the certificate is issued for the name — so
+    /// an origin rebuilt from `address` produces a control plane that *looks* like it speaks TLS
+    /// and fails hostname validation on every real share. [`candidates`] says the same thing from
+    /// the other end ("https to the bare IP fails validation by design"); this is the accessor
+    /// that keeps a caller from having to know it.
+    ///
+    /// `None` only for a `url` that is not an origin this app can speak — which [`candidates`]
+    /// never builds, since it either copies a `uri` plex.tv sent or synthesizes one itself. A
+    /// caller therefore treats `None` as "skip this candidate", exactly as it already treats an
+    /// address the transport cannot dial.
+    pub fn origin(&self) -> Option<Origin> {
+        Origin::parse(&self.url)
+    }
 }
 
 /// Everything a prober needs about one server, and nothing it does not.
@@ -178,17 +197,13 @@ fn host_for_url(address: &str) -> String {
     }
 }
 
-/// The host of a bare origin — **what would actually be dialled**, which for a `uri` candidate is
-/// NOT [`Candidate::address`]: plex.tv advertises the `plex.direct` hostname in `uri` while
-/// `address` stays the dotted quad behind it. Ranking the `uri` candidate on `address` would score
-/// `https://203-0-113-9.hash.plex.direct:32400` as numeric when it is the very name that needs DNS.
-fn host_of(url: &str) -> &str {
-    let rest = url.split_once("://").map_or(url, |(_, r)| r);
-    if let Some(end) = rest.find(']') {
-        return &rest[..=end]; // bracketed v6 literal, port (if any) follows
-    }
-    rest.split(':').next().unwrap_or(rest)
-}
+// The host of a bare origin — **what would actually be dialled**, which for a `uri` candidate is
+// NOT `Candidate::address`: plex.tv advertises the `plex.direct` hostname in `uri` while `address`
+// stays the dotted quad behind it. Ranking the `uri` candidate on `address` would score
+// `https://203-0-113-9.hash.plex.direct:32400` as numeric when it is the very name that needs DNS.
+//
+// It used to be a `host_of` of this file's own; it is `origin::url_host` now, so there is exactly
+// one reading of a URL in this layer and the bracket convention is decided in one place.
 
 /// Is this host a NUMERIC literal (v4 or v6) rather than a name that needs resolving?
 ///
@@ -253,9 +268,9 @@ pub fn candidates(res: &Resource) -> Vec<Candidate> {
     }
     // Stable, so plex.tv's own order survives inside a tier — it is the only tiebreak left once
     // location, scheme, resolvability and address family have spoken, and it is not ours to reorder.
-    // Resolvability is read off the URL's own host, not `address` — see `host_of`, which is the
-    // difference between scoring the `plex.direct` uri and scoring the quad hiding behind it.
-    out.sort_by_key(|c| (c.location, c.scheme, !is_numeric_address(host_of(&c.url)), c.ipv6));
+    // Resolvability is read off the URL's own host, not `address` — see `origin::url_host`, which
+    // is the difference between scoring the `plex.direct` uri and scoring the quad hiding behind it.
+    out.sort_by_key(|c| (c.location, c.scheme, !is_numeric_address(url_host(&c.url)), c.ipv6));
     out
 }
 
@@ -384,11 +399,44 @@ mod tests {
         assert!(!is_numeric_address(""));
     }
 
+    /// **A candidate's origin comes from its `url` and NEVER from its `address`.** The https
+    /// candidate here is the whole reason: plex.tv advertises the `plex.direct` NAME in `uri`
+    /// while `address` stays the dotted quad, and the certificate is issued for the name — so an
+    /// origin rebuilt from `address` gives a URL that connects and then fails TLS validation on
+    /// every real share. This is the assertion that fails if anyone "simplifies" `Candidate::origin`
+    /// into `Origin::http(&self.address, self.port)`.
     #[test]
-    fn the_host_of_an_origin_is_read_without_its_scheme_or_port() {
-        assert_eq!(host_of("http://203.0.113.9:31234"), "203.0.113.9");
-        assert_eq!(host_of("https://media.example.internal:31234"), "media.example.internal");
-        assert_eq!(host_of("http://[2001:db8::1]:32400"), "[2001:db8::1]", "the port is not a v6 group");
+    fn a_candidates_origin_is_parsed_from_its_url_not_rebuilt_from_its_address() {
+        let cs = candidates(&shared_server());
+
+        let uri = cs.iter().find(|c| c.scheme == Scheme::Https && c.address == "203.0.113.9").expect("the https uri");
+        let o = uri.origin().expect("an advertised uri is an origin");
+        assert_eq!(o.host(), "203-0-113-9.hash2.plex.direct", "the NAME the certificate is for");
+        assert_ne!(o.host(), uri.address, "…which is not the quad hiding behind it");
+        assert_eq!(o.base(), "https://203-0-113-9.hash2.plex.direct:31234");
+        assert!(o.is_tls());
+
+        // and the synthesized plain-http twin — the one this app can actually dial today — is the
+        // address, unchanged, so nothing about the current transport moves
+        let twin = cs.iter().find(|c| c.url == "http://203.0.113.9:31234").expect("the http twin");
+        let t = twin.origin().expect("parses");
+        assert_eq!((t.scheme(), t.host(), t.port()), (Scheme::Http, "203.0.113.9", 31234));
+        assert_eq!(t.base(), twin.url, "every candidate's origin round-trips to its own url");
+
+        // every candidate this policy builds is a parseable origin — a caller's `None` branch is
+        // for a hand-made `Candidate`, never for one that came from here
+        assert!(cs.iter().all(|c| c.origin().is_some_and(|o| o.base() == c.url)), "{cs:#?}");
+    }
+
+    /// A v6 candidate's origin is bare for the resolver and bracketed in its URL — the invariant
+    /// `origin.rs` documents, asserted where the v6 candidate is actually built.
+    #[test]
+    fn a_v6_candidates_origin_is_bare_for_the_resolver() {
+        let cs = candidates(&owned_server());
+        let v6 = cs.iter().find(|c| c.url == "http://[2001:db8::1]:32400").expect("the v6 twin");
+        let o = v6.origin().expect("parses");
+        assert_eq!(o.host(), "2001:db8::1", "the getaddrinfo node is never bracketed");
+        assert_eq!(o.authority(), "[2001:db8::1]:32400", "…and the URL authority always is");
     }
 
     /// **A hostname ranks behind a numeric address**, and the share is the live case: plex.tv lists

--- a/rust-modules/src/plex/servers.rs
+++ b/rust-modules/src/plex/servers.rs
@@ -398,15 +398,41 @@ pub fn register_origin(machine_id: &str, origin: &Origin, token: &str) -> Server
     id
 }
 
-/// [`register`] with the device id supplied — the seam that keeps the session file out of the
-/// registry proper (and out of the tests).
+/// [`register`] with the device id supplied — the seam that keeps the session file **and the
+/// network** out of the registry proper, and out of the tests.
 ///
 /// `pub(crate)` rather than `pub(super)` because tests OUTSIDE `plex/` need it too (`route.rs`
-/// grades which server a `/:/timeline` POST reaches, which takes two registered clients): the
-/// public [`register`] resolves the device id through `session::load`, which MINTS AND PERSISTS a
-/// uuid when there is none, and a host test must not write one.
+/// grades which server a `/:/timeline` POST reaches, which takes two registered clients).
+///
+/// **Two reasons a host test must come through here, and the second one cost a red CI run.**
+///
+/// 1. The public [`register`] resolves the device id through `session::load`, which MINTS AND
+///    PERSISTS a uuid when there is none. A host test must not write one.
+/// 2. [`register`] also fires [`serverinfo::refresh`](super::serverinfo::refresh), which spawns a
+///    `task::spawn_small` worker that really opens a socket — on a **256 KiB** stack. In a DEBUG
+///    build `stream::http_stream_boxed` builds its 64 KiB `HttpStream` as a stack temporary before
+///    it reaches the heap (the optimizer elides that in the `--release` build the television
+///    ships, and only there), so that worker needs somewhere north of 192 KiB on ARM64 and more
+///    than 256 KiB on x86-64. A test that calls [`register`] therefore aborts the whole suite with
+///    `thread '<unknown>' has overflowed its stack` — on Linux only, in a thread libtest never
+///    named, at whatever test happened to be printing. `make check` passed on the dev Mac while CI
+///    failed twice.
+///
+/// So: **no test in this crate may call [`register`] or [`register_origin`]**. The two seams here
+/// are the whole test surface, and neither loads a session nor spawns anything.
 pub(crate) fn register_with_client_id(machine_id: &str, host: &str, port: i32, token: &str, client_id: &str) -> ServerId {
-    register_lazy(machine_id, &Origin::http(host, port), token, &|| client_id.to_owned())
+    register_origin_with_client_id(machine_id, &Origin::http(host, port), token, client_id)
+}
+
+/// [`register_with_client_id`], given the whole [`Origin`] — the seam for a test that is about the
+/// SCHEME, which the `(host, port)` form cannot express. Same contract: no session file, no worker.
+pub(crate) fn register_origin_with_client_id(
+    machine_id: &str,
+    origin: &Origin,
+    token: &str,
+    client_id: &str,
+) -> ServerId {
+    register_lazy(machine_id, origin, token, &|| client_id.to_owned())
 }
 
 fn register_lazy(machine_id: &str, origin: &Origin, token: &str, client_id: &dyn Fn() -> String) -> ServerId {
@@ -619,17 +645,23 @@ mod tests {
     /// comparison wrong — compare `host`/`port` and forget the scheme, which is exactly what the
     /// pair-shaped code did because it could not spell one — and the day a server moves to https
     /// the registry keeps a plaintext client for it, in place, with nothing in the log.
+    ///
+    /// Driven through [`register_origin_with_client_id`], NOT the public [`register_origin`] — see
+    /// that seam's doc. This test was written against the public one and turned CI red on Linux
+    /// with a stack overflow in an unnamed thread, because `register_origin` spawns a real
+    /// `serverinfo` worker that opens a real socket on a 256 KiB stack.
     #[test]
     fn moving_a_server_to_https_re_points_its_slot() {
         let _g = fresh();
+        let reg_at = |o: &Origin, tok: &str| register_origin_with_client_id("mach-A", o, tok, "test-client-id");
         let plain = Origin::http("10.0.0.1", 32400);
-        let id = register_origin("mach-A", &plain, "tok-a");
+        let id = reg_at(&plain, "tok-a");
         let before: *const Client = client_for(id).unwrap();
         let gen_before = client_for(id).unwrap().token_gen();
         client_for(id).unwrap().set_link(crate::plex::probe::Location::Local);
 
         let tls = Origin::parse("https://10-0-0-1.hash.plex.direct:32400").expect("an origin");
-        assert_eq!(register_origin("mach-A", &tls, "tok-a"), id, "same machine, same slot");
+        assert_eq!(reg_at(&tls, "tok-a"), id, "same machine, same slot");
         assert_eq!(count(), 1, "a scheme change is not a second server");
 
         let c = client_for(id).unwrap();
@@ -641,7 +673,7 @@ mod tests {
 
         // and re-registering the SAME origin lands in place again, as any unchanged address does
         let same: *const Client = c;
-        assert_eq!(register_origin("mach-A", &tls, "tok-b"), id);
+        assert_eq!(reg_at(&tls, "tok-b"), id);
         assert!(std::ptr::eq(client_for(id).unwrap(), same), "unchanged origin, unchanged pointer");
     }
 

--- a/rust-modules/src/plex/servers.rs
+++ b/rust-modules/src/plex/servers.rs
@@ -425,11 +425,12 @@ fn register_lazy(machine_id: &str, origin: &Origin, token: &str, client_id: &dyn
             // with it; the fresh one also gets a fresh token generation, so token-baked caches
             // flush without a special case.
             //
-            // The line says the AUTHORITY (`host:port`, a v6 literal bracketed) and not the whole
-            // base URL, which keeps it byte-identical to the `{host}:{port}` it has always been
-            // for the http/IPv4 origins this app has today — and correct for the v6 spelling that
-            // format could not express at all.
-            crate::log(&format!("plex: server slot {} re-pointed to {}", id.0, origin.authority()));
+            // `log_form`: the bare authority for a plaintext origin, so this line stays
+            // byte-identical to the `{host}:{port}` it has always been and an archived log is
+            // still comparable with a current one — and the whole URL the moment the scheme is
+            // worth saying, which is the only way a headless run armed with `{"scheme":"https"}`
+            // can be told from an http one at all. See `Origin::log_form`.
+            crate::log(&format!("plex: server slot {} re-pointed to {}", id.0, origin.log_form()));
             publish(id, Client::new(id, mid, origin.clone(), token, &client_id()));
         } else {
             c.set_token(token); // in place — every reference already handed out follows along
@@ -447,9 +448,9 @@ fn register_lazy(machine_id: &str, origin: &Origin, token: &str, client_id: &dyn
     publish(id, Client::new(id, machine_id, origin.clone(), token, &client_id()));
     COUNT.store(n + 1, Ordering::Release); // after the pointer: a visible count implies a live slot
     // Address only — the machineIdentifier is a permanent household fingerprint (see `ui::stats`)
-    // and the event log is what users send us. The AUTHORITY rather than the base URL, for the
-    // reason the re-point line above gives.
-    crate::log(&format!("plex: server slot {} registered at {}", id.0, origin.authority()));
+    // and the event log is what users send us. `log_form` rather than `base`, for the reason the
+    // re-point line above gives.
+    crate::log(&format!("plex: server slot {} registered at {}", id.0, origin.log_form()));
     if !current().is_set() {
         // Release: this store is what makes the `publish` above reachable through `client()`, so it
         // must not be seen before it (see `current()`).

--- a/rust-modules/src/plex/servers.rs
+++ b/rust-modules/src/plex/servers.rs
@@ -2,7 +2,7 @@
 //! `&'static Client` handed to ~30 call sites outside this module.
 //!
 //! This replaces `client.rs`'s `static PLEX: OnceLock<Client>`: one server per process, forever,
-//! whose second `install` could only swap a token because host/port were frozen by the first.
+//! whose second `install` could only swap a token because its address was frozen by the first.
 //! That single fact is what made browsing a SECOND (shared) server impossible — not the UI, not
 //! the ops. So the singleton becomes a table, and `client()` becomes "the current entry of it"
 //! with its signature untouched, which is why nothing outside `plex/` changed in the commit that
@@ -10,10 +10,16 @@
 //!
 //! **Keyed by `machineIdentifier`.** The server's own permanent id is the only identity that
 //! survives it changing address (LAN ↔ remote, DHCP, a relay), so the table keys on it and an
-//! address is just where that key currently answers. The legacy `install(host, port, token)`
-//! doesn't know the id — its callers (`app.rs`, `auth.rs`) have only a stored session address —
-//! so it registers with an EMPTY id and matches on the address; a later [`register`] that does
-//! know the id adopts that slot instead of adding a second one for the same server.
+//! address is just where that key currently answers. [`install`] doesn't know the id — its callers
+//! (`app.rs`, `auth.rs`) have only a stored session origin — so it registers with an EMPTY id and
+//! matches on the origin; a later [`register_origin`] that does know the id adopts that slot
+//! instead of adding a second one for the same server.
+//!
+//! **An address here is an [`Origin`], not a `(host, port)` pair** — scheme included, and parsed
+//! from the URL plex.tv advertised rather than rebuilt from the address behind it (`origin.rs` has
+//! the reasoning; the one-line version is that a `plex.direct` certificate is issued for the NAME).
+//! [`register`] and [`register_with_client_id`] keep the pair-shaped spelling for callers that
+//! genuinely hold nothing else, and say `Origin::http` out loud when they do.
 //!
 //! ## Why an atomic pointer table and not an `RwLock<Vec<Arc<Client>>>`
 //!
@@ -55,6 +61,7 @@
 //! inside one process.
 
 use super::client::Client;
+use super::origin::Origin;
 use std::sync::atomic::{AtomicPtr, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
@@ -326,11 +333,11 @@ fn pick(new: &str, old: Option<&str>) -> String {
 /// address moving. Otherwise the address is all there is: for the legacy `install` (no id at
 /// all), and for a `register` that has learned an id for a slot registered without one, which is
 /// the ADOPT case rather than a second slot for one server.
-fn same_server(c: &Client, machine_id: &str, host: &str, port: i32) -> bool {
+fn same_server(c: &Client, machine_id: &str, origin: &Origin) -> bool {
     if !machine_id.is_empty() && !c.machine_id().is_empty() {
         return c.machine_id() == machine_id;
     }
-    c.host() == host && c.port() == port
+    c.origin() == origin
 }
 
 /// Publish a client into a slot. Takes the leak (see the module doc); the Release store pairs
@@ -362,12 +369,24 @@ fn publish(id: ServerId, c: Client) {
 /// (otherwise there is nothing for `client()` to answer with). Use [`set_current`] to switch,
 /// or [`install`], which is the session path and always retargets.
 pub fn register(machine_id: &str, host: &str, port: i32, token: &str) -> ServerId {
+    register_origin(machine_id, &Origin::http(host, port), token)
+}
+
+/// [`register`], given the server's whole [`Origin`] instead of a plaintext address.
+///
+/// **This is the real one.** The `(host, port)` spelling above cannot say `https`, and an origin
+/// is not something that can be rebuilt from an address afterwards: plex.tv advertises a server's
+/// TLS origin as the `plex.direct` HOSTNAME while its `address` stays the dotted quad behind it,
+/// and the certificate is issued for the name. So an origin has to be carried from where it was
+/// parsed ([`super::probe::Candidate::origin`]) all the way to here, and the pair-shaped entry
+/// points are kept only for callers that genuinely have nothing but an address.
+pub fn register_origin(machine_id: &str, origin: &Origin, token: &str) -> ServerId {
     // The playback identity (`X-Plex-Client-Identifier`) is the persisted login identity, so it
     // comes from the session file — read LAZILY, i.e. only when a `Client` is actually built.
     // `session::load` can WRITE (it mints + persists the uuid when there is none), and the
     // commonest call here by far is the profile switch, which only swaps a token; the singleton
     // this replaced read the file exactly once, and so does this.
-    let id = register_lazy(machine_id, host, port, token, &|| super::session::load().client_id);
+    let id = register_lazy(machine_id, origin, token, &|| super::session::load().client_id);
     // Every server the app actually talks to arrives through THIS function (the `_with_client_id`
     // seam below is the test one and deliberately does not), so it is the single place that keeps
     // each server's self-description — version + Plex Pass, issue #22's blind spot — fresh
@@ -387,26 +406,31 @@ pub fn register(machine_id: &str, host: &str, port: i32, token: &str) -> ServerI
 /// public [`register`] resolves the device id through `session::load`, which MINTS AND PERSISTS a
 /// uuid when there is none, and a host test must not write one.
 pub(crate) fn register_with_client_id(machine_id: &str, host: &str, port: i32, token: &str, client_id: &str) -> ServerId {
-    register_lazy(machine_id, host, port, token, &|| client_id.to_owned())
+    register_lazy(machine_id, &Origin::http(host, port), token, &|| client_id.to_owned())
 }
 
-fn register_lazy(machine_id: &str, host: &str, port: i32, token: &str, client_id: &dyn Fn() -> String) -> ServerId {
+fn register_lazy(machine_id: &str, origin: &Origin, token: &str, client_id: &dyn Fn() -> String) -> ServerId {
     let _w = WRITE.lock().unwrap_or_else(|e| e.into_inner());
     let n = COUNT.load(Ordering::Acquire);
     // LIVE slots only. A revoked slot for this very machine is not adopted: the previous account's
     // grant on it is dead, and the number belongs to that account's stores forever (module doc).
-    let found = ids().find(|&id| client_for(id).is_some_and(|c| same_server(c, machine_id, host, port)));
+    let found = ids().find(|&id| client_for(id).is_some_and(|c| same_server(c, machine_id, origin)));
 
     if let Some(id) = found {
         let c = client_for(id).expect("the matched slot is populated");
         // Keep an id we already know: a legacy address-keyed call must not blank it.
         let mid = if machine_id.is_empty() { c.machine_id() } else { machine_id };
-        if c.host() != host || c.port() != port || c.machine_id() != mid {
+        if c.origin() != origin || c.machine_id() != mid {
             // Re-point. The old `Client` stays alive and merely stale for anyone mid-request
             // with it; the fresh one also gets a fresh token generation, so token-baked caches
             // flush without a special case.
-            crate::log(&format!("plex: server slot {} re-pointed to {host}:{port}", id.0));
-            publish(id, Client::new(id, mid, host, port, token, &client_id()));
+            //
+            // The line says the AUTHORITY (`host:port`, a v6 literal bracketed) and not the whole
+            // base URL, which keeps it byte-identical to the `{host}:{port}` it has always been
+            // for the http/IPv4 origins this app has today — and correct for the v6 spelling that
+            // format could not express at all.
+            crate::log(&format!("plex: server slot {} re-pointed to {}", id.0, origin.authority()));
+            publish(id, Client::new(id, mid, origin.clone(), token, &client_id()));
         } else {
             c.set_token(token); // in place — every reference already handed out follows along
         }
@@ -420,11 +444,12 @@ fn register_lazy(machine_id: &str, host: &str, port: i32, token: &str, client_id
         return ServerId::UNSET;
     }
     let id = ServerId(n as u16);
-    publish(id, Client::new(id, machine_id, host, port, token, &client_id()));
+    publish(id, Client::new(id, machine_id, origin.clone(), token, &client_id()));
     COUNT.store(n + 1, Ordering::Release); // after the pointer: a visible count implies a live slot
     // Address only — the machineIdentifier is a permanent household fingerprint (see `ui::stats`)
-    // and the event log is what users send us.
-    crate::log(&format!("plex: server slot {} registered at {host}:{port}", id.0));
+    // and the event log is what users send us. The AUTHORITY rather than the base URL, for the
+    // reason the re-point line above gives.
+    crate::log(&format!("plex: server slot {} registered at {}", id.0, origin.authority()));
     if !current().is_set() {
         // Release: this store is what makes the `publish` above reachable through `client()`, so it
         // must not be seen before it (see `current()`).
@@ -440,10 +465,10 @@ fn register_lazy(machine_id: &str, host: &str, port: i32, token: &str, client_id
 /// so the same address is the same server: a second call for it swaps the token in place exactly
 /// as the old singleton did — which is every install this app makes today, and why nothing about
 /// a single-server session changed. A call naming a DIFFERENT address now registers a second slot
-/// and makes it current, where the singleton kept the FIRST server's host/port and quietly applied
-/// the new token to it (a mis-target no caller could see, because host/port were frozen).
-pub fn install(host: &str, port: i32, token: &str) {
-    let id = register("", host, port, token);
+/// and makes it current, where the singleton kept the FIRST server's address and quietly applied
+/// the new token to it (a mis-target no caller could see, because the address was frozen).
+pub fn install(origin: &Origin, token: &str) {
+    let id = register_origin("", origin, token);
     set_current(id); // the session path always retargets: this is now the server we are using
     // (`register` already refreshed this server's self-description — see its doc.)
 }
@@ -583,6 +608,40 @@ mod tests {
         assert_eq!(count(), 1);
         assert_eq!(token_of(client_for(id).unwrap()), "tok-c");
         assert_eq!(client_for(id).unwrap().machine_id(), "mach-A", "a call with no id must not blank one");
+    }
+
+    /// **A scheme change is an ADDRESS change**, so it re-points the slot exactly as a new host or
+    /// port does — a fresh `Client`, a fresh token generation, the tier reset to unknown.
+    ///
+    /// It cannot be observed any other way: `same_server` matches on the machine id whenever both
+    /// sides have one, so the origin comparison only ever decides whether to RE-POINT. Get that
+    /// comparison wrong — compare `host`/`port` and forget the scheme, which is exactly what the
+    /// pair-shaped code did because it could not spell one — and the day a server moves to https
+    /// the registry keeps a plaintext client for it, in place, with nothing in the log.
+    #[test]
+    fn moving_a_server_to_https_re_points_its_slot() {
+        let _g = fresh();
+        let plain = Origin::http("10.0.0.1", 32400);
+        let id = register_origin("mach-A", &plain, "tok-a");
+        let before: *const Client = client_for(id).unwrap();
+        let gen_before = client_for(id).unwrap().token_gen();
+        client_for(id).unwrap().set_link(crate::plex::probe::Location::Local);
+
+        let tls = Origin::parse("https://10-0-0-1.hash.plex.direct:32400").expect("an origin");
+        assert_eq!(register_origin("mach-A", &tls, "tok-a"), id, "same machine, same slot");
+        assert_eq!(count(), 1, "a scheme change is not a second server");
+
+        let c = client_for(id).unwrap();
+        assert!(!std::ptr::eq(c, before), "the slot was RE-POINTED, not updated in place");
+        assert_eq!(c.origin(), &tls);
+        assert_eq!(c.host(), "10-0-0-1.hash.plex.direct", "the name a certificate is issued for");
+        assert_ne!(c.token_gen(), gen_before, "a fresh client means token-baked caches flush");
+        assert_eq!(c.link(), None, "a new address is not evidence about the old tier");
+
+        // and re-registering the SAME origin lands in place again, as any unchanged address does
+        let same: *const Client = c;
+        assert_eq!(register_origin("mach-A", &tls, "tok-b"), id);
+        assert!(std::ptr::eq(client_for(id).unwrap(), same), "unchanged origin, unchanged pointer");
     }
 
     /// A different server is a NEW slot, never a silent retarget of the old one — the singleton's

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -218,8 +218,12 @@ pub struct ServerRef {
     /// interchangeable: the host a TLS certificate is issued for is the `plex.direct` NAME, which
     /// `address` never holds (`origin.rs`). Storing the URL keeps the file legible to a human
     /// editing it on the television, which the struct-shaped alternative does not.
-    #[serde(default)]
-    pub origin: String,
+    ///
+    /// **The `_url` suffix is not decoration**: this is the raw string, [`ServerRef::origin`] is
+    /// the parsed value, and naming both `origin` would put a silent mix-up two characters away at
+    /// every use. The FILE's key stays `origin`, which is what a human editing it reads.
+    #[serde(default, rename = "origin")]
+    pub origin_url: String,
 }
 
 impl ServerRef {
@@ -235,7 +239,7 @@ impl ServerRef {
     /// The gate stays where it is, and the `port as i32` below is the same cast those readers were
     /// already doing, kept in one documented place instead of three.
     pub fn origin(&self) -> Origin {
-        Origin::parse(&self.origin).unwrap_or_else(|| Origin::http(&self.address, self.port as i32))
+        Origin::parse(&self.origin_url).unwrap_or_else(|| Origin::http(&self.address, self.port as i32))
     }
 }
 
@@ -273,9 +277,9 @@ pub struct SourceRef {
     /// **Where this server is, as a URL** — the [`Origin`] the probe accepted, serialized. Empty
     /// in every file written before the field existed; [`SourceRef::origin`] falls back to
     /// `http://{address}:{port}` for those, which is what they meant. See [`ServerRef::origin`]
-    /// for why that fallback exists at all.
-    #[serde(default)]
-    pub origin: String,
+    /// for why that fallback exists at all, and [`ServerRef::origin_url`] for the `_url` suffix.
+    #[serde(default, rename = "origin")]
+    pub origin_url: String,
 }
 
 impl SourceRef {
@@ -311,8 +315,8 @@ impl SourceRef {
     /// [`SourceRef::usable`] — so `None` costs one roster entry, which is the rule `de_soft_vec`
     /// establishes for this whole struct.
     pub fn origin(&self) -> Option<Origin> {
-        if !self.origin.is_empty() {
-            return Origin::parse(&self.origin);
+        if !self.origin_url.is_empty() {
+            return Origin::parse(&self.origin_url);
         }
         if self.address.is_empty() {
             return None;
@@ -441,8 +445,8 @@ impl Session {
     /// (`Origin::parse` refuses an undialable port and a scheme this app does not speak); a legacy
     /// file with no origin is judged exactly as before.
     fn server_dialable(&self) -> bool {
-        if !self.server.origin.is_empty() {
-            return Origin::parse(&self.server.origin).is_some();
+        if !self.server.origin_url.is_empty() {
+            return Origin::parse(&self.server.origin_url).is_some();
         }
         !self.server.address.is_empty() && super::probe::dial_port(self.server.port).is_some()
     }

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -16,6 +16,7 @@
 //! **Nothing here carries a timestamp**, deliberately: this TV's wall clock runs ~3 h skewed
 //! (root `CLAUDE.md`), so a stored "last seen" would be a number that cannot be compared with
 //! anything and would invite an expiry rule built on it.
+use super::origin::Origin;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Mutex;
@@ -204,9 +205,38 @@ pub struct HomeUserRef {
 pub struct ServerRef {
     pub name: String,
     pub machine_id: String,
+    /// The dotted quad (or v6 literal, or hostname) discovery recorded. **Diagnostic, and the
+    /// LEGACY fallback** — see [`ServerRef::origin`], which is what anything dialling reads.
     pub address: String,
     pub port: i64,
     pub token: String,
+    /// **Where this server is, as a URL** — `"http://192.0.2.10:32400"`. Written since the origin
+    /// model landed; **empty in every file written before it**, which is the whole reason
+    /// [`ServerRef::origin`] has a fallback rather than an `Option`.
+    ///
+    /// It is a serialized [`Origin`] and not a `scheme` beside `address` because the two are not
+    /// interchangeable: the host a TLS certificate is issued for is the `plex.direct` NAME, which
+    /// `address` never holds (`origin.rs`). Storing the URL keeps the file legible to a human
+    /// editing it on the television, which the struct-shaped alternative does not.
+    #[serde(default)]
+    pub origin: String,
+}
+
+impl ServerRef {
+    /// **Where the primary server is.** [`ServerRef::origin`] when the file has one, else the
+    /// legacy `http://{address}:{port}` — which is exactly what a file written before that field
+    /// existed meant, and what every reader of this struct did with those two fields by hand.
+    ///
+    /// **TOTAL, unlike [`SourceRef::origin`].** The asymmetry is deliberate. A roster entry has
+    /// [`SourceRef::usable`] in front of every caller, so `None` there costs one entry. This is
+    /// the PRIMARY: `app.rs`'s boot gate and `auth::cancel` read it unconditionally, gated only by
+    /// [`Session::can_go_local`], so a `None` here would be a NEW refusal on a path that has never
+    /// had one — a silent sign-out at boot, which is the failure this whole field exists to avoid.
+    /// The gate stays where it is, and the `port as i32` below is the same cast those readers were
+    /// already doing, kept in one documented place instead of three.
+    pub fn origin(&self) -> Origin {
+        Origin::parse(&self.origin).unwrap_or_else(|| Origin::http(&self.address, self.port as i32))
+    }
 }
 
 /// One server this identity can browse — our own or a friend's share. What discovery resolved:
@@ -231,11 +261,21 @@ pub struct SourceRef {
     pub owned: bool,
     /// The address that answered `/identity` with the right `machineIdentifier` — not the first
     /// one advertised. A share's `local` address is the OWNER's LAN and is never this.
+    ///
+    /// **Diagnostic metadata, and the LEGACY fallback.** It is what [`SourceRef::describe`] prints
+    /// and what the Sources panel says; it is *not* what a connection is built from — that is
+    /// [`SourceRef::origin`], and for an https server the two genuinely differ (`origin.rs`).
     pub address: String,
     pub port: i64,
     /// This identity's per-(user, server) `accessToken` for THIS server. A secret — never logged.
     /// Our own server's token gets a 401 from a share, which is why one token cannot serve both.
     pub token: String,
+    /// **Where this server is, as a URL** — the [`Origin`] the probe accepted, serialized. Empty
+    /// in every file written before the field existed; [`SourceRef::origin`] falls back to
+    /// `http://{address}:{port}` for those, which is what they meant. See [`ServerRef::origin`]
+    /// for why that fallback exists at all.
+    #[serde(default)]
+    pub origin: String,
 }
 
 impl SourceRef {
@@ -255,7 +295,29 @@ impl SourceRef {
     /// An out-of-range port wraps in that cast; here it costs the entry instead, and `de_soft_vec`
     /// already establishes that one bad roster entry costs that entry and never the session.
     pub fn usable(&self) -> bool {
-        !self.address.is_empty() && super::probe::dial_port(self.port).is_some() && !self.token.is_empty()
+        self.origin().is_some() && !self.token.is_empty()
+    }
+
+    /// **Where to dial this source**, `None` when there is nothing dialable written down.
+    ///
+    /// [`SourceRef::origin`] when the file has one, else the legacy `http://{address}:{port}` — an
+    /// entry written before the field existed, which is every entry in every session file on every
+    /// television today. The port still goes through
+    /// [`probe::dial_port`](super::probe::dial_port) on that path, for the reason
+    /// [`SourceRef::usable`] gives: this file is JSON on disk that a hand edit or an older build
+    /// can leave holding anything an `i64` can hold, and `port as i32` WRAPS.
+    ///
+    /// `Option`, unlike [`ServerRef::origin`], because every caller here is already behind
+    /// [`SourceRef::usable`] — so `None` costs one roster entry, which is the rule `de_soft_vec`
+    /// establishes for this whole struct.
+    pub fn origin(&self) -> Option<Origin> {
+        if !self.origin.is_empty() {
+            return Origin::parse(&self.origin);
+        }
+        if self.address.is_empty() {
+            return None;
+        }
+        super::probe::dial_port(self.port).map(|p| Origin::http(&self.address, p))
     }
 }
 
@@ -368,9 +430,21 @@ impl Session {
     /// also covers `port` simply being ABSENT from an older file (`#[serde(default)]` = 0), which
     /// could never have connected either.
     pub fn can_go_local(&self) -> bool {
-        !self.server.address.is_empty()
-            && super::probe::dial_port(self.server.port).is_some()
-            && !self.pms_token().is_empty()
+        self.server_dialable() && !self.pms_token().is_empty()
+    }
+
+    /// Is the primary's address one this app could actually open a socket to?
+    ///
+    /// Split out of [`Session::can_go_local`] because [`ServerRef::origin`] is deliberately total
+    /// (see its doc) — so the refusal that used to be implicit in reading `address`/`port` has to
+    /// be stated somewhere, and this is it. A stored ORIGIN is judged by whether it parses at all
+    /// (`Origin::parse` refuses an undialable port and a scheme this app does not speak); a legacy
+    /// file with no origin is judged exactly as before.
+    fn server_dialable(&self) -> bool {
+        if !self.server.origin.is_empty() {
+            return Origin::parse(&self.server.origin).is_some();
+        }
+        !self.server.address.is_empty() && super::probe::dial_port(self.server.port).is_some()
     }
     /// The token PMS calls use: the switched managed-user token if we have one, else the server
     /// access token (owner).
@@ -811,6 +885,94 @@ mod tests {
             "home_pins":[{"user":"u-7","asked":true,
                           "on":[{"machine_id":"bbbb2222","key":1}],
                           "off":[{"machine_id":"aaaa1111","key":1}]}]}"#
+    }
+
+    /// **THE COMPATIBILITY GATE: a session file written by 0.4.1 must still boot.**
+    ///
+    /// That build knew nothing about origins — it wrote `address` and `port` and no more — and
+    /// every signed-in television in the world is holding one of these files right now. If
+    /// `Session::server` failed to carry through, the cost is not a degraded feature: `app.rs`'s
+    /// boot gate runs on `can_go_local()`, so the app would land on the QR sign-in screen on
+    /// **every boot for every existing user**, which is a silent sign-out that no test above this
+    /// one can see (the roster lists are soft-parsed — `de_soft_vec` — but the primary is not a
+    /// disposable entry, and nothing soft-parses a MISSING field into a different meaning).
+    ///
+    /// Written as literal 0.4.1-shaped JSON rather than by serialising a `Session`, because the
+    /// thing under test is precisely that today's struct is not what wrote those bytes.
+    #[test]
+    fn a_session_file_written_before_origins_existed_still_boots_as_plain_http() {
+        // Byte-for-byte the shape 0.4.1 wrote: no `origin` on the primary, none on any source.
+        let v041 = r#"{"client_id":"cid-1","account_token":"acct",
+            "server":{"name":"Mac mini","machine_id":"aaaa1111","address":"192.168.0.10",
+                      "port":32400,"token":"tok-own"},
+            "user":{"id":7,"uuid":"u-7","title":"Gleb","thumb":"","token":"tok-user"},
+            "sources":[
+              {"machine_id":"aaaa1111","name":"Mac mini","shared_by":"","owned":true,
+               "address":"192.168.0.10","port":32400,"token":"tok-own"},
+              {"machine_id":"bbbb2222","name":"nas-home","shared_by":"friend","owned":false,
+               "address":"203.0.113.9","port":31234,"token":"tok-share"}]}"#;
+        let s: Session = serde_json::from_str(v041).expect("a 0.4.1 session file still parses");
+
+        // the boot gate itself — this is the assertion whose failure is the silent sign-out
+        assert!(s.can_go_local(), "a 0.4.1 session must still reach Home without a QR code");
+
+        // …and it boots against exactly the address it always did, as plain http
+        let o = s.server.origin();
+        assert_eq!(o.base(), "http://192.168.0.10:32400");
+        assert_eq!((o.host(), o.port()), ("192.168.0.10", 32400));
+        assert!(!o.is_tls(), "nothing in that file ever meant TLS");
+
+        // every roster entry too, including the share on its non-default port
+        assert!(s.sources.iter().all(|x| x.usable()), "{:#?}", s.sources.len());
+        assert_eq!(s.owned_source().unwrap().origin().unwrap().base(), "http://192.168.0.10:32400");
+        assert_eq!(s.source("bbbb2222").unwrap().origin().unwrap().base(), "http://203.0.113.9:31234");
+    }
+
+    /// The other side of the gate: once an origin IS written down it is what gets dialled, and it
+    /// beats the address pair beside it. That is not a tie-break for its own sake — for an https
+    /// server the two genuinely differ (the certificate is issued for the `plex.direct` NAME, not
+    /// for the quad), so reading the pair would connect and then fail validation.
+    #[test]
+    fn a_stored_origin_beats_the_address_pair_beside_it() {
+        let json = r#"{"client_id":"c","account_token":"a",
+            "server":{"machine_id":"aaaa1111","address":"203.0.113.9","port":31234,"token":"t",
+                      "origin":"https://203-0-113-9.hash.plex.direct:31234"},
+            "sources":[{"machine_id":"aaaa1111","owned":true,"address":"203.0.113.9","port":31234,
+                        "token":"t","origin":"https://203-0-113-9.hash.plex.direct:31234"}]}"#;
+        let s: Session = serde_json::from_str(json).expect("parses");
+
+        let o = s.server.origin();
+        assert_eq!(o.host(), "203-0-113-9.hash.plex.direct", "the name TLS validates against");
+        assert!(o.is_tls());
+        assert_eq!(s.server.address, "203.0.113.9", "…and the quad survives as the diagnostic half");
+        assert!(s.can_go_local(), "an https primary is still a session this device holds");
+        assert_eq!(s.sources[0].origin().unwrap(), o, "the roster entry says the same thing");
+
+        // and it round-trips: what we write back is what we would read next boot
+        let again: Session = serde_json::from_slice(&serde_json::to_vec(&s).unwrap()).expect("re-read");
+        assert_eq!(again.server.origin(), o);
+    }
+
+    /// A stored origin that cannot be dialled is refused rather than silently repaired. The port
+    /// is the case that really arrives — the session file is JSON on disk that a hand edit or an
+    /// older build can leave holding anything an `i64` can hold, and `4_294_999_696 as i32` is
+    /// **32400**, so "repair it to the default" means dialling a port nobody wrote down.
+    #[test]
+    fn an_undialable_stored_origin_is_refused_not_repaired() {
+        let bad = |origin: &str| {
+            let json = format!(
+                r#"{{"client_id":"c","account_token":"a",
+                     "server":{{"address":"192.168.0.10","port":32400,"token":"t","origin":"{origin}"}},
+                     "sources":[{{"machine_id":"m","address":"192.168.0.10","port":32400,"token":"t",
+                                  "origin":"{origin}"}}]}}"#
+            );
+            serde_json::from_str::<Session>(&json).expect("the file still parses")
+        };
+        for origin in ["http://192.168.0.10:4294999696", "ftp://192.168.0.10:21", "http://"] {
+            let s = bad(origin);
+            assert!(!s.can_go_local(), "{origin} is not something to boot on");
+            assert!(!s.sources[0].usable(), "{origin} is not something to register");
+        }
     }
 
     /// The roster survives a write/read cycle intact — including the two facts that make a share

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -444,6 +444,15 @@ impl Session {
     /// be stated somewhere, and this is it. A stored ORIGIN is judged by whether it parses at all
     /// (`Origin::parse` refuses an undialable port and a scheme this app does not speak); a legacy
     /// file with no origin is judged exactly as before.
+    ///
+    /// **It asks "is there an address written down", NOT "can this build's transport open it".**
+    /// The two are the same question today and will not be during the transport work: an https or
+    /// hostname origin parses fine and `crate::stream` cannot reach either, so a session file
+    /// holding one boots to a Home whose every request fails silently. That is not gated here on
+    /// purpose — refusing would send the user to a QR code for a transport gap that is not theirs,
+    /// and `can_go_local` means "this device holds a session", which it does. The half-landed state
+    /// it exposes (discovery accepting https before `stream.rs` speaks it) is one lane's to avoid,
+    /// and `player::engine` refuses a TLS stream target out loud for the same reason.
     fn server_dialable(&self) -> bool {
         if !self.server.origin_url.is_empty() {
             return Origin::parse(&self.server.origin_url).is_some();

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -285,7 +285,7 @@ impl Client {
     /// The start.mkv stream target for `spec` — same params as the registering decision.
     pub fn transcode_start_url(&self, spec: &TranscodeSpec) -> StreamUrl {
         let path = format!("/video/:/transcode/universal/start.mkv?{}", self.transcode_query(spec));
-        StreamUrl { host: self.host.clone(), port: self.port, path: self.with_token(&path) }
+        StreamUrl { origin: self.origin.clone(), path: self.with_token(&path) }
     }
 
     /// GET /video/:/transcode/universal/stop — free the server-side encoder for `session`.
@@ -310,12 +310,12 @@ impl Client {
 mod tests {
     use super::{link_policy, Client, Location, LinkPolicy, TranscodeSpec};
     use crate::devcaps::Caps;
-    use crate::plex::ServerId;
+    use crate::plex::{Origin, ServerId};
 
     // ---- the universal-transcoder query: who is allowed to COPY ---------------------------
 
     fn a_client() -> Client {
-        Client::new(ServerId::from_raw(1), "mach", "10.0.0.1", 32400, "tok", "cid")
+        Client::new(ServerId::from_raw(1), "mach", Origin::http("10.0.0.1", 32400), "tok", "cid")
     }
 
     fn spec<'a>(remux: bool, no_video_copy: bool) -> TranscodeSpec<'a> {

--- a/rust-modules/src/route.rs
+++ b/rust-modules/src/route.rs
@@ -835,7 +835,7 @@ fn up_next_of(r: &crate::plex::QueueRow) -> Option<UpNext> {
 ///   1. **The registry's own id for this client** — it is the key the server is filed under, so it
 ///      cannot belong to another one. Free, and refreshed whenever the slot is re-pointed.
 ///   2. `cached`, which `ResolveEnv` only fills in when the cache was learned from *this* server
-///      (see [`Session::machine_sid`]) — the legacy `install(host, port, token)` path registers with no id, so
+///      (see [`Session::machine_sid`]) — the `install(&Origin, token)` path registers with no id, so
 ///      for the session's own server rung 1 is empty and this is what saves a round trip.
 ///   3. `GET /identity`, whose answer travels back in `QueueInfo::machine_id` for `apply_plan` to
 ///      cache against this server.


### PR DESCRIPTION
**T1 of the transport chain: `plex::Origin` — a server's address as ONE value, parsed from a URL.**
A behaviour-preserving refactor that deliberately changes nothing a user can see, and exists so the
lanes above it cannot build the one bug that would make TLS look done and be broken.

## Why it has to land before any `scheme` field

`plex/probe.rs` builds ranked connection `Candidate`s from `/api/v2/resources`. A `Candidate` carries
**both** `url` and `address`, and the two are deliberately different: plex.tv advertises the
`plex.direct` **hostname** in `Connection.uri` while `Connection.address` stays the dotted quad behind
it. `probe.rs` has said so in prose since it was written — *"https to the bare IP fails validation by
design"* — because the certificate is issued for the name.

`auth::resolve_roster` then threw `Candidate::url` away and wrote `c.address` into `SourceRef`, which
became `plex::register(host, port)` and then `Client { host, port }`. Adding a `scheme` field on top
of that would have produced a control plane that *looks* like it speaks TLS and fails hostname
validation on every real server — including the LG reviewer's, which is the whole point of the
project.

So the origin is **parsed from a URL, never rebuilt from an address**, and `Candidate::address` is
documented down to what it actually is: diagnostic metadata for the log and the Sources panel.

## The shape

```rust
pub struct Origin { scheme: Scheme, host: String, port: i32 }

Origin::parse(url) -> Option<Origin>   // the front door; the ONLY way an https origin exists
Origin::http(host, port) -> Origin     // the plaintext constructor, named so it is GREPPABLE
origin::split(url) -> (Origin, &str)   // total sibling, for StreamUrl::parse

o.host()       // ALWAYS UNBRACKETED — the getaddrinfo node, and the name a cert must match
o.authority()  // ALWAYS brackets a v6 literal — URL serialization
o.base()       // "{scheme}://{authority}" — no path, no trailing slash
o.log_form()   // authority for http, base otherwise — see below
```

**The bracket rule is an invariant, not a detail**, and it is pinned by a round-trip test:
`http://[::1]:32400` → `host() == "::1"` → `authority() == "[::1]:32400"` → `base()` identical to the
input. Without it the failure is silent in the worst direction — URL construction keeps looking right
while name resolution quietly stops working. `probe`'s own `host_of` returned the **bracketed**
spelling, correct for a URL and wrong for a resolver, so it is gone: there is now exactly one reading
of a URL in the layer (`origin::url_host`).

Threaded through every site that passed a bare `(host, port)`: `Client` (with `host()`/`port()` kept
as views, so the ~30 call sites below the layer are untouched), `StreamUrl` and its two construction
sites, `register_origin`/`install`, `SourceRef`/`ServerRef`, `ReadyCreds`, `app.rs`'s `install_pms`
and boot gate, and the engine's URL splitter.

`dev::DevServer` gains an optional `"scheme"`. **That is how every other lane and the integrator can
put a TLS origin through the whole control plane headlessly**, with no account that has one — and a
value that is neither `http` nor `https` fails the trigger loudly rather than silently meaning `http`.

## The two hard gates

**(a) A 0.4.1 session file must still boot.** `Session::server` is not a soft-parsed roster entry —
`de_soft_vec` covers the lists beside it and cannot cover a missing field meaning something else — so
dropping it is a **silent sign-out at every boot for every existing user**. `ServerRef::origin()` is
deliberately TOTAL (the roster's `SourceRef::origin()` is `Option`, because `usable()` gates every
caller there); the test uses a literal 0.4.1-shaped JSON string and asserts `can_go_local()` plus
`http://{address}:{port}`. Two more pin the other side: a stored origin beats the address pair beside
it, and an undialable stored origin is **refused rather than repaired** (`…:4294999696` must not
become 32400, which is what that number wraps to).

**(b) No behaviour change.** Every origin is still `http://` and dials the same address, and the
equality is asserted rather than assumed: the only candidates this transport dials are plain-http
IPv4 ones, whose URL `probe::candidates` synthesized as `http://{address}:{port}`.

## Verification

- **`make check`: 997 pass, 0 fail** (nightly, plus the three named clippy lints, `ci/flavor.py
  --selftest` and `tests/test_harness.py`). ~24 of those are new.
- **`RELEASE=1` / `--no-default-features` type-checks clean** — the `PostToolUse` hook ran after every
  edit and blocked several intermediate states, correctly.
- **Simulator boot against a real PMS, before and after: the event log is IDENTICAL on all 30
  non-heartbeat lines**, including `plex: server slot 0 registered at <pms-host>:32400`. The only
  diff is the three `loop=`/`fps=` heartbeat lines, and those vary run-to-run on an *unchanged*
  binary too (two consecutive AFTER runs differ on one of them), so they are sampling noise. Home
  renders correctly: hero, shelves, posters, tab strip.

No device tier was run and none is needed: no FFI, no linkage, no `dynlib!`, no playback path, no
pixels. This is control-plane plumbing plus one URL parser, and the simulator exercises all of it
against a real PMS.

## `/code-review high` — 8 findings, 6 fixed, 2 answered

The two that were worth the review on their own:

**The origin recorded was not provably the origin dialled.** `resolve_roster` wrote
`Candidate::origin()` while `probe_server` dialled `(&c.address, dial_port(c.port))` — and my comment
justifying that was wrong about its own gate: `dial_target` checks `is_ipv4_literal(&c.address)`,
which admits a plex.tv-advertised `uri` candidate and not only the synthesized twin. A connection
whose `uri` names a different port from `port` would be *verified* at one and *written down* as the
other. Now `dial_target` returns the **`Origin`**, `probe_server` dials that origin's host and port,
and `Reach::At` hands it back beside the candidate — one value, so the two cannot diverge. (Its
fixture had `url` and `port` disagreeing, which is exactly what let the old shape look consistent; it
builds both from one pair now.)

**The silent-instrument trap, twice.** The `scheme` trigger exists so a lane can exercise an https
origin — and both registry log lines and `DevServer::describe` printed `host:port`, so such a run was
byte-identical to an http one. `Origin::log_form()` is the shared answer: the bare authority for a
plaintext origin (archived logs stay comparable, and gate (b) holds) and the whole URL as soon as the
scheme is worth saying.

Also fixed: `player::engine` now **refuses** a TLS stream target with a logged reason instead of
silently opening a plaintext socket to it (reachable today — a client at an https origin copies that
origin into `direct_play_url`); `Origin::parse` refuses an **empty** port (`http://h:`) rather than
defaulting to 32400, since that is a truncated write, not a request for the default; and
`reconcile_primary` no longer logs *"primary now answers at …"* when the only change was the stored
origin going from empty to populated — which is what the first boot after this lands does on every
existing install, i.e. a one-shot false DHCP-churn report in the primary evidence surface.

Answered in prose rather than changed: `Origin::port`'s doc claimed a narrowing one constructor does
not perform, so it now says where the narrowing really lives; and `Session::can_go_local` still asks
*"is there an address written down"* rather than *"can THIS build's transport open it"* — gating it
would send a user to a QR code for a transport gap that is not theirs. The half-landed state that
exposes (discovery accepting https before `stream.rs` speaks it) is named in the doc and refused out
loud one layer down, in the engine.

## What a later lane inherits

- **`rust-modules/src/ui/alt_sources.rs`'s dev stand-in is the one remaining `(host, port)` caller**
  that *has* an origin and discards it (`register(&name, c.host(), c.port(), &token)`). It is
  `#[cfg(not(test))]` and needs `dev::read("token")`, so it is dev-only and cannot mis-dial a real
  server. The fix is one line — `register_origin(&name, c.origin(), &token)` — and it is written down
  in `plex/CLAUDE.md` rather than done here, because that file is not in this unit's ownership.
- **`SourceRef::describe()` still prints the address pair**, not the origin. That is right for a
  diagnostic today; the TLS lane may want it to say the origin.
- `register`, `register_with_client_id` and `Origin::http` are kept as **explicitly plaintext**
  spellings. That is the point: **`Origin::http(` is the grep that finds every remaining cleartext
  assumption**, and today they are all correct because `stream.rs` speaks nothing else.

## Docs

`plex/CLAUDE.md`, `servers.rs` and `client.rs` described the registry in `(host, port)` terms and were
updated. `docs/plex-api-design.md` is a design note whose sketches were the implementation of their
day — it gets a **banner** naming the one thing in it that would now mislead (rule 9, "Numeric host,
no DNS", and the two struct sketches), not a rewrite. `docs/shared-servers.md` §7 gains the trigger's
new `scheme` field.

## One place the plan and the tree disagreed

The plan put `client.rs`'s `StreamUrl` at `:363-395`; it is `:362-395`. Everything else checked out,
including both `probe.rs` line references and the `session.rs:124` `de_soft_vec` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GovTtrsD9P7Ld7DnLCMK2G

---

## CI was red on Linux, and the mechanism was not where anyone was looking

`make check` passed on the dev Mac while the x86-64 Linux runner aborted twice with
`thread '<unknown>' has overflowed its stack`, at a different point in the output each run.

**It was not serde_json and not the session file.** `moving_a_server_to_https_re_points_its_slot`
called the **public** `register_origin`, where every other test in that module deliberately goes
through the `register_with_client_id` seam. The public path fires `serverinfo::refresh`, which spawns
a `task::spawn_small` worker that really opens a socket — and in a **debug** build
`stream::http_stream_boxed` materialises its 64 KiB `HttpStream` as a **stack temporary** before it
reaches the heap, despite the comment directly above it promising the opposite (*"box it off the
caller's stack"*). lldb caught it on the guard page:

```
frame #0  stream::http_stream_boxed
frame #1  stream::http_get(host="10.0.0.1", port=32400, path="/?X-Plex-Token=…")
frame #2  Client::get_json
frame #3  Client::server_root
frame #4  serverinfo::fetch_once
frame #5  serverinfo::refresh::{closure#0}      <- spawn_small, 256 KiB stack
```

**Measured, by varying `SMALL_STACK` on this branch:** debug overflows at 48, 128 *and* 192 KiB on
ARM64, and needs more than 256 KiB on x86-64 — which is exactly why one host passed and the other did
not. The margin was always razor-thin; the base just had no host test that reached `http_get` from a
`spawn_small` worker.

### Does it bite in production? No — measured, not assumed

**`--release` passes at 48 KiB**, where debug aborts. At release opt-level the zeroing goes straight
into the heap allocation and the temporary never exists. The television ships
`cargo build --release` (`Makefile:438`), so its 256 KiB `spawn_small` stacks are unaffected and
`SMALL_STACK` keeps the headroom `task.rs` measured (3745 threads against `RLIMIT_NPROC`).

**It is still a latent hazard worth someone's attention, and it is not this PR's to fix** —
`stream.rs` is another lane's file and the code is unchanged from the base. For whoever picks it up:
the fix is to allocate zeroed on the heap instead of copying a stack temporary into it
(`Box::new_uninit()` + `write_bytes`, or `alloc_zeroed`), which makes the comment true in every
profile and costs nothing. Until then, **no test in this crate may call `register`/`register_origin`**
— that is now written into the seam's doc, with this run as the reason.

### The fix here

The test was wrong on its own terms regardless of the stack: `register` also **mints and persists a
client-id uuid**, and that seam's doc has said since it was written that a host test must not write
one. It gains an origin-taking sibling (the pair-shaped seam cannot express a scheme, which is what
this test is *about*) and a second documented reason nobody had paid for yet.

Verified with the same differential that found it: at `SMALL_STACK = 48 * 1024` this branch was 3/3
aborts and is now 3/3 clean — 997 tests, both `--test-threads=1` and parallel. `task.rs` is untouched.
