### PR TITLE
text: a font fallback chain, and a host gate that would have caught the ♪ bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,8 +511,15 @@ TURBOJPEG_SO := $(firstword $(wildcard $(SYSROOT)/usr/lib/libturbojpeg.so.0.*))
 APPINFO   = $(if $(filter stable,$(FLAVOR)),pkg/appinfo.json,pkg/.flavor/$(FLAVOR)/appinfo.json)
 ICONS     = $(if $(filter stable,$(FLAVOR)),pkg/icon.png pkg/largeIcon.png,pkg/dev/icon.png pkg/dev/largeIcon.png)
 APP_FILES = pkg/plxnative $(APPINFO) $(ICONS) pkg/splash.png \
-            pkg/appfont.ttf pkg/appfont-bold.ttf pkg/OFL.txt THIRD-PARTY-NOTICES.md \
+            pkg/appfont.ttf pkg/appfont-bold.ttf pkg/appfont-cjk.ttf pkg/OFL.txt \
+            THIRD-PARTY-NOTICES.md \
             $(FFMPEG_STAGED)
+# appfont-cjk.ttf is the fallback face (Noto Sans CJK KR, tools/cut-noto-cjk.py) and it is the
+# single largest thing in the package — 21 MB raw, ~11 MB of the .ipk. It is PAYLOAD, not an
+# optional extra: without it a Korean, Japanese or Chinese library renders as tofu end to end, and
+# the television's own DroidSansFallback is present on the sets we have measured but is not
+# something a submission can be graded against. `rust-modules/src/fontcov.rs`'s host gate asserts
+# what it must cover; `text.rs`'s module doc is the chain.
 
 # TRADEMARKS.md ships too: it carries the brand reservation and the Plex/LG non-affiliation
 # statement, which used to be appended to LICENSE. It was moved out because GitHub's `licensee`
@@ -573,6 +580,22 @@ deploy: pkg/plxnative $(FFMPEG_STAGED) $(APPINFO) release-guard tv-lock-require
 	# never reach the TV, so a font swap looked like it had no effect. They are ~300 KB.
 	$(SCP) pkg/appfont.ttf root@$(TV):$(APPDIR)/appfont.ttf
 	$(SCP) pkg/appfont-bold.ttf root@$(TV):$(APPDIR)/appfont-bold.ttf
+	# ...and the CJK fallback face, which is 21 MB — the one exception to "unconditional", because
+	# it is a minute of scp on every deploy and it changes only when tools/cut-noto-cjk.py is
+	# re-run. Without it text.rs's chain has no link 2 and CJK falls through to the system face.
+	# The .ipk path (APP_FILES) has no guard at all and is what a real install uses.
+	#
+	# The guard is an MD5, deliberately not a size compare, and this is not hypothetical caution:
+	# the very first re-cut of this font (adding `recalcTimestamp=False` for reproducibility)
+	# produced a file of IDENTICAL SIZE and different bytes, because only `head.modified` moved. A
+	# size guard would have kept the old font on the television and said nothing — which is exactly
+	# the failure the `test -f || scp` guard above was removed for. One ssh round trip either way.
+	@l=`md5 -q pkg/appfont-cjk.ttf 2>/dev/null || md5sum pkg/appfont-cjk.ttf | cut -d' ' -f1`; \
+	 t=`$(SSH) 'md5sum $(APPDIR)/appfont-cjk.ttf 2>/dev/null | cut -d" " -f1'`; \
+	 if [ "$$l" != "$$t" ]; then \
+	   echo "  scp pkg/appfont-cjk.ttf (21 MB — absent or re-cut)"; \
+	   $(SCP) pkg/appfont-cjk.ttf root@$(TV):$(APPDIR)/appfont-cjk.ttf; \
+	 fi
 	@if [ -n "$(TURBOJPEG_SO)" ]; then \
 	  $(SSH) 'test -f $(APPDIR)/libturbojpeg.so.0' || $(SCP) $(TURBOJPEG_SO) root@$(TV):$(APPDIR)/libturbojpeg.so.0; \
 	else echo "note: no libturbojpeg in the sysroot — capture JPEG mode will use the slow encoder"; fi

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -145,6 +145,28 @@ copyright statement declares **no Reserved Font Name**, so OFL §3 imposes no re
 family name "Inter" is retained. The fonts also carry the upstream trademark statement
 "Inter UI and Inter is a trademark of rsms."
 
+**Noto Sans CJK KR** — `appfont-cjk.ttf`
+Copyright © 2014-2021 Adobe (https://www.adobe.com/), per the font's own name table. Version
+2.004, from `github.com/notofonts/noto-cjk` release `Sans2.004`, asset
+`Sans/Variable/TTF/NotoSansCJKkr-VF.ttf`.
+Licence: **SIL Open Font License 1.1** — the same text that ships in this package as `OFL.txt`.
+The licence body distributed with Noto CJK and the one distributed with Inter are identical; only
+their copyright headers differ, and both copyright statements are reproduced here and inside each
+font's own name table (IDs 0, 7, 13 and 14).
+*Modified*: this is a static instance cut from the variable font at weight 400, with the `GSUB`,
+`GPOS`, `GDEF`, `BASE`, `DSIG`, `vhea` and `vmtx` tables removed — all of them unreadable by
+SDL2_ttf 2.0.x, which performs no shaping and no vertical layout. **No codepoint was removed**:
+all 44810 ship. The recipe is `tools/cut-noto-cjk.py`, which pins the input by sha256.
+The Reserved Font Name declared by this font's copyright statement is **"Source"** (Noto Sans CJK
+derives from Adobe's Source Han Sans), which this package does not use, so OFL §3 imposes no
+rename and the family name "Noto Sans CJK KR" is retained. The font also carries the upstream
+trademark statement "Source is a trademark of Adobe in the United States and/or other countries."
+
+*Why it ships:* it is the second link of the application's font fallback chain. Inter covers no
+Hangul, Kana or Han, so without this face every Korean, Japanese and Chinese title in a Plex
+library renders as empty boxes. See `rust-modules/src/text.rs` for the chain and
+`rust-modules/src/fontcov.rs` for the coverage each face is required to have.
+
 ### 2.4 Rust code statically linked into `plxnative`
 
 The application core is Rust. The Rust standard library is compiled from source
@@ -313,8 +335,11 @@ This package must contain exactly the following licence texts, verbatim:
 | `licenses/Unicode-3.0.txt` | Unicode Character Database tables in Rust `core` (§2.4) — UNICODE LICENSE V3, "Copyright © 1991-2024 Unicode, Inc." |
 | `licenses/Zlib.txt` | nanosvg (§2.1) |
 
-`OFL.txt` (SIL Open Font License 1.1, for Inter) already ships at the root of this package. Keep
-it there; do not add a second copy under `licenses/`.
+`OFL.txt` (SIL Open Font License 1.1, for **Inter and Noto Sans CJK KR** — §2.3) already ships at
+the root of this package. Keep it there; do not add a second copy under `licenses/`, and do not
+add a second copy for the second font: the two upstream licence bodies are byte-identical, and
+what differs between them (the copyright statement and the Reserved Font Name) is reproduced in
+§2.3 and carried inside each font's own name table.
 
 No BSD-3-Clause text is required because Apache-2.0 is elected for `moxcms` and `pxfm`. No
 GPL-3.0 text is required: the only GPL-3-covered components are GCC runtime pieces carried by

--- a/ci/check-package.py
+++ b/ci/check-package.py
@@ -441,12 +441,24 @@ print("== shipped fonts ==")
 # Landed 2026-08-01: Inter (SIL OFL 1.1). This is now a REAL gate, not an XFAIL — its job is to
 # stop Monotype Arial coming back through a stale local copy, which is exactly how it would
 # return (the files are named appfont*.ttf, so nothing about the filename reveals the swap).
-ALLOWED = {"Inter", "Arimo", "Roboto", "Noto Sans", "Source Sans 3"}
-for f in ("pkg/appfont.ttf", "pkg/appfont-bold.ttf"):
+ALLOWED = {"Inter", "Arimo", "Roboto", "Noto Sans", "Source Sans 3", "Noto Sans CJK KR"}
+for f in ("pkg/appfont.ttf", "pkg/appfont-bold.ttf", "pkg/appfont-cjk.ttf"):
     fam = font_family(ROOT / f)
     check(fam in ALLOWED, f"{f} family={fam!r} is redistributable (allowed: {sorted(ALLOWED)})")
+# The fallback face, checked for PRESENCE separately: the payload assertion below only runs when
+# an .ipk has been built, and this file is the difference between a Korean library rendering and
+# rendering as tofu. The floor is deliberately crude — a subsetted or truncated stand-in is caught
+# properly by `fontcov.rs`'s cmap gate in `make check`; this only catches "it is not there".
+_cjk = ROOT / "pkg/appfont-cjk.ttf"
+check(_cjk.exists() and _cjk.stat().st_size > 15_000_000,
+      "pkg/appfont-cjk.ttf present and whole — the CJK fallback face (see rust-modules/src/fontcov.rs)")
 check((ROOT / "pkg/OFL.txt").exists(),
       "pkg/OFL.txt present — the OFL requires the licence to travel with the font")
+# One OFL text covers both faces: Inter's and Noto CJK's licence bodies are byte-identical after
+# their differing copyright headers, and the per-font copyright notices live in THIRD-PARTY-NOTICES
+# and in each font's own name table (ID 0/7/13/14, asserted by tools/cut-noto-cjk.py).
+check("Noto Sans CJK" in (ROOT / "THIRD-PARTY-NOTICES.md").read_text(),
+      "THIRD-PARTY-NOTICES.md attributes Noto Sans CJK (OFL 1.1 §2 wants the notice to travel)")
 
 print("== compliance artifacts ==")
 # LGPL-2.1 §6 requires the notice AND the licence text to travel with the BINARY, so these are
@@ -478,7 +490,9 @@ for name, why in NEEDED_LICENCES.items():
 print("== ipk payload ==")
 expected = {
     "plxnative", "appinfo.json", "icon.png", "largeIcon.png", "splash.png",
-    "appfont.ttf", "appfont-bold.ttf", "OFL.txt",
+    # appfont-cjk.ttf is the fallback face. Its absence is not a cosmetic loss: every Korean,
+    # Japanese and Chinese title in the library becomes tofu, which is LG checklist #6 and #48.
+    "appfont.ttf", "appfont-bold.ttf", "appfont-cjk.ttf", "OFL.txt",
     "THIRD-PARTY-NOTICES.md", "LICENSE", "TRADEMARKS.md", *NEEDED_LICENCES,
 }
 data_tar = ROOT / "ipkroot/data.tar.gz"

--- a/rust-modules/src/fontcov.rs
+++ b/rust-modules/src/fontcov.rs
@@ -1,0 +1,770 @@
+//! Which codepoints a font file can actually draw — read straight out of its `cmap`.
+//!
+//! Two callers, for the same reason. [`text.rs`](crate::text) asks it per character to decide
+//! which link of the fallback chain renders a run; the test module at the bottom of THIS file
+//! asks it of the shipped `pkg/appfont*.ttf` and asserts a **declared codepoint set**, inside
+//! `make check`, in milliseconds, with no television and no GL context.
+//!
+//! ## Why the gate exists
+//!
+//! `pkg/appfont.ttf` covers 2853 codepoints — Latin, Cyrillic, Greek — and **zero** Hangul, Kana
+//! or Han. A Plex library with Korean, Japanese or Chinese titles rendered 100 % tofu, and every
+//! test tier this project has was structurally blind to it: the host suite draws nothing, the
+//! simulator renders through a different rasterizer, and the device FPS scenes grade `loop=`.
+//! Coverage is not a rendering question at all — it is a property of a file on disk — so it
+//! belongs in the cheapest tier, and this is it.
+//!
+//! The same defect class already shipped once, visibly: subtitle convention wraps a sung line in
+//! U+2669–U+266C, Inter carries none of them, and a panel capture of the Family Guy theme read
+//! `▯NO GLYPH▯ It seems today`. `tools/cut-inter.py` synthesizes those four; nothing asserted it
+//! until now.
+//!
+//! ## Why the cmap and not `TTF_GlyphIsProvided`
+//!
+//! SDL2_ttf does expose a coverage query, and it is the wrong tool twice over. `TTF_GlyphIsProvided`
+//! takes a **`Uint16`**, so it cannot be asked about anything above U+FFFF; and the 32-bit
+//! `TTF_GlyphIsProvided32` is declared in the NDK's header, exported by the NDK's
+//! `libSDL2_ttf-2.0.so.0.18.0`, and present on **none of the 14 firmware inventories** — the NDK is
+//! 2.0.18 and every television ships 2.0.10 or 2.0.14
+//! (`tools/fwcompat.py --lib libSDL2_ttf-2.0.so.0 --grep '32$'` returns zero matches on all 14).
+//! It would therefore have compiled, linked and passed `make check`, then failed at the first
+//! coverage query on every set. `text.rs`'s `extern` block carries the general form of that trap.
+//!
+//! Either one also needs an open `TTF_Font` — a size, a GL-adjacent init and a device — which is
+//! precisely what a host gate must not need. Parsing the cmap answers the same question from the
+//! file alone.
+//!
+//! ## What it reads
+//!
+//! Only the sfnt table directory and the `cmap` table, by seek — never the whole file. That
+//! matters: `pkg/appfont-cjk.ttf` is 21 MB and its cmap is 233 KB. Unicode subtable formats 4, 6,
+//! 12 and 13 are decoded and **unioned**; a mapping to glyph 0 is not coverage and is excluded,
+//! which is the difference between "the cmap has an entry" and "the font can draw it".
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// A font's codepoint coverage: a flat bitset for the BMP, sorted ranges above it.
+///
+/// The BMP half is the hot one — `text.rs` asks per character on every cache-missing string — and
+/// 8 KB of bitset makes that a shift and a mask instead of a binary search. Astral codepoints
+/// (emoji, CJK ext-B) are rare enough in a Plex library to be worth a `partition_point`.
+pub(crate) struct Coverage {
+    bmp: Box<[u64; 1024]>,
+    sup: Vec<(u32, u32)>,
+    count: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CovErr {
+    Io(String),
+    /// The bytes are not an sfnt we recognise, or the table we need is missing/malformed. The
+    /// string names WHICH, because "the font is bad" is not an actionable log line.
+    Malformed(&'static str),
+}
+
+impl std::fmt::Display for CovErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CovErr::Io(e) => write!(f, "{e}"),
+            CovErr::Malformed(w) => write!(f, "malformed font: {w}"),
+        }
+    }
+}
+
+impl Coverage {
+    fn new() -> Coverage {
+        Coverage { bmp: Box::new([0u64; 1024]), sup: Vec::new(), count: 0 }
+    }
+
+    pub(crate) fn contains(&self, cp: u32) -> bool {
+        if cp <= 0xFFFF {
+            let i = cp as usize;
+            return self.bmp[i >> 6] & (1u64 << (i & 63)) != 0;
+        }
+        // ranges are sorted and disjoint: the last one starting at or before `cp` is the only
+        // candidate. `partition_point` is the standard spelling of "how many start <= cp".
+        let k = self.sup.partition_point(|&(s, _)| s <= cp);
+        k > 0 && self.sup[k - 1].1 >= cp
+    }
+
+    /// How many codepoints this font maps to a real glyph. The gate quotes it, and `text.rs` logs
+    /// it once per face so an event log says what the chain actually loaded.
+    pub(crate) fn len(&self) -> u32 {
+        self.count
+    }
+
+    fn add(&mut self, cp: u32) {
+        if cp > 0x10FFFF {
+            return;
+        }
+        if cp <= 0xFFFF {
+            let i = cp as usize;
+            let (w, b) = (i >> 6, 1u64 << (i & 63));
+            if self.bmp[w] & b == 0 {
+                self.bmp[w] |= b;
+                self.count += 1;
+            }
+        } else {
+            self.sup.push((cp, cp));
+        }
+    }
+
+    fn add_range(&mut self, lo: u32, hi: u32) {
+        if lo > hi {
+            return;
+        }
+        // The BMP part goes bit by bit (bounded by 65536 iterations); anything above is stored as
+        // a range, so a font mapping all of plane 2 costs one entry rather than 43 000.
+        let bmp_hi = hi.min(0xFFFF);
+        for cp in lo..=bmp_hi {
+            self.add(cp);
+        }
+        if hi > 0xFFFF {
+            let lo = lo.max(0x10000);
+            let hi = hi.min(0x10FFFF);
+            if lo <= hi {
+                self.sup.push((lo, hi));
+            }
+        }
+    }
+
+    /// Sort and coalesce the supplementary ranges, and only then count them. Subtables are unioned,
+    /// so the same astral codepoint can arrive from two of them; counting before the merge would
+    /// double it, and `contains` needs the sorted invariant `partition_point` assumes.
+    fn seal(&mut self) {
+        self.sup.sort_unstable();
+        let mut merged: Vec<(u32, u32)> = Vec::with_capacity(self.sup.len());
+        for &(lo, hi) in &self.sup {
+            match merged.last_mut() {
+                // `lo <= last.1 + 1` also coalesces ADJACENT ranges, which is what keeps a
+                // per-codepoint format-4 walk from leaving thousands of one-wide entries.
+                Some(last) if lo <= last.1.saturating_add(1) => last.1 = last.1.max(hi),
+                _ => merged.push((lo, hi)),
+            }
+        }
+        for &(lo, hi) in &merged {
+            self.count += hi - lo + 1;
+        }
+        self.sup = merged;
+    }
+}
+
+// --- sfnt / cmap decoding -----------------------------------------------------------------------
+
+fn be16(b: &[u8], off: usize) -> Option<u32> {
+    Some(u16::from_be_bytes(b.get(off..off + 2)?.try_into().ok()?) as u32)
+}
+fn be32(b: &[u8], off: usize) -> Option<u32> {
+    Some(u32::from_be_bytes(b.get(off..off + 4)?.try_into().ok()?))
+}
+
+fn read_at<R: Read + Seek>(r: &mut R, off: u64, len: usize) -> Result<Vec<u8>, CovErr> {
+    // A malformed directory can claim a table of any length; refuse absurd ones rather than
+    // trying to allocate them. No real cmap is anywhere near 32 MB (Noto Sans CJK's is 233 KB).
+    if len > 32 << 20 {
+        return Err(CovErr::Malformed("table length is implausible"));
+    }
+    r.seek(SeekFrom::Start(off)).map_err(|e| CovErr::Io(e.to_string()))?;
+    let mut v = vec![0u8; len];
+    r.read_exact(&mut v).map_err(|e| CovErr::Io(e.to_string()))?;
+    Ok(v)
+}
+
+/// Locate `cmap` in the sfnt directory and return its bytes. Handles a TrueType **collection**
+/// (`ttcf`) by taking font 0 — the shipped faces are not collections, but the upstream Noto CJK
+/// release ships `.ttc` files beside the `.ttf` we pin, and reading one as a plain sfnt would
+/// otherwise fail with a misleading "not an sfnt".
+fn cmap_bytes<R: Read + Seek>(r: &mut R) -> Result<Vec<u8>, CovErr> {
+    let mut base = 0u64;
+    let head = read_at(r, 0, 12)?;
+    if &head[0..4] == b"ttcf" {
+        let n = be32(&head, 8).ok_or(CovErr::Malformed("short ttc header"))?;
+        if n == 0 {
+            return Err(CovErr::Malformed("ttc with no fonts"));
+        }
+        let dir = read_at(r, 12, 4)?;
+        base = be32(&dir, 0).ok_or(CovErr::Malformed("short ttc directory"))? as u64;
+    }
+    let head = read_at(r, base, 12)?;
+    let tag = be32(&head, 0).ok_or(CovErr::Malformed("short sfnt header"))?;
+    // 0x00010000 TrueType outlines, 'OTTO' CFF outlines, 'true' the old Apple spelling. The cmap
+    // is in the same place in all three, which is the whole point of asking the directory.
+    if tag != 0x0001_0000 && tag != 0x4F54_544F && tag != 0x7472_7565 {
+        return Err(CovErr::Malformed("not an sfnt (bad version tag)"));
+    }
+    let num = be16(&head, 4).ok_or(CovErr::Malformed("short sfnt header"))? as usize;
+    let dir = read_at(r, base + 12, num.checked_mul(16).ok_or(CovErr::Malformed("absurd table count"))?)?;
+    for i in 0..num {
+        let rec = &dir[i * 16..];
+        if &rec[0..4] == b"cmap" {
+            let off = be32(rec, 8).ok_or(CovErr::Malformed("short cmap record"))?;
+            let len = be32(rec, 12).ok_or(CovErr::Malformed("short cmap record"))?;
+            return read_at(r, base + off as u64, len as usize);
+        }
+    }
+    Err(CovErr::Malformed("no cmap table"))
+}
+
+/// Is this (platform, encoding) pair a **Unicode** cmap? Platform 0 is Unicode by definition;
+/// platform 3 (Windows) is Unicode only at encoding 1 (BMP) and 10 (full repertoire). Encoding
+/// 3/0 is "symbol" — a private-use remapping that would report coverage the font cannot really
+/// draw at the codepoints claimed — and platform 1 is Mac Roman. Both are skipped.
+fn is_unicode(platform: u32, encoding: u32) -> bool {
+    platform == 0 || (platform == 3 && (encoding == 1 || encoding == 10))
+}
+
+fn parse_format4(t: &[u8], cov: &mut Coverage) -> Option<()> {
+    let seg2 = be16(t, 6)? as usize;
+    let segs = seg2 / 2;
+    let (end_at, start_at, delta_at, ro_at) = (14, 16 + seg2, 16 + 2 * seg2, 16 + 3 * seg2);
+    for i in 0..segs {
+        let end = be16(t, end_at + 2 * i)?;
+        let start = be16(t, start_at + 2 * i)?;
+        let delta = be16(t, delta_at + 2 * i)?;
+        let ro = be16(t, ro_at + 2 * i)?;
+        if start > end {
+            continue;
+        }
+        for cp in start..=end {
+            if cp == 0xFFFF {
+                continue; // the mandatory terminating segment, never real coverage
+            }
+            let g = if ro == 0 {
+                (cp.wrapping_add(delta)) & 0xFFFF
+            } else {
+                // The spec's pointer arithmetic: idRangeOffset is a byte offset FROM ITS OWN slot.
+                let at = ro_at + 2 * i + ro as usize + 2 * (cp - start) as usize;
+                match be16(t, at) {
+                    Some(0) | None => 0,
+                    Some(g) => (g.wrapping_add(delta)) & 0xFFFF,
+                }
+            };
+            if g != 0 {
+                cov.add(cp);
+            }
+        }
+    }
+    Some(())
+}
+
+fn parse_format6(t: &[u8], cov: &mut Coverage) -> Option<()> {
+    let first = be16(t, 6)?;
+    let n = be16(t, 8)? as usize;
+    for i in 0..n {
+        if be16(t, 10 + 2 * i)? != 0 {
+            cov.add(first + i as u32);
+        }
+    }
+    Some(())
+}
+
+/// Formats 12 (segmented) and 13 (many-to-one). Identical headers; they differ only in whether
+/// `startGlyphID` advances across the group, which does not change WHICH codepoints are covered.
+fn parse_format12_13(t: &[u8], many_to_one: bool, cov: &mut Coverage) -> Option<()> {
+    let n = be32(t, 12)? as usize;
+    // The bounds check is done in u64, and that is load-bearing rather than tidy: **`usize` is
+    // 32 BITS on `arm-unknown-linux-gnueabi`**, the only target that ships. A `numGroups` of
+    // 357_913_941 makes `n * 12` exactly 0xFFFF_FFFC, so `16 + n * 12` WRAPS to 12 — which is
+    // ≤ `t.len()` — and the indexing below then panics out of the SDL main thread on the second
+    // group. Release builds have overflow checks off, so it wraps silently rather than aborting.
+    // No host test can catch this: `cargo test` runs on a 64-bit Mac where the same expression is
+    // simply true. In u64 the product cannot overflow for any u32 count, on either width.
+    if 16u64 + n as u64 * 12 > t.len() as u64 {
+        return None;
+    }
+    for i in 0..n {
+        let g = &t[16 + i * 12..];
+        let (lo, hi, gid) = (be32(g, 0)?, be32(g, 4)?, be32(g, 8)?);
+        if lo > hi || hi > 0x10FFFF {
+            continue;
+        }
+        if gid == 0 {
+            // Format 13 maps the whole group to one glyph, so gid 0 means the group is empty;
+            // format 12 walks the glyph id, so only the first codepoint lands on notdef.
+            if !many_to_one && lo < hi {
+                cov.add_range(lo + 1, hi);
+            }
+            continue;
+        }
+        cov.add_range(lo, hi);
+    }
+    Some(())
+}
+
+/// Coverage of the font in `r`, unioned across every Unicode cmap subtable it carries. The test
+/// seam: it takes any `Read + Seek`, which is what lets the decoder be driven from a `Cursor` over
+/// a synthetic sfnt — shapes no shipped font has, like a cmap entry pointing at glyph 0.
+/// Production reads a path and goes through [`of_file`], which closes the file sooner.
+#[cfg(test)]
+pub(crate) fn of_reader<R: Read + Seek>(r: &mut R) -> Result<Coverage, CovErr> {
+    decode(&cmap_bytes(r)?)
+}
+
+/// The decode half, split from the I/O half so [`of_file`] can CLOSE the file before doing the
+/// slow part. The walk over a pan-CJK format-4 subtable is milliseconds and the read is
+/// microseconds; holding a descriptor across the difference is free to avoid and not free to keep
+/// (`stream.rs`'s fd-leak assertion grades the process-wide count, and the host suite reads these
+/// fonts from several tests at once).
+fn decode(t: &[u8]) -> Result<Coverage, CovErr> {
+    let n = be16(t, 2).ok_or(CovErr::Malformed("short cmap header"))? as usize;
+    let mut cov = Coverage::new();
+    let mut seen = 0usize;
+    for i in 0..n {
+        let rec = 4 + 8 * i;
+        let (Some(plat), Some(enc), Some(off)) = (be16(&t, rec), be16(&t, rec + 2), be32(&t, rec + 4)) else {
+            break;
+        };
+        if !is_unicode(plat, enc) {
+            continue;
+        }
+        let Some(sub) = t.get(off as usize..) else { continue };
+        let Some(format) = be16(sub, 0) else { continue };
+        // Formats 0 (byte), 2 (high-byte CJK legacy) and 14 (variation selectors) are `None`, and
+        // that is the point: `seen` counts subtables this decoder ACTUALLY READ, never ones it
+        // skipped. Counting a skip made a font whose only Unicode subtables are unsupported decode
+        // as `Ok(<empty coverage>)` instead of `Err`, and the two are not interchangeable
+        // downstream — `text.rs::link_covers` falls back to "the base face covers everything" only
+        // on `Err`, and takes an empty `Ok` as authoritative. The result would have been that every
+        // accented Latin, Cyrillic and Greek character failed Inter and resolved to the CJK
+        // fallback, which carries a full Latin set: the whole interface silently in the wrong
+        // typeface, with no error anywhere.
+        let decoded = match format {
+            4 => parse_format4(sub, &mut cov),
+            6 => parse_format6(sub, &mut cov),
+            12 => parse_format12_13(sub, false, &mut cov),
+            13 => parse_format12_13(sub, true, &mut cov),
+            _ => None,
+        };
+        if decoded.is_some() {
+            seen += 1;
+        }
+    }
+    if seen == 0 {
+        return Err(CovErr::Malformed("no usable Unicode cmap subtable"));
+    }
+    cov.seal();
+    Ok(cov)
+}
+
+/// The errors do NOT name `path` — every caller has it and prefixes its own message with it, and
+/// a doubled path reads as a bug in the error plumbing rather than as the missing file it is.
+pub(crate) fn of_file(path: &Path) -> Result<Coverage, CovErr> {
+    let cmap = {
+        let mut f = File::open(path).map_err(|e| CovErr::Io(e.to_string()))?;
+        cmap_bytes(&mut f)? // `f` is dropped HERE, before `decode` — see `decode`'s doc
+    };
+    decode(&cmap)
+}
+
+/// The shipped faces' coverage, parsed ONCE for the whole test binary.
+///
+/// Two reasons, both measured on the way in. The fallback's cmap is 233 KB and its format-4 walk
+/// is the most expensive thing this module does; and every `of_file` holds a descriptor, so
+/// fourteen tests reading three fonts in parallel moved the PROCESS-wide descriptor count enough
+/// to trip `stream.rs`'s fd-leak assertion — whose slack is +8 over whatever the rest of the suite
+/// happens to be holding, and which then fails naming a leak that does not exist. Parsing once
+/// turns fourteen concurrent opens into three sequential ones.
+#[cfg(test)]
+pub(crate) fn shipped(name: &str) -> &'static Result<Coverage, String> {
+    use std::sync::OnceLock;
+    static REG: OnceLock<Result<Coverage, String>> = OnceLock::new();
+    static BOLD: OnceLock<Result<Coverage, String>> = OnceLock::new();
+    static CJK: OnceLock<Result<Coverage, String>> = OnceLock::new();
+    let slot = match name {
+        "appfont.ttf" => &REG,
+        "appfont-bold.ttf" => &BOLD,
+        "appfont-cjk.ttf" => &CJK,
+        other => panic!("no shipped-font slot for {other:?} — add one beside the other three"),
+    };
+    slot.get_or_init(|| {
+        // The fonts are repository payload, not crate data — `pkg/` sits beside `rust-modules/`.
+        let p = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../pkg")).join(name);
+        of_file(&p).map_err(|e| format!("{}: {e}", p.display()))
+    })
+}
+
+// ------------------------------------------------------------------------------------------------
+// THE GATE. Everything below runs in `make check`.
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn cov(name: &str) -> &'static Coverage {
+        shipped(name).as_ref().unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Every codepoint in `lo..=hi` that the coverage is missing, capped so a totally absent
+    /// block reports as a block rather than eleven thousand lines.
+    fn missing(c: &Coverage, lo: u32, hi: u32) -> Vec<u32> {
+        (lo..=hi).filter(|&cp| !c.contains(cp)).take(12).collect()
+    }
+
+    fn count(c: &Coverage, lo: u32, hi: u32) -> u32 {
+        (lo..=hi).filter(|&cp| c.contains(cp)).count() as u32
+    }
+
+    // --- the declared set ------------------------------------------------------------------------
+    //
+    // LINK 1 — `appfont.ttf` / `appfont-bold.ttf` (Inter, cut by tools/cut-inter.py). Every
+    // codepoint the product chrome itself can emit, plus the scripts the Plex libraries this
+    // client is built for actually contain. Whole blocks, not samples: a partial block is how
+    // "Cyrillic works" and "Ё is a box" coexist.
+    const LINK1_BLOCKS: &[(&str, u32, u32)] = &[
+        ("ASCII printable", 0x0020, 0x007E),
+        ("Latin-1 letters", 0x00C0, 0x00FF),
+        // Split around U+0149 (ŉ), which Inter does not carry and should not: Unicode DEPRECATED
+        // it, no locale produces it, and it decomposes to U+02BC U+006E. Excluding it here is the
+        // difference between a declared set and a wish list — every other position is asserted.
+        ("Latin Extended-A (before U+0149)", 0x0100, 0x0148),
+        ("Latin Extended-A (after U+0149)", 0x014A, 0x017E),
+        // U+03A2 is a permanent hole in Unicode itself (reserved between Ρ and Σ), so the block
+        // is split around it for the same reason as U+0149 above.
+        ("Greek and Coptic (before U+03A2)", 0x0391, 0x03A1),
+        ("Greek and Coptic (after U+03A2)", 0x03A3, 0x03CE),
+        ("Cyrillic", 0x0400, 0x045F),
+        // The regression that named this whole unit. Subtitle convention wraps a sung line in
+        // these four; Inter has none of them, and `tools/cut-inter.py` synthesizes them. A panel
+        // capture of the Family Guy theme read "▯NO GLYPH▯ It seems today" before it did.
+        ("musical symbols (subtitle convention)", 0x2669, 0x266C),
+    ];
+
+    /// Individual codepoints link 1 must carry: the typographic punctuation the UI composes by
+    /// hand (`elide` appends U+2026; headings join with U+00B7; PMS metadata is full of curly
+    /// quotes and en/em dashes) and the marks drawn beside ratings.
+    const LINK1_CHARS: &[(&str, char)] = &[
+        ("ellipsis (elide appends it)", '\u{2026}'),
+        ("middle dot (heading separator)", '\u{00B7}'),
+        ("bullet", '\u{2022}'),
+        ("en dash", '\u{2013}'),
+        ("em dash", '\u{2014}'),
+        ("left single quote", '\u{2018}'),
+        ("right single quote / apostrophe", '\u{2019}'),
+        ("left double quote", '\u{201C}'),
+        ("right double quote", '\u{201D}'),
+        ("multiplication sign", '\u{00D7}'),
+        ("degree sign", '\u{00B0}'),
+        ("no-break space", '\u{00A0}'),
+        ("copyright", '\u{00A9}'),
+        ("registered", '\u{00AE}'),
+    ];
+
+    // LINK 2 — `appfont-cjk.ttf` (Noto Sans CJK KR, cut by tools/cut-noto-cjk.py). Checklist #6
+    // and #48 are unreachable without these: a Korean, Japanese or Chinese title is 100 % tofu
+    // in link 1.
+    const LINK2_BLOCKS: &[(&str, u32, u32)] = &[
+        ("Hangul syllables", 0xAC00, 0xD7A3),
+        ("Hangul Jamo", 0x1100, 0x11FF),
+        ("Hangul Compatibility Jamo (letters)", 0x3131, 0x318E),
+        ("Hiragana", 0x3041, 0x3096),
+        ("Katakana", 0x30A1, 0x30FA),
+        ("CJK symbols and punctuation", 0x3000, 0x303F),
+    ];
+
+    /// Han is not asserted as a whole block: Unicode leaves a handful of positions unassigned in
+    /// every CJK range, and a floor is the honest shape of "this font draws Chinese". The numbers
+    /// are the measured coverage of the pinned cut, so a subsetted or truncated replacement fails.
+    const LINK2_FLOORS: &[(&str, u32, u32, u32)] = &[
+        ("CJK unified ideographs", 0x4E00, 0x9FFF, 20_900),
+        ("CJK unified ideographs ext-A", 0x3400, 0x4DBF, 6_500),
+        ("halfwidth and fullwidth forms", 0xFF00, 0xFFEF, 200),
+    ];
+
+    /// Real titles, in the scripts the chain claims. A block assertion cannot catch a font whose
+    /// cmap is fine and whose *combination* is not, and these read as evidence in a PR body.
+    const SAMPLES: &[(&str, &str)] = &[
+        ("Korean", "오징어 게임 · 기생충 · 부산행"),
+        ("Japanese", "君の名は。 千と千尋の神隠し ドラえもん"),
+        ("Chinese (simplified)", "流浪地球 · 让子弹飞"),
+        ("Chinese (traditional)", "臥虎藏龍 · 東京物語"),
+        ("Russian", "Ирония судьбы, или С лёгким паром!"),
+        ("Greek", "Ο Θίασος"),
+        ("Latin with diacritics", "Amélie · Das Boot · Coração"),
+        ("subtitle sung line", "\u{266A} It seems today \u{266B}"),
+    ];
+
+    /// Report EVERY gap in one run, not the first. A fail-fast gate over eight blocks and
+    /// fourteen characters makes a font swap an eight-iteration guessing game, which is how a
+    /// re-cut ends up half-checked.
+    fn report(font: &str, gaps: Vec<String>) {
+        assert!(gaps.is_empty(), "pkg/{font} does not cover the declared set:\n  {}", gaps.join("\n  "));
+    }
+
+    #[test]
+    fn shipped_regular_font_covers_the_declared_latin_set() {
+        let c = cov("appfont.ttf");
+        let mut gaps = Vec::new();
+        for &(name, lo, hi) in LINK1_BLOCKS {
+            let m = missing(&c, lo, hi);
+            if !m.is_empty() {
+                gaps.push(format!("{name} (U+{lo:04X}..U+{hi:04X}) is missing {m:04X?}"));
+            }
+        }
+        for &(name, ch) in LINK1_CHARS {
+            if !c.contains(ch as u32) {
+                gaps.push(format!("{name} (U+{:04X})", ch as u32));
+            }
+        }
+        report("appfont.ttf", gaps);
+    }
+
+    /// The bold face is a separate cut and can rot on its own. A bold-only hole is invisible in
+    /// every other tier — the same string renders fine as body text and tofus as a heading.
+    #[test]
+    fn bold_face_covers_exactly_what_the_regular_one_does() {
+        let (r, b) = (cov("appfont.ttf"), cov("appfont-bold.ttf"));
+        assert_eq!(r.len(), b.len(), "appfont.ttf covers {} codepoints, appfont-bold.ttf {}", r.len(), b.len());
+        for &(name, lo, hi) in LINK1_BLOCKS {
+            for cp in lo..=hi {
+                assert_eq!(r.contains(cp), b.contains(cp), "regular/bold disagree on U+{cp:04X} ({name})");
+            }
+        }
+        for &(name, ch) in LINK1_CHARS {
+            assert!(b.contains(ch as u32), "pkg/appfont-bold.ttf is missing {name} (U+{:04X})", ch as u32);
+        }
+    }
+
+    #[test]
+    fn bundled_fallback_covers_the_declared_cjk_set() {
+        let c = cov("appfont-cjk.ttf");
+        let mut gaps = Vec::new();
+        for &(name, lo, hi) in LINK2_BLOCKS {
+            let m = missing(&c, lo, hi);
+            if !m.is_empty() {
+                gaps.push(format!("{name} (U+{lo:04X}..U+{hi:04X}) is missing {m:04X?}"));
+            }
+        }
+        for &(name, lo, hi, floor) in LINK2_FLOORS {
+            let n = count(&c, lo, hi);
+            if n < floor {
+                gaps.push(format!("{name}: {n} codepoints, expected at least {floor}"));
+            }
+        }
+        report("appfont-cjk.ttf", gaps);
+    }
+
+    /// Pins the cut itself. `tools/cut-noto-cjk.py` pins its INPUT by sha256; this pins its
+    /// OUTPUT, so a re-cut that silently subsets (the `Subset/NotoSansKR-VF.ttf` mistake the
+    /// script's docstring warns about drops ~5000 Han ideographs) fails here rather than on a
+    /// reviewer's television.
+    #[test]
+    fn bundled_fallback_is_the_pinned_cut() {
+        let c = cov("appfont-cjk.ttf");
+        assert_eq!(
+            c.len(), 44_810,
+            "pkg/appfont-cjk.ttf covers {} codepoints, not the 44810 of Noto Sans CJK KR \
+             (noto-cjk @ Sans2.004, Sans/Variable/TTF/NotoSansCJKkr-VF.ttf, instanced at wght 400). \
+             If the pin moved on purpose, move this number and tools/cut-noto-cjk.py's together.",
+            c.len()
+        );
+    }
+
+    /// The whole point: the chain, not any one link. This is the assertion that would have
+    /// failed on 2026-08-22 and passed on 2026-08-23.
+    #[test]
+    fn the_shipped_chain_can_draw_every_sample_string() {
+        let links = [cov("appfont.ttf"), cov("appfont-cjk.ttf")];
+        for &(script, s) in SAMPLES {
+            let bad: Vec<char> = s.chars().filter(|&ch| !links.iter().any(|c| c.contains(ch as u32))).collect();
+            assert!(bad.is_empty(), "{script}: the shipped chain cannot draw {bad:?} in {s:?}");
+        }
+    }
+
+    /// **RTL is out of scope, and this is where that is written down as a test rather than a
+    /// comment.** Neither shipped face carries Hebrew or Arabic — and neither does the television's
+    /// own `/usr/share/fonts/DroidSansFallback.ttf` (measured on webOS 4.10.0, 2026-08-23: 11172
+    /// Hangul, 20902 Han, zero Hebrew, zero Arabic), so no link of the chain can draw them.
+    ///
+    /// Coverage would not be enough even if it existed. "The font contains the codepoint" is not
+    /// "the renderer supports the script": Arabic needs joining and contextual shaping, Hebrew
+    /// needs bidi reordering, and `text.rs` has neither — it hands byte runs to
+    /// `TTF_RenderUTF8_Blended`, which in SDL2_ttf 2.0.x is a left-to-right advance loop with no
+    /// shaper behind it. Adding a face here would turn tofu into *fluent-looking wrong text*,
+    /// which is worse.
+    ///
+    /// So this test asserts the ABSENCE, deliberately: it fails the moment someone adds an RTL
+    /// face, and the failure message is the reason not to. **Checklist #6 / #48 must not be marked
+    /// Pass for RTL content on the strength of this unit.**
+    #[test]
+    fn rtl_is_out_of_scope_and_stays_that_way() {
+        for name in ["appfont.ttf", "appfont-cjk.ttf"] {
+            let c = cov(name);
+            for (script, lo, hi) in [("Hebrew", 0x05D0u32, 0x05EAu32), ("Arabic", 0x0620, 0x064A)] {
+                let n = count(&c, lo, hi);
+                assert_eq!(
+                    n, 0,
+                    "pkg/{name} now carries {n} {script} codepoints. Coverage is NOT support: \
+                     text.rs does no bidi and no shaping, so this would render fluent-looking \
+                     wrong text instead of tofu. Ship a shaper before you ship the face, and do \
+                     not mark checklist #6/#48 Pass for RTL until you have."
+                );
+            }
+        }
+    }
+
+    // --- decoder unit tests, on synthetic sfnts -------------------------------------------------
+
+    /// A minimal one-table sfnt wrapping `cmap`, so the decoder can be exercised on shapes no
+    /// shipped font has (a notdef mapping, a format 12 group, a truncated table).
+    fn sfnt(cmap: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&0x0001_0000u32.to_be_bytes());
+        v.extend_from_slice(&1u16.to_be_bytes()); // numTables
+        v.extend_from_slice(&[0; 6]); // searchRange/entrySelector/rangeShift
+        v.extend_from_slice(b"cmap");
+        v.extend_from_slice(&0u32.to_be_bytes()); // checksum
+        v.extend_from_slice(&28u32.to_be_bytes()); // offset (12 + 16)
+        v.extend_from_slice(&(cmap.len() as u32).to_be_bytes());
+        v.extend_from_slice(cmap);
+        v
+    }
+
+    /// cmap header + one subtable record pointing at `sub`.
+    fn cmap1(platform: u16, encoding: u16, sub: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&0u16.to_be_bytes());
+        v.extend_from_slice(&1u16.to_be_bytes());
+        v.extend_from_slice(&platform.to_be_bytes());
+        v.extend_from_slice(&encoding.to_be_bytes());
+        v.extend_from_slice(&12u32.to_be_bytes());
+        v.extend_from_slice(sub);
+        v
+    }
+
+    fn format12(groups: &[(u32, u32, u32)]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&12u16.to_be_bytes());
+        v.extend_from_slice(&0u16.to_be_bytes()); // reserved
+        v.extend_from_slice(&(16 + 12 * groups.len() as u32).to_be_bytes());
+        v.extend_from_slice(&0u32.to_be_bytes()); // language
+        v.extend_from_slice(&(groups.len() as u32).to_be_bytes());
+        for &(lo, hi, gid) in groups {
+            v.extend_from_slice(&lo.to_be_bytes());
+            v.extend_from_slice(&hi.to_be_bytes());
+            v.extend_from_slice(&gid.to_be_bytes());
+        }
+        v
+    }
+
+    /// A cmap entry pointing at glyph 0 is a mapping to `.notdef` — the tofu box itself. Counting
+    /// it as coverage is exactly the bug this module exists to prevent: the chain would resolve
+    /// the run to a face that draws a box, and never consult the next link.
+    #[test]
+    fn a_mapping_to_glyph_zero_is_not_coverage() {
+        let f = sfnt(&cmap1(3, 10, &format12(&[(0x41, 0x43, 0), (0x61, 0x62, 7)])));
+        let c = of_reader(&mut Cursor::new(f)).expect("decodes");
+        assert!(!c.contains(0x41), "U+0041 maps to glyph 0");
+        assert!(c.contains(0x42) && c.contains(0x43), "the rest of the group walks off glyph 1, 2");
+        assert!(c.contains(0x61) && c.contains(0x62));
+        assert_eq!(c.len(), 4);
+    }
+
+    /// Astral coverage lives in a range list, not the bitset. `partition_point` has an off-by-one
+    /// on both edges of every range, and the whole emoji/CJK-ext-B plane rides on it.
+    #[test]
+    fn supplementary_plane_ranges_answer_at_both_edges() {
+        let f = sfnt(&cmap1(3, 10, &format12(&[(0x2_0000, 0x2_A6DF, 1), (0x1_F600, 0x1_F64F, 9)])));
+        let c = of_reader(&mut Cursor::new(f)).expect("decodes");
+        for cp in [0x2_0000, 0x2_A6DF, 0x1_F600, 0x1_F64F, 0x2_5000] {
+            assert!(c.contains(cp), "U+{cp:05X} is inside a declared group");
+        }
+        for cp in [0x1_FFFF, 0x2_A6E0, 0x1_F5FF, 0x1_F650] {
+            assert!(!c.contains(cp), "U+{cp:05X} is outside every declared group");
+        }
+        assert_eq!(c.len(), (0x2_A6DF - 0x2_0000 + 1) + (0x1_F64F - 0x1_F600 + 1));
+    }
+
+    /// Format 4's second addressing mode (`idRangeOffset != 0`) indexes a trailing glyph array by
+    /// pointer arithmetic relative to its own slot. It is the mode every real font uses for its
+    /// sparse segments, and getting the base wrong silently reports a plausible WRONG set.
+    #[test]
+    fn format4_honours_the_id_range_offset_indirection() {
+        // one real segment U+0041..U+0043 through glyphIdArray, plus the mandatory 0xFFFF segment
+        let mut sub: Vec<u8> = Vec::new();
+        let seg2 = 4u16;
+        sub.extend_from_slice(&4u16.to_be_bytes()); // format
+        sub.extend_from_slice(&0u16.to_be_bytes()); // length (unused by the decoder)
+        sub.extend_from_slice(&0u16.to_be_bytes()); // language
+        sub.extend_from_slice(&seg2.to_be_bytes());
+        sub.extend_from_slice(&[0; 6]); // searchRange/entrySelector/rangeShift
+        sub.extend_from_slice(&0x0043u16.to_be_bytes()); // endCode[0]
+        sub.extend_from_slice(&0xFFFFu16.to_be_bytes()); // endCode[1]
+        sub.extend_from_slice(&0u16.to_be_bytes()); // reservedPad
+        sub.extend_from_slice(&0x0041u16.to_be_bytes()); // startCode[0]
+        sub.extend_from_slice(&0xFFFFu16.to_be_bytes()); // startCode[1]
+        sub.extend_from_slice(&0u16.to_be_bytes()); // idDelta[0]
+        sub.extend_from_slice(&1u16.to_be_bytes()); // idDelta[1]
+        // idRangeOffset[0] must skip the rest of the array (2 entries * 2 bytes = 4) to reach
+        // glyphIdArray; entry 1 is the terminator and addresses nothing.
+        sub.extend_from_slice(&4u16.to_be_bytes());
+        sub.extend_from_slice(&0u16.to_be_bytes());
+        sub.extend_from_slice(&5u16.to_be_bytes()); // glyphIdArray: U+0041 -> 5
+        sub.extend_from_slice(&0u16.to_be_bytes()); //               U+0042 -> notdef
+        sub.extend_from_slice(&6u16.to_be_bytes()); //               U+0043 -> 6
+        let c = of_reader(&mut Cursor::new(sfnt(&cmap1(3, 1, &sub)))).expect("decodes");
+        assert!(c.contains(0x41) && c.contains(0x43));
+        assert!(!c.contains(0x42), "U+0042 indexes a zero in glyphIdArray");
+        assert!(!c.contains(0xFFFF), "the terminating segment is not coverage");
+        assert_eq!(c.len(), 2);
+    }
+
+    /// A symbol cmap (3,0) remaps into the private-use area; treating it as Unicode would claim
+    /// coverage of U+F020.. that no caller can ever ask for, and — worse — could make a garbage
+    /// font look like it covers the declared set.
+    #[test]
+    fn non_unicode_subtables_are_ignored() {
+        let f = sfnt(&cmap1(3, 0, &format12(&[(0xF020, 0xF0FF, 1)])));
+        let err = of_reader(&mut Cursor::new(f)).err().expect("a symbol-only cmap has no Unicode coverage");
+        assert_eq!(err, CovErr::Malformed("no usable Unicode cmap subtable"));
+    }
+
+    /// Truncation must be an error, never a panic. `text.rs` calls this on a file the installer
+    /// wrote, which is exactly where a short read comes from — and it runs on the SDL thread.
+    #[test]
+    fn a_truncated_font_is_an_error_not_a_panic() {
+        let full = sfnt(&cmap1(3, 10, &format12(&[(0x41, 0x5A, 1)])));
+        for cut in [0, 4, 11, 20, 30, full.len() - 1] {
+            let r = of_reader(&mut Cursor::new(full[..cut].to_vec()));
+            assert!(r.is_err(), "a font truncated to {cut} bytes decoded successfully");
+        }
+        // ...and a group count the table cannot hold must not be trusted either. The last two are
+        // the values that WRAP a 32-bit `usize`, which is the width the shipped ARM binary uses:
+        // 12 × 357_913_941 is 0xFFFF_FFFC, so `16 + n * 12` becomes 12 in 32-bit arithmetic and
+        // sails through a naive bounds check. This assertion cannot fail on the 64-bit dev Mac
+        // whichever way `parse_format12_13` is written — it is here to pin the intent and to fail
+        // for anyone who runs the suite on a 32-bit host. The guarantee itself comes from doing
+        // the arithmetic in u64; see the comment at the check.
+        for groups in [9999u32, 357_913_941, 357_913_942, u32::MAX] {
+            let mut lying = format12(&[(0x41, 0x5A, 1)]);
+            lying[12..16].copy_from_slice(&groups.to_be_bytes());
+            let r = of_reader(&mut Cursor::new(sfnt(&cmap1(3, 10, &lying))));
+            assert!(r.is_err(), "a format 12 claiming {groups} groups in 28 bytes decoded successfully");
+        }
+    }
+
+    /// A font whose only Unicode cmap subtable is one this decoder does not read must be an
+    /// **error**, never an empty success. `text.rs::link_covers` falls back to "the base face
+    /// covers everything" on `Err` and treats `Ok` as authoritative, so an empty `Ok` for
+    /// `appfont.ttf` would push every accented Latin, Cyrillic and Greek character onto the CJK
+    /// fallback — which has a full Latin set — and silently render the interface in the wrong
+    /// typeface with nothing logged.
+    #[test]
+    fn a_font_with_only_unsupported_subtables_is_an_error_not_empty_coverage() {
+        // format 0: a 256-byte byte-encoding table. Unicode platform, so it is not skipped as
+        // non-Unicode — it is skipped because the decoder does not read format 0.
+        let mut sub = vec![0u8; 262];
+        sub[0..2].copy_from_slice(&0u16.to_be_bytes()); // format 0
+        sub[2..4].copy_from_slice(&262u16.to_be_bytes());
+        for (i, b) in sub.iter_mut().enumerate().skip(6) {
+            *b = (i - 6) as u8; // every byte maps to a non-zero glyph
+        }
+        let err = of_reader(&mut Cursor::new(sfnt(&cmap1(3, 1, &sub))))
+            .err()
+            .expect("a format-0-only cmap is not coverage this decoder can vouch for");
+        assert_eq!(err, CovErr::Malformed("no usable Unicode cmap subtable"));
+    }
+}

--- a/rust-modules/src/lib.rs
+++ b/rust-modules/src/lib.rs
@@ -20,6 +20,7 @@ mod dynlib; // dlopen-by-SONAME-candidate: the libraries whose major moves betwe
 mod egl; // boot-time EGL capability probe (extensions, swap behaviour, buffer age) — diagnostic only
 mod ff; // FFmpeg (libavformat/libavcodec/libavutil) demuxer — the TV's own FFmpeg 3.3 via the stub-.so link
 mod focusprobe; // dev: one diffable line naming everything app.rs's key ladder can move, logged when it changes
+mod fontcov; // which codepoints a font file can draw, read from its cmap — text.rs's fallback chain, and the host gate that stops tofu shipping
 mod gfx;
 #[cfg(feature = "devtriggers")]
 mod hwcnt; // direct userspace Mali r12p0 vinstr reader for the phase profiler

--- a/rust-modules/src/text.rs
+++ b/rust-modules/src/text.rs
@@ -2,6 +2,66 @@
 //! draw_text. Main-thread only (all GL), so the caches are plain statics (no
 //! locking). Uses gfx's link_program/use_prog (crate path). Mostly GL/TTF FFI —
 //! the retui text backend.
+//!
+//! # The fallback chain, and why the unit of work is a RUN
+//!
+//! Inter carries 2853 codepoints — Latin, Cyrillic, Greek — and no Hangul, Kana or Han at all, so
+//! a Korean, Japanese or Chinese Plex library used to render as tofu end to end. SDL2_ttf 2.0.x
+//! has **no fallback-font API**: one `TTF_Font` is one face, and `TTF_RenderUTF8_Blended` draws
+//! whatever that one face has, box glyphs included. So the chain has to be built here, and
+//! building it means changing the unit of work from a *string* to a **run**:
+//!
+//!   1. split the string into maximal runs, each entirely drawable by ONE face
+//!      ([`split_runs`], deciding per character through [`crate::fontcov`]),
+//!   2. render each run with its own face,
+//!   3. composite the run surfaces side by side, **aligned on the baseline**, into one buffer,
+//!   4. upload that buffer exactly as a single-run string was uploaded before.
+//!
+//! Step 4 is what keeps everything downstream unchanged: the 160-slot LRU still keys on
+//! `(string bytes, size, bold)` — run splitting is a pure function of the string, so the key still
+//! determines the texture — and the `ink_t`/`ink_b` cap-band machinery still measures one texture.
+//!
+//! **The chain, in order:** Inter (`appfont.ttf`) → the **bundled** `appfont-cjk.ttf` → the
+//! television's own `/usr/share/fonts/DroidSansFallback.ttf`. The bundled face is the guarantee,
+//! because a submission is graded on whatever firmware the reviewer happens to have; the system
+//! face behind it is free insurance, measured present on webOS 4.10.0 (2026-08-23: 11172/11172
+//! Hangul, 20902 Han, Kana, and — see below — no Hebrew and no Arabic).
+//!
+//! **Baseline, not top.** Two faces have two line boxes, so compositing by the surface top would
+//! shift Latin down whenever a CJK glyph shared the line. Every run is placed so its baseline
+//! lands on the BASE face's baseline (`TTF_RenderUTF8_Blended` puts the baseline `TTF_FontAscent`
+//! rows from the top), and the composite keeps the base face's box. That box provably contains the
+//! fallback's ink at every rung of `theme::size`: measured host-side through FreeType with
+//! SDL_ttf's own metric arithmetic, Noto Sans CJK's ink top is 16..53 px against Inter's 22..70 px
+//! ascent for 22..72 px sizes, and its descent is shallower at every rung. Swept across the whole
+//! Hangul / Han / Kana / fullwidth repertoire the fallback's ink reaches 0.842–0.939 em above the
+//! baseline against Inter's 0.9688 em ascent, so the `y < 0` guard in [`render_runs`] discards only
+//! blank rows. The single exception in the font is **U+3031** (a vertical-writing kana repeat mark,
+//! 1.323 em), which SDL_ttf already clips inside its own run surface before the compositor sees it.
+//!
+//! One consequence of anchoring on the base face, worth knowing before anyone reports it as a bug:
+//! `text_cap_band` still measures Inter's "H", so a CJK label vertically centred through
+//! [`text_vcenter_y`] is centred on INTER's cap band, not on its own ink. CJK glyphs fill more of
+//! the em than Latin caps do (at 28 px: ink 21 px above the baseline against Inter's 15), so such a
+//! label sits ~1–2 px lower than optically centred. That is deliberate, not an oversight — the cap
+//! band is string-INDEPENDENT by design (see [`text_cap_band`]), which is what makes every label of
+//! a size align with every other, and making it depend on the script would break that for the mixed
+//! lines this feature exists to draw.
+//!
+//! **The fallback face is NOT emboldened for bold runs.** It ships at one weight (a second is
+//! ~21 MB), and SDL_ttf's synthetic bold is `FT_Outline_Embolden` at ppem/10 — 2.2 px at
+//! `size::MICRO`. Rendered against this face that fills 電視劇, 曇天 and 鬱 into solid blocks at
+//! **every** size in the ladder, 22 through 40. A weight mismatch beside bold Latin is a
+//! typographic compromise; an illegible ideograph is a defect, so bold runs use the regular
+//! fallback face.
+//!
+//! **RTL is out of scope.** No link of the chain has Hebrew or Arabic, and that is deliberate
+//! twice over: coverage is not support. Arabic needs joining and contextual shaping, Hebrew needs
+//! bidi reordering, and neither exists anywhere in this module — `TTF_RenderUTF8_Blended` in
+//! SDL2_ttf 2.0.x is a left-to-right advance loop with no shaper behind it. Adding a face without
+//! a shaper would turn tofu into fluent-looking WRONG text, which is harder to notice and worse to
+//! ship. `fontcov`'s `rtl_is_out_of_scope_and_stays_that_way` asserts the absence so this stays a
+//! decision rather than an oversight.
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -69,6 +129,34 @@ extern "C" {
     /// on device 2026-07-29 by dumping its dynamic symbols), and in the NDK sysroot copy we link
     /// against, so this resolves for real at link time like every other TTF symbol here.
     fn TTF_SizeUTF8(font: *mut TtfFont, text: *const c_char, w: *mut c_int, h: *mut c_int) -> c_int;
+    /// Rows from the top of a `TTF_RenderUTF8_Blended` surface to the BASELINE — the anchor the
+    /// run compositor aligns every face on. `TTF_FontHeight` is that surface's height. Both are
+    /// plain metric readers with no allocation.
+    ///
+    /// **Declared here rather than routed through `dynlib!` because the SONAME holds still**, which
+    /// is that module's actual criterion — `libSDL2_ttf-2.0.so.0` on all 14 firmware inventories
+    /// (`tools/fwcompat.py --inventory libSDL2_ttf`), unlike libcurl's `.so.5`→`.so.4`. Symbol
+    /// presence is the second half, also 14/14 (`--lib libSDL2_ttf-2.0.so.0 --grep '^TTF_FontAscent$'`).
+    ///
+    /// **READ THIS BEFORE ADDING ANOTHER `TTF_*` SYMBOL.** For this one library, "it compiles and
+    /// links" is evidence of NOTHING. The repo pins SDL2's *core* headers in `include/` but not
+    /// SDL_ttf's, so a TTF call compiles against the NDK's header and links against the NDK's
+    /// `libSDL2_ttf-2.0.so.0.18.0` — **2.0.18**, while every firmware ships 2.0.10 or 2.0.14. The
+    /// NDK exports 75 `TTF_*` functions; the televisions export 47 or 48, and **27 of them link
+    /// cleanly here and exist on no supported release** (`TTF_SetFontSize`, `TTF_MeasureUTF8`,
+    /// `TTF_SetDirection`, every `*32` and `*_Wrapped`, …). There is no local signal at all: it
+    /// builds, `make check` passes, and the process dies at the first call on every set. Grade a
+    /// new symbol with `tools/fwcompat.py --lib libSDL2_ttf-2.0.so.0 --grep '^NAME$'` before
+    /// writing the call.
+    ///
+    /// That is exactly the trap this module dodged. The coverage query one would reach for —
+    /// `TTF_GlyphIsProvided` — takes a `Uint16`, so it cannot be asked about anything above
+    /// U+FFFF; and `TTF_GlyphIsProvided32` is in the NDK header, exported by the NDK `.so`, and
+    /// present on **none of the 14** (`--grep '32$'` returns zero matches on every release). So
+    /// `crate::fontcov` reads the cmap from the file instead, which also makes coverage a host
+    /// question rather than a device one.
+    fn TTF_FontAscent(font: *mut TtfFont) -> c_int;
+    fn TTF_FontHeight(font: *mut TtfFont) -> c_int;
     fn TTF_SetFontStyle(font: *mut TtfFont, style: c_int);
     fn TTF_SetFontHinting(font: *mut TtfFont, hinting: c_int);
     fn SDL_FreeSurface(surf: *mut SdlSurface);
@@ -194,6 +282,281 @@ unsafe fn font_at(sz: c_int, bold: c_int) -> *mut TtfFont {
     arr[sz]
 }
 
+// ------------------------------------------------------------------------------------------------
+// The fallback chain. See this module's header for the design; this half is the mechanism.
+// ------------------------------------------------------------------------------------------------
+
+/// One link of the chain, in priority order. `as usize` indexes [`COV`] and the face arrays, so
+/// the discriminants are load-bearing.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Link {
+    /// Inter — `appfont.ttf` / `appfont-bold.ttf`. The app's typeface, and the ONLY link with a
+    /// bold companion. 2853 codepoints.
+    Base = 0,
+    /// The bundled `appfont-cjk.ttf` (Noto Sans CJK KR, `tools/cut-noto-cjk.py`). 44810
+    /// codepoints: all of Hangul, Kana, Han and CJK punctuation. Shipped rather than borrowed
+    /// because a submission is graded on whichever firmware the reviewer has.
+    Cjk = 1,
+    /// The television's own `DroidSansFallback.ttf`. Free insurance behind the bundled face —
+    /// measured on webOS 4.10.0 as covering the same Hangul/Han/Kana ground — and it costs
+    /// nothing when it is absent, as it is on the desktop simulator and the macOS app.
+    ///
+    /// **That measurement is ONE television and cannot be generalised.** `tools/fwcompat.py`
+    /// grades symbols, not filesystems, so it has nothing to say about a font PATH on the other 13
+    /// releases; we have no images for them. This is precisely why link 2 is bundled rather than
+    /// borrowed — this link is a bonus that may or may not exist, and the code treats it as such.
+    Sys = 2,
+}
+const CHAIN: [Link; 3] = [Link::Base, Link::Cjk, Link::Sys];
+
+/// The bundled fallback face, cut by `tools/cut-noto-cjk.py` and staged beside the binary.
+const CJK_FONT: &str = "appfont-cjk.ttf";
+/// The television's pan-CJK fallback. Distinct from [`DROIDSANS`], which is the *Latin* face and a
+/// defect path: reaching this one is normal and expected on a Korean library.
+const DROIDSANS_FALLBACK: &str = "/usr/share/fonts/DroidSansFallback.ttf";
+
+static mut FONTS_CJK: [*mut TtfFont; 80] = [std::ptr::null_mut(); 80];
+static mut FONTS_SYS: [*mut TtfFont; 80] = [std::ptr::null_mut(); 80];
+/// Per-link coverage, read from the file's cmap on FIRST NEED and never again. `None` after
+/// `COV_TRIED` means the file is absent or unreadable, i.e. the link is empty.
+static mut COV: [Option<crate::fontcov::Coverage>; 3] = [None, None, None];
+static mut COV_TRIED: [bool; 3] = [false; 3];
+
+/// The ONE place a link's file is named — both the coverage read and the `TTF_OpenFont` go
+/// through it, so the two can never disagree about which file a link is.
+fn link_file(link: Link) -> std::path::PathBuf {
+    match link {
+        // Coverage is read from the REGULAR face only. That is sound because `fontcov`'s
+        // `bold_face_covers_exactly_what_the_regular_one_does` asserts the two are identical in
+        // `make check` — the gate is not decoration here, it is what makes one read enough.
+        Link::Base => crate::paths::in_app_dir("appfont.ttf"),
+        Link::Cjk => crate::paths::in_app_dir(CJK_FONT),
+        Link::Sys => std::path::PathBuf::from(DROIDSANS_FALLBACK),
+    }
+}
+
+/// Can `link` draw `cp`? Loads that link's coverage on first ask.
+///
+/// The BASE link answers `true` for everything when its own cmap cannot be read. That is
+/// deliberate: an install whose `appfont.ttf` is missing has already fallen through to
+/// `font_at`'s DroidSans branch and logged loudly, and in that state the useful behaviour is the
+/// pre-chain one — render the whole string in one call with whatever face opened — not to split
+/// every string into runs against a coverage set of nothing.
+unsafe fn link_covers(link: Link, cp: u32) -> bool {
+    let i = link as usize;
+    let tried = &mut *addr_of_mut!(COV_TRIED);
+    if !tried[i] {
+        tried[i] = true;
+        let path = link_file(link);
+        let cov = &mut *addr_of_mut!(COV);
+        match crate::fontcov::of_file(&path) {
+            Ok(c) => {
+                log(&format!("font chain: {link:?} {} codepoints={}", path.display(), c.len()));
+                cov[i] = Some(c);
+            }
+            // Not a failure for Cjk/Sys — a television without DroidSansFallback, or a host
+            // simulator with no bundled face, simply has a shorter chain. Logged once either way,
+            // WITH the path, because "why is this still tofu" is otherwise unanswerable from a log
+            // and the answer is usually that the file is not where the install put it.
+            Err(e) => log(&format!("font chain: {link:?} unavailable — {}: {e}", path.display())),
+        }
+    }
+    match &(*addr_of!(COV))[i] {
+        Some(c) => c.contains(cp),
+        None => link == Link::Base,
+    }
+}
+
+/// The face for one run. Bold exists only on [`Link::Base`]: the fallback ships at a single
+/// weight, and SDL_ttf's synthetic bold turns dense ideographs into solid blocks at every UI size
+/// (measured — see this module's header). So a bold CJK run renders in the regular fallback face,
+/// which is also what halves the memory below.
+///
+/// **Cost, and why it is lazy.** SDL_ttf 2.0.x opens one `FT_Face` per (file, ptsize) — there is
+/// no size sharing — and this face has 65535 glyphs, so its `loca`, `hmtx` and `cmap` are large.
+/// Host-measured through the same FreeType: **~2.1 MB resident per opened size**, ~17 MB if a
+/// library exercises all eight rungs of `theme::size`. Nothing here opens until a string actually
+/// needs it, so a Latin or Cyrillic library pays exactly zero — and sharing one face between
+/// regular and bold is what keeps the worst case at eight faces rather than sixteen.
+unsafe fn link_font(link: Link, sz: c_int, bold: c_int) -> *mut TtfFont {
+    if link == Link::Base {
+        return font_at(sz, bold);
+    }
+    let sz = sz.clamp(8, 79) as usize;
+    let arr = match link {
+        Link::Cjk => &mut *addr_of_mut!(FONTS_CJK),
+        _ => &mut *addr_of_mut!(FONTS_SYS),
+    };
+    if arr[sz].is_null() {
+        let file = link_file(link);
+        let Ok(c) = CString::new(file.into_os_string().into_encoded_bytes()) else {
+            return std::ptr::null_mut();
+        };
+        arr[sz] = TTF_OpenFont(c.as_ptr(), sz as c_int);
+        if !arr[sz].is_null() {
+            // The same light-hinting contract the base face is opened under (see `font_at`).
+            TTF_SetFontHinting(arr[sz], TTF_HINTING_LIGHT);
+        }
+    }
+    arr[sz]
+}
+
+/// A string's split into single-face runs. Fixed capacity so the common path allocates nothing;
+/// a string that alternates script more than this absorbs its tail into the last run, which
+/// degrades to the pre-chain behaviour (tofu for the overflow) instead of failing.
+const MAX_RUNS: usize = 24;
+struct Runs {
+    n: usize,
+    at: [(Link, usize, usize); MAX_RUNS], // (face, byte start, byte end)
+}
+
+/// Split `s` into maximal runs, each drawable by one face. Returns `None` when the WHOLE string
+/// is drawable by [`Link::Base`] — the overwhelmingly common case, and the caller's signal to take
+/// the untouched single-render path.
+///
+/// The ASCII shortcut is the reason an English library pays nothing at all for this feature: it
+/// returns before any coverage is loaded, so `appfont-cjk.ttf`'s cmap is never even opened.
+unsafe fn split_runs(s: &str) -> Option<Runs> {
+    split_runs_with(s, |link, cp| link_covers(link, cp))
+}
+
+/// [`split_runs`] with the coverage oracle passed in — the pure half, so the host suite can drive
+/// it against the REAL shipped cmaps without a `TTF_Font`, a GL context or an install directory.
+/// The `unsafe` half is only the lazy file load behind `link_covers`.
+fn split_runs_with(s: &str, covers: impl Fn(Link, u32) -> bool) -> Option<Runs> {
+    if s.is_ascii() {
+        return None;
+    }
+    let mut runs = Runs { n: 0, at: [(Link::Base, 0, 0); MAX_RUNS] };
+    let mut mixed = false;
+    for (off, ch) in s.char_indices() {
+        let cp = ch as u32;
+        // First covering link wins, ALWAYS — never "stay in the current face because it happens
+        // to have this glyph too". Noto Sans CJK carries a full Latin set, so a sticky rule would
+        // render "(2024)" in a different typeface from the rest of the interface.
+        //
+        // A codepoint NO link covers resolves to Base, which draws its .notdef box. That is the
+        // right answer: it is the honest tofu, it keeps the runs contiguous, and it is what the
+        // renderer did before the chain existed.
+        let link = CHAIN.iter().copied().find(|&l| covers(l, cp)).unwrap_or(Link::Base);
+        if link != Link::Base {
+            mixed = true;
+        }
+        let end = off + ch.len_utf8();
+        match runs.at.get_mut(..runs.n).and_then(|r| r.last_mut()) {
+            Some(last) if last.0 == link => last.2 = end,
+            _ if runs.n < MAX_RUNS => {
+                runs.at[runs.n] = (link, off, end);
+                runs.n += 1;
+            }
+            // Out of run slots: everything left joins the final run. Extending rather than
+            // stopping is what keeps the runs a PARTITION of the string — a gap here would drop
+            // characters from the composite silently, which is worse than the wrong face.
+            _ => runs.at[MAX_RUNS - 1].2 = s.len(),
+        }
+    }
+    // A single all-Base run is exactly the fast path, however the string is spelled.
+    if !mixed {
+        return None;
+    }
+    Some(runs)
+}
+
+/// vertical ink bounds of a packed RGBA buffer — the same scan [`surface_ink_v`] does, over a
+/// buffer we own rather than an SDL surface.
+fn buf_ink_v(px: &[u8], w: c_int, h: c_int) -> (c_int, c_int) {
+    let (mut top, mut bot) = (h, -1);
+    for y in 0..h {
+        let row = &px[(y as usize) * (w as usize) * 4..];
+        if (0..w as usize).any(|x| row[x * 4 + 3] > 24) {
+            if y < top {
+                top = y;
+            }
+            bot = y;
+        }
+    }
+    if bot < 0 {
+        (0, h)
+    } else {
+        (top, bot + 1)
+    }
+}
+
+/// Render each run with its own face and composite them into one packed RGBA buffer.
+///
+/// Returns `(pixels, w, h)`. Geometry: the composite keeps the BASE face's box — height
+/// `TTF_FontHeight`, baseline `TTF_FontAscent` rows down — and each run is placed so its own
+/// baseline lands there. The box only ever grows DOWNWARD (a run that descends further than the
+/// base face), because growing it upward would move every glyph relative to the caller's `y` and
+/// silently mis-align a mixed-script label against its pure-Latin neighbours.
+unsafe fn render_runs(s: &str, runs: &Runs, sz: c_int, bold: c_int) -> Option<(Vec<u8>, c_int, c_int)> {
+    let base = font_at(sz, bold);
+    if base.is_null() {
+        return None;
+    }
+    let base_asc = TTF_FontAscent(base);
+    let white = SdlColor { r: 255, g: 255, b: 255, a: 255 };
+    // (surface, x, ascent) per run. Surfaces are freed on every exit path below.
+    let mut parts: Vec<(*mut SdlSurface, c_int, c_int)> = Vec::with_capacity(runs.n);
+    let free_all = |parts: &Vec<(*mut SdlSurface, c_int, c_int)>| {
+        for &(s, _, _) in parts {
+            SDL_FreeSurface(s);
+        }
+    };
+    let (mut w, mut below) = (0i32, TTF_FontHeight(base) - base_asc);
+    for &(link, from, to) in &runs.at[..runs.n] {
+        let f = link_font(link, sz, bold);
+        // A link whose face will not open is not fatal: fall back to the base face, which draws
+        // the run's .notdef boxes — the pre-chain result for that run only.
+        let f = if f.is_null() { base } else { f };
+        let Ok(c) = CString::new(&s[from..to]) else {
+            free_all(&parts);
+            return None;
+        };
+        let surf = TTF_RenderUTF8_Blended(f, c.as_ptr(), white);
+        if surf.is_null() {
+            free_all(&parts);
+            return None;
+        }
+        let asc = TTF_FontAscent(f);
+        below = below.max((*surf).h - asc);
+        parts.push((surf, w, asc));
+        w += (*surf).w;
+    }
+    let h = base_asc + below;
+    if w <= 0 || h <= 0 {
+        free_all(&parts);
+        return None;
+    }
+    let stride = w as usize * 4;
+    let mut out = vec![0u8; stride * h as usize];
+    for &(surf, x, asc) in &parts {
+        let (sw, sh, pitch) = ((*surf).w, (*surf).h, (*surf).pitch as usize);
+        let src = (*surf).pixels as *const u8;
+        if src.is_null() {
+            continue;
+        }
+        let dy = base_asc - asc; // negative when the run's face rises higher than the base's
+        for row in 0..sh {
+            let y = dy + row;
+            if y < 0 {
+                continue;
+            }
+            if y >= h {
+                break;
+            }
+            let n = (sw as usize * 4).min(stride - x as usize * 4);
+            std::ptr::copy_nonoverlapping(
+                src.add(row as usize * pitch),
+                out.as_mut_ptr().add(y as usize * stride + x as usize * 4),
+                n,
+            );
+        }
+    }
+    free_all(&parts);
+    Some((out, w, h))
+}
+
 pub(crate) fn init_text() {
     unsafe {
         if TTF_Init() != 0 {
@@ -300,6 +663,21 @@ unsafe fn text_tex(s_bytes: &[u8], s_c: *const c_char, sz: c_int, bold: c_int) -
             }
         }
     }
+    // A string the base face cannot draw on its own goes through the run compositor; everything
+    // else — every ASCII string, and every string Inter fully covers — takes the single
+    // `TTF_RenderUTF8_Blended` it always did, byte for byte. A compositor FAILURE also falls
+    // through to that path, which renders the base face's .notdef boxes: the pre-chain result,
+    // which is a worse picture but never a missing one.
+    let composed = std::str::from_utf8(s_bytes)
+        .ok()
+        .and_then(|st| Some((st, split_runs(st)?)))
+        .and_then(|(st, runs)| render_runs(st, &runs, sz, bold));
+    if let Some((px, w, h)) = composed {
+        let (ink_t, ink_b) = buf_ink_v(&px, w, h);
+        let tex = crate::gfx::upload_rgba(0, w, h, px.as_ptr());
+        return cache_store(s_bytes, hash, sz, bold, tex, w, h, ink_t, ink_b);
+    }
+
     let f = font_at(sz, bold);
     if f.is_null() {
         return (0, 0, 0, 0, 0);
@@ -338,7 +716,17 @@ unsafe fn text_tex(s_bytes: &[u8], s_c: *const c_char, sz: c_int, bold: c_int) -
         crate::gfx::upload_rgba(0, sw, sh, packed.as_ptr())
     };
     SDL_FreeSurface(surf);
+    cache_store(s_bytes, hash, sz, bold, tex, sw, sh, ink_t, ink_b)
+}
 
+/// Evict the LRU slot and install a freshly uploaded texture in it, returning what `text_tex`
+/// returns. Split out because there are now TWO ways to get a texture — one
+/// `TTF_RenderUTF8_Blended`, or a composite of several — and exactly one cache to put it in.
+#[allow(clippy::too_many_arguments)]
+unsafe fn cache_store(
+    s_bytes: &[u8], hash: u64, sz: c_int, bold: c_int, tex: c_uint, sw: c_int, sh: c_int,
+    ink_t: c_int, ink_b: c_int,
+) -> (c_uint, c_int, c_int, c_int, c_int) {
     let cache = &mut *addr_of_mut!(TCACHE_A);
     let mut slot = 0usize;
     let mut oldest = c_uint::MAX;
@@ -393,10 +781,37 @@ unsafe fn text_tex(s_bytes: &[u8], s_c: *const c_char, sz: c_int, bold: c_int) -
 /// layout, and the ones that also draw the string get their texture from `draw_text` on the same
 /// frame (a cache miss there, but the identical single render the measure used to do — so the
 /// per-frame render count never rises, and for measure-only strings it falls to zero).
+///
+/// **A mixed-script string is measured per RUN and summed**, because that is how it is drawn. The
+/// two agree exactly rather than approximately: SDL_ttf sizes a blended surface with this very
+/// call, so each run's `TTF_SizeUTF8` width IS the width `render_runs` advances the cursor by.
+/// (Cross-run kerning is lost — there is no such thing between a Latin and a Han glyph, and the
+/// faces are different files, so no kern table spans the boundary.)
+///
+/// The cost model changes for those strings only, and both callers that hammer this absorb it:
+/// `elide`'s binary search is memoised on its RESULT, and `TextView`'s wrap sweep goes through
+/// `elide`. A pure-ASCII string still costs exactly one `TTF_SizeUTF8`, decided before any
+/// coverage is loaded.
 pub(crate) fn text_width(s: *const c_char, sz: c_int, bold: c_int) -> f32 {
     unsafe {
         if TEXT_OK == 0 || s.is_null() || *s == 0 {
             return 0.0;
+        }
+        let bytes = CStr::from_ptr(s).to_bytes();
+        if let Some((st, runs)) =
+            std::str::from_utf8(bytes).ok().and_then(|st| Some((st, split_runs(st)?)))
+        {
+            let mut total = 0.0f32;
+            for &(link, from, to) in &runs.at[..runs.n] {
+                let f = link_font(link, sz, bold);
+                let f = if f.is_null() { font_at(sz, bold) } else { f };
+                let Ok(c) = CString::new(&st[from..to]) else { continue };
+                let (mut w, mut h): (c_int, c_int) = (0, 0);
+                if !f.is_null() && TTF_SizeUTF8(f, c.as_ptr(), &mut w, &mut h) == 0 {
+                    total += w as f32;
+                }
+            }
+            return total;
         }
         let f = font_at(sz, bold);
         if f.is_null() {
@@ -612,5 +1027,144 @@ pub(crate) fn draw_text_fade(
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         }
         w as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The RUN SPLITTER, against the real shipped cmaps.
+    //!
+    //! Everything else in this module needs a `TTF_Font`, a GL context and a television, which is
+    //! exactly why the chain's *decision* was factored out of its *rendering*: `split_runs_with`
+    //! is pure, and the coverage it consults is a property of files this repository ships. So the
+    //! half that decides which face draws which characters is gradable in `make check`, and only
+    //! the rasterization is left to the device.
+    //!
+    //! What these CANNOT see, and the reason a device capture is still required: whether the
+    //! composite is aligned, hinted and snapped correctly on the panel. `cargo test` runs on
+    //! Darwin against a different FreeType, and the simulator renders through desktop GL — the ♪
+    //! regression that named this unit was found by a photograph, not by a test.
+
+    use super::*;
+    use crate::fontcov;
+
+    /// The real shipped cmaps, parsed once for the whole test binary (see `fontcov::shipped`).
+    /// `Link::Sys` is `None` on purpose: the television's DroidSansFallback does not exist on a
+    /// build host, so this is also the "the chain is SHORT" configuration under test.
+    fn chain() -> [Option<&'static fontcov::Coverage>; 3] {
+        [
+            fontcov::shipped("appfont.ttf").as_ref().ok(),
+            fontcov::shipped("appfont-cjk.ttf").as_ref().ok(),
+            None,
+        ]
+    }
+
+    fn split(s: &str) -> Option<Runs> {
+        let cov = chain();
+        split_runs_with(s, |link, cp| cov[link as usize].is_some_and(|c| c.contains(cp)))
+    }
+
+    /// Every run, as (face, the text it draws).
+    fn runs_of(s: &str) -> Vec<(Link, &str)> {
+        match split(s) {
+            None => vec![(Link::Base, s)],
+            Some(r) => r.at[..r.n].iter().map(|&(l, a, b)| (l, &s[a..b])).collect(),
+        }
+    }
+
+    /// The one invariant the compositor's correctness rests on: the runs PARTITION the string —
+    /// contiguous, in order, covering every byte exactly once. A gap drops characters from the
+    /// picture with nothing in any log; an overlap draws them twice.
+    fn assert_partitions(s: &str) {
+        let Some(r) = split(s) else { return };
+        let mut at = 0usize;
+        for &(_, from, to) in &r.at[..r.n] {
+            assert_eq!(from, at, "run starts at {from}, previous ended at {at}, in {s:?}");
+            assert!(to > from, "empty run in {s:?}");
+            at = to;
+        }
+        assert_eq!(at, s.len(), "runs stop at byte {at} of {} in {s:?}", s.len());
+        let joined: String = r.at[..r.n].iter().map(|&(_, a, b)| &s[a..b]).collect();
+        assert_eq!(joined, s, "the runs do not reassemble the string");
+    }
+
+    /// Anything Inter fully covers must return `None`, which is the caller's signal to take the
+    /// single-render path byte for byte. This is the performance contract of the whole feature:
+    /// an English or Russian library pays nothing, and never even opens the 21 MB fallback.
+    #[test]
+    fn strings_the_base_face_covers_take_the_untouched_fast_path() {
+        for s in [
+            "Breaking Bad",                     // pure ASCII — decided before any cmap is read
+            "Amélie",                           // Latin-1
+            "Ирония судьбы",                    // Cyrillic
+            "Ο Θίασος",                         // Greek
+            "\u{266A} It seems today \u{266B}", // the ♪ regression: Inter carries U+2669..U+266C
+            "S1 · E1 — 47 min",                 // the punctuation the UI composes by hand
+        ] {
+            assert!(split(s).is_none(), "{s:?} should not need the fallback chain");
+        }
+    }
+
+    #[test]
+    fn a_korean_title_splits_onto_the_bundled_face() {
+        assert_eq!(
+            runs_of("오징어 게임 (2021)"),
+            vec![(Link::Cjk, "오징어"), (Link::Base, " "), (Link::Cjk, "게임"), (Link::Base, " (2021)")],
+        );
+    }
+
+    /// Japanese mixes three scripts inside one word boundary, and Chinese shares Han with Korean.
+    /// Both must land on the same single fallback face rather than fragmenting further.
+    #[test]
+    fn japanese_and_chinese_land_on_one_face() {
+        assert_eq!(runs_of("君の名は。"), vec![(Link::Cjk, "君の名は。")]);
+        assert_eq!(runs_of("ドラえもん"), vec![(Link::Cjk, "ドラえもん")]);
+        assert_eq!(runs_of("臥虎藏龍"), vec![(Link::Cjk, "臥虎藏龍")]);
+        assert_eq!(
+            runs_of("流浪地球 The Wandering Earth"),
+            vec![(Link::Cjk, "流浪地球"), (Link::Base, " The Wandering Earth")],
+        );
+    }
+
+    /// Noto Sans CJK carries a complete Latin set. If the splitter ever went "sticky" — staying in
+    /// the current face while it happens to cover the next character — a title like this would
+    /// render its Latin half in a DIFFERENT TYPEFACE from the rest of the interface, which is a
+    /// subtle enough wrong to survive review.
+    #[test]
+    fn latin_after_a_cjk_run_returns_to_the_app_typeface() {
+        assert_eq!(runs_of("東京物語 1953"), vec![(Link::Cjk, "東京物語"), (Link::Base, " 1953")]);
+        assert_eq!(runs_of("A한B"), vec![(Link::Base, "A"), (Link::Cjk, "한"), (Link::Base, "B")]);
+    }
+
+    /// A codepoint no link covers stays on the base face and stays INSIDE the run structure, so it
+    /// draws a box where it belongs rather than vanishing. Hebrew is the honest example, because
+    /// the chain deliberately has no face for it (see the module header — coverage is not support).
+    #[test]
+    fn an_uncoverable_codepoint_is_a_box_not_a_gap() {
+        assert_eq!(
+            runs_of("한글 \u{05D0}\u{05D1}"),
+            vec![(Link::Cjk, "한글"), (Link::Base, " \u{05D0}\u{05D1}")]
+        );
+        assert_partitions("한글 \u{05D0}\u{05D1}");
+    }
+
+    /// The run array is fixed-capacity, and the overflow policy has to keep the partition. A
+    /// string that alternates on every character is the worst case by construction.
+    #[test]
+    fn overflowing_the_run_array_still_partitions_the_string() {
+        let pathological: String = (0..MAX_RUNS * 3).map(|i| if i % 2 == 0 { 'A' } else { '한' }).collect();
+        assert_partitions(&pathological);
+        let r = split(&pathological).expect("a mixed string splits");
+        assert_eq!(r.n, MAX_RUNS, "the array is full");
+        assert_eq!(r.at[MAX_RUNS - 1].2, pathological.len(), "the tail was absorbed, not dropped");
+    }
+
+    /// Byte-indexed boundary arithmetic on multi-byte characters at the very edges of the string,
+    /// where an off-by-one would slice mid-codepoint and panic inside `&s[a..b]`.
+    #[test]
+    fn multibyte_characters_at_both_edges_are_sliced_on_char_boundaries() {
+        for s in ["한", "한A", "A한", "한A한", "\u{1F600}한", "君の名は。 2016", "ラーメン大好き小泉さん"] {
+            assert_partitions(s);
+        }
     }
 }

--- a/tools/cut-inter.py
+++ b/tools/cut-inter.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
-"""Cut the shipped `pkg/appfont*.ttf` statics from the Inter variable font.
+"""Cut the shipped Inter statics — `pkg/appfont.ttf` and `pkg/appfont-bold.ttf` — from the Inter
+variable font.
 
     python3 tools/cut-inter.py path/to/Inter[opsz,wght].ttf
+
+A THIRD face ships and does not come from here: `pkg/appfont-cjk.ttf` is Noto Sans CJK KR, cut by
+`tools/cut-noto-cjk.py` from a pinned upstream asset. It matches this file's old `appfont*.ttf`
+glob, which is why the wording above is now explicit. None of the three fixes below apply to it —
+that script's docstring says why, one by one.
 
 Why this is a script and not a one-off: the two fixes below restore conditions the UI was tuned
 under for months, and BOTH are invisible in the font's appearance — a future re-cut that forgets
 them reintroduces two silent regressions. Re-running this is the only supported way to change the
-shipped fonts.
+two Inter faces.
 
   1. wght 400/700, **opsz 18**. opsz 18 is the single point on Inter's optical-size axis where the
      theme's whole size ladder renders design-true under LIGHT hinting: regular is bar-heavy only

--- a/tools/cut-noto-cjk.py
+++ b/tools/cut-noto-cjk.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Cut the shipped `pkg/appfont-cjk.ttf` fallback face from the Noto Sans CJK KR variable font.
+
+    python3 tools/cut-noto-cjk.py path/to/NotoSansCJKkr-VF.ttf
+
+This is the sibling of `tools/cut-inter.py`. Inter is the app's TYPEFACE; this is the app's
+**fallback face** — the second link of `text.rs`'s chain, reached only for codepoints Inter does
+not carry. `pkg/appfont.ttf` covers 2853 codepoints (Latin, Cyrillic, Greek) and **zero** Hangul,
+Kana or Han, so before this face existed a Korean, Japanese or Chinese library rendered as 100%
+tofu and nothing in any test tier could see it. `fontcov.rs`'s host gate is what stops that
+returning; this script is what makes the gate satisfiable.
+
+**The input is PINNED, by tag, path AND sha256** (the three constants below, asserted before
+anything is read). "The current release" is not a reproducible dependency: Noto CJK re-cuts its
+Han glyphs between releases, and a silent re-cut would move every ideograph's design without
+moving a single line of code.
+
+Four things are deliberately NOT done here, and each one is a difference from `cut-inter.py` that
+a reader will otherwise assume is an omission:
+
+  1. **No `opsz`.** Noto Sans CJK has one axis, `wght`. There is no optical-size choice to make.
+
+  2. **No tabular-figure freeze.** `cut-inter.py` freezes `tnum` into cmap because the HUD clock
+     measures a digit template and would otherwise breathe ~5 px. Digits never reach this face:
+     U+0030..U+0039 are covered by Inter, so `text.rs`'s run splitter always resolves them to
+     link 1. Freezing anything here would be freezing it for a code path that cannot execute.
+     (The face's own Latin — which it does carry, in full — is dead for the same reason.)
+
+  3. **No legacy `kern` synthesis.** Same argument, plus CJK is not kerned: Noto Sans CJK's GPOS
+     carries `palt`/`vpal` proportional-alternate positioning, not Latin-style pair kerning, and
+     SDL2_ttf 2.0.x reads neither (see `cut-inter.py` §3 — `FT_Get_Kerning` never reads GPOS).
+     Latin runs are kerned by Inter's own `kern` table, on the Inter link.
+
+  4. **No second weight.** The `wght` 700 instance is another ~21 MB in a package that is
+     currently ~5 MB, which is not a trade this app can make for a fallback face. `text.rs` opens
+     THIS face for bold runs too, without synthetic emboldening — see `text.rs::link_font` for why
+     smearing a 20-stroke ideograph is worse than a weight mismatch beside it.
+
+**What IS dropped, and why it is not "narrowing the subset".** The codepoint set is untouched —
+all 44810 of them ship. What goes is four tables this renderer provably cannot read:
+
+  * `GSUB` (163 KB) and `GPOS` (78 KB) + `GDEF` — SDL2_ttf 2.0.x does no shaping and no OpenType
+    feature selection at all (the device's is 2.0.14; HarfBuzz support landed in 2.0.18). Dropping
+    them also makes the desktop simulator, whose SDL2_ttf may be newer, render the same thing the
+    television does instead of quietly better.
+  * `vhea` + `vmtx` (261 KB) — vertical writing metrics. Nothing in this app lays out vertically.
+  * `BASE` (278 B), `DSIG` (8 B) — baseline tables for a shaper we do not have, and a signature
+    that is invalid the moment the font is instanced.
+
+Name IDs 0, 7, 13 and 14 (copyright, trademark, licence, licence URL) are asserted present on the
+way out: OFL 1.1 §2 requires the notice to travel with the Font Software, and `pkg/OFL.txt` alone
+does not discharge it. Note the Reserved Font Name in this font's own notice is **'Source'** (Noto
+CJK is built from Source Han Sans), not "Noto" — so OFL §3 imposes no rename and the family name
+"Noto Sans CJK KR" is retained, exactly as `cut-inter.py` retains "Inter".
+"""
+import hashlib
+import sys
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from fontTools.varLib import instancer
+
+# --- the pin. Change all four together or not at all. ------------------------------------------
+UPSTREAM = "https://github.com/notofonts/noto-cjk"
+RELEASE_TAG = "Sans2.004"
+ASSET = "Sans/Variable/TTF/NotoSansCJKkr-VF.ttf"
+ASSET_SHA256 = "7715af52f5fe77153ce5678546258993982d2da61abea8d25fb89eb5aaec5ca6"
+ASSET_BYTES = 36140528
+# The regional variant is `kr` ON PURPOSE. Every Noto CJK variant covers Han + Kana + Hangul in
+# full; they differ only in which Han glyph FORM is the default. Korean-preferred is the right
+# default for an LG submission. The `Subset/NotoSansKR-VF.ttf` in the same release is a different
+# thing entirely — it is region-subsetted and DROPS the Han ideographs Korean does not need, which
+# makes it wrong for a general fallback.
+
+WGHT = 400
+DROP_TABLES = ("GSUB", "GPOS", "GDEF", "BASE", "DSIG", "vhea", "vmtx")
+LICENCE_NAME_IDS = {0: "copyright", 7: "trademark", 13: "licence", 14: "licence URL"}
+
+# What the cut MUST still cover when it is done — a coarse self-check so a bad instancer upgrade
+# fails here rather than in `fontcov.rs`'s gate an hour later. (start, end, minimum count).
+COVERAGE_FLOOR = (
+    ("Hangul syllables", 0xAC00, 0xD7A3, 11172),
+    ("Hangul jamo", 0x1100, 0x11FF, 256),
+    ("Hiragana", 0x3040, 0x309F, 90),
+    ("Katakana", 0x30A0, 0x30FF, 90),
+    ("CJK unified", 0x4E00, 0x9FFF, 20900),
+    ("CJK ext-A", 0x3400, 0x4DBF, 6500),
+    ("CJK symbols", 0x3000, 0x303F, 60),
+)
+
+
+def covered(font: TTFont) -> set:
+    cps = set()
+    for table in font["cmap"].tables:
+        cps |= set(table.cmap.keys())
+    return cps
+
+
+def check_input(path: Path) -> None:
+    if path.name != Path(ASSET).name:
+        raise SystemExit(
+            f"expected {Path(ASSET).name} (from {UPSTREAM} @ {RELEASE_TAG}, path {ASSET}), got {path.name}")
+    blob = path.read_bytes()
+    if len(blob) != ASSET_BYTES:
+        raise SystemExit(f"{path.name}: {len(blob)} bytes, expected {ASSET_BYTES}")
+    got = hashlib.sha256(blob).hexdigest()
+    if got != ASSET_SHA256:
+        raise SystemExit(
+            f"{path.name}: sha256 {got}\n  expected {ASSET_SHA256}\n"
+            f"  This is a PINNED input. If you meant to move to a new release, update RELEASE_TAG,\n"
+            f"  ASSET, ASSET_SHA256 and ASSET_BYTES together, and re-read the coverage gate in\n"
+            f"  rust-modules/src/fontcov.rs — a re-cut moves every ideograph's design.")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__.strip().splitlines()[2].strip())
+    src = Path(sys.argv[1])
+    check_input(src)
+    out = Path(__file__).resolve().parent.parent / "pkg" / "appfont-cjk.ttf"
+
+    # recalcTimestamp=False, or the cut is NOT REPRODUCIBLE: fontTools stamps `head.modified` with
+    # the current time on save, so two runs of this script over the same pinned input produce two
+    # different sha256s. Measured — the first two runs here differed by exactly that field. The
+    # whole point of pinning the input is that the output can be re-derived and compared; a clock
+    # in the artifact destroys that, and it destroys it silently, which is the same shape as the
+    # reproducibility work in `ci/mkipk.py`.
+    font = TTFont(src, recalcTimestamp=False)
+    before = covered(font)
+
+    # A full pin on the only axis: `fvar`/`gvar`/`avar`/`HVAR`/`STAT` go with it. updateFontNames
+    # rewrites the family/subfamily off STAT — without it the output keeps the variable font's
+    # DEFAULT instance names, which are "NotoSansCJKkr-Thin" (the axis minimum), so the shipped
+    # regular face would announce itself as Thin to every tool that reads a name table.
+    instancer.instantiateVariableFont(font, {"wght": WGHT}, inplace=True, optimize=True,
+                                      updateFontNames=True)
+    for tag in DROP_TABLES:
+        if tag in font:
+            del font[tag]
+
+    after = covered(font)
+    if after != before:
+        raise SystemExit(f"instancing changed coverage: {len(before)} -> {len(after)} codepoints")
+    for label, lo, hi, floor in COVERAGE_FLOOR:
+        n = sum(1 for cp in range(lo, hi + 1) if cp in after)
+        if n < floor:
+            raise SystemExit(f"{label}: {n} codepoints, expected at least {floor}")
+    have = {r.nameID for r in font["name"].names}
+    missing = [why for nid, why in LICENCE_NAME_IDS.items() if nid not in have]
+    if missing:
+        raise SystemExit(f"name table lost the OFL notice chain: {', '.join(missing)}")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    font.save(out)
+    # The OUTPUT hash, printed rather than asserted. Two runs of one fontTools version over the
+    # pinned input now agree byte for byte (see recalcTimestamp above), so this is comparable — but
+    # a fontTools upgrade may legitimately reorder or repad tables without changing the font, so
+    # pinning it here would fail for the wrong reason. What IS asserted is the semantics:
+    # the coverage floors above, and `fontcov.rs`'s exact 44810.
+    print(f"{out}  {out.stat().st_size:,} bytes  {len(after):,} codepoints")
+    print(f"  sha256   {hashlib.sha256(out.read_bytes()).hexdigest()}")
+    print(f"  family   {font['name'].getDebugName(1)!r} / {font['name'].getDebugName(2)!r}")
+    print(f"  from     {UPSTREAM} @ {RELEASE_TAG}  {ASSET}")
+    print(f"  dropped  {', '.join(DROP_TABLES)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/font-hint-audit.py
+++ b/tools/font-hint-audit.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """
 font-hint-audit.py — verify the theme::size ladder rasterizes with design-true stroke
-weights for the fonts we ship.
+weights for the INTER faces we ship (`FONTS` below).
+
+Scope, because a third face ships and is deliberately NOT audited here: `pkg/appfont-cjk.ttf`
+(Noto Sans CJK KR, the fallback chain's link 2 — see rust-modules/src/text.rs) never draws Latin
+in this app, the ladder was tuned on Inter's stems, and SDL_ttf's synthetic bold is never applied
+to it. A CJK re-cut is graded by rust-modules/src/fontcov.rs's coverage gate and by a device
+capture, not by this script.
 
 Why this exists: TrueType hinting grid-fits strokes to whole pixels, and the rounding is
 size- and font-specific. Under FreeType's default NORMAL hinting, Arial's own bytecode


### PR DESCRIPTION
Closes LG checklist **#6 (correct text)**, **#48 (subtitles)** and **#22 CASE2 (a query in an
unsupported language)** — which are one defect, measured: `pkg/appfont.ttf` covers **2853**
codepoints (Latin, Cyrillic 248, Greek 105) and **zero** Hangul, Kana, Han, Hebrew or Arabic. A
Plex library with Korean, Japanese or Chinese titles rendered **100% tofu**, and no test tier
could see it. Same defect class as the ♪ bug, where a capture of the Family Guy theme read
`▯NO GLYPH▯ It seems today` because Inter had no U+2669–U+266C.

Two deliverables: a **host gate** that would have caught the ♪ bug in 40 ms, and the **per-glyph
fallback chain** that fixes the CJK half.

---

## (a) The host gate — `rust-modules/src/fontcov.rs`

A TrueType `cmap` parser and a **declared codepoint set**, asserted over the shipped
`appfont*.ttf` inside `make check`. **12 tests, 0.04 s, no television, no GL context.**

It reads only the sfnt table directory and the `cmap` table, by seek — never the whole file, which
matters now that one face is 21 MB. Formats 4, 6, 12 and 13 are decoded and unioned, and **a
mapping to glyph 0 is not counted as coverage**, which is the difference between "the cmap has an
entry" and "the font can draw it".

The declared set is whole blocks, not samples — a partial block is how "Cyrillic works" and "Ё is
a box" coexist. Link 1 must carry ASCII, Latin-1 letters, Latin Ext-A, Greek, Cyrillic, the
punctuation the UI composes by hand (U+2026 from `elide`, U+00B7, curly quotes, dashes) and
**U+2669–U+266C**. Link 2 must carry Hangul (all 11172), Jamo, Kana, CJK symbols, and floors for
Han. Two blocks are split around **U+0149** (Unicode-deprecated) and **U+03A2** (a permanent hole
in Unicode) — excluding those two is what makes the rest a declared set rather than a wish list.

Four properties beyond raw coverage:

- **regular and bold must agree exactly.** A bold-only hole is invisible in every other tier: the
  same string renders fine as body text and tofus as a heading. This assertion is also what makes
  it sound for `text.rs` to read coverage from the regular face only.
- **the CHAIN can draw real sample strings** — Korean, Japanese, both Chinese scripts, Russian,
  Greek, Latin-with-diacritics, and a sung subtitle line. This is the assertion that fails on
  `cf6cef7e` and passes here.
- **the pinned cut is pinned** — `appfont-cjk.ttf` must cover exactly 44810 codepoints, so a
  re-cut that silently subsets fails in `make check` rather than on a reviewer's television.
- **RTL absence is asserted** (see below).

Plus six decoder unit tests on synthetic sfnts, for shapes no shipped font has: a notdef mapping,
supplementary-plane range edges, format 4's `idRangeOffset` indirection, a symbol (3,0) cmap, an
unsupported-format-only cmap, and six truncations + four lying group counts (an error, never a
panic — this runs on the SDL thread).

**Negative control, run:** dropping the wrong font into the CJK slot fails three tests and prints
every missing block by name. Deleting the file fails with the path.

## (b) The fallback chain — `rust-modules/src/text.rs`

SDL2_ttf 2.0.x has **no fallback-font API**, so the chain had to change the unit of work from a
*string* to a **run**:

1. split the string into maximal runs each drawable by one face (per character, via `fontcov`),
2. render each run with its own face,
3. composite the run surfaces side by side **aligned on the baseline**,
4. upload that buffer exactly as a single-run string was uploaded before.

Step 4 is what leaves everything downstream untouched: the 160-slot LRU still keys on
`(string bytes, size, bold)` — run splitting is a pure function of the string — and the
`ink_t`/`ink_b` cap-band machinery still measures one texture. `text_width` sums per-run
`TTF_SizeUTF8`, which agrees with the composite **exactly** rather than approximately, because
SDL_ttf sizes a blended surface with that very call.

**The chain:** Inter → the bundled `pkg/appfont-cjk.ttf` → the television's
`/usr/share/fonts/DroidSansFallback.ttf`. The bundled face is the guarantee (LG QA picks whichever
firmware they like); the system face behind it is free insurance, measured present on webOS 4.10.0.

### Four decisions, each measured rather than assumed

**Baseline, not top.** Two faces have two line boxes, so compositing by surface top would shift
Latin down whenever a CJK glyph shared the line. Every run is placed so its baseline lands on the
BASE face's, and the box grows only *downward*. Measured host-side through FreeType using SDL_ttf's
own metric arithmetic — at every rung of `theme::size` from 22 to 72, Noto Sans CJK's ink top
(16..53 px) fits inside Inter's ascent (22..70 px) and its descent is shallower. Nothing clips.

**No synthetic bold on the fallback.** SDL_ttf's bold is `FT_Outline_Embolden` at ppem/10 — 2.2 px
at `size::MICRO`. Rendered against this face that fills 電視劇, 曇天 and 鬱 into **solid blocks at
every size in the ladder, 22 through 40**. A weight mismatch beside bold Latin is a typographic
compromise; an illegible ideograph is a defect. Contact sheet:
`$HOME/plx-fleet/b4-font/evidence/cjk-synthetic-bold.png` (alternating rows, plain / emboldened).
This also halves the memory below, since regular and bold share one face.

**First covering link always wins — never sticky.** Noto Sans CJK carries a complete Latin set, so
a "stay in the current face while it covers the next character" rule would render `(2024)` in a
different typeface from the rest of the interface. Asserted.

**A codepoint no link covers stays on the base face**, inside the run structure, so it draws a box
where it belongs rather than vanishing. The runs are a **partition** of the string — asserted,
including the fixed-capacity overflow path, because a gap would drop characters with nothing in any
log.

### Cost

An English or Cyrillic library pays **nothing**: `s.is_ascii()` returns before any cmap is opened,
and a string Inter fully covers takes the untouched single-render path byte for byte. Proven on the
simulator — an all-Latin session logs `font chain: Base … codepoints=2853` and **never opens the
21 MB face at all** (`grep -c "font chain: Cjk"` → 0).

## The font — `tools/cut-noto-cjk.py`, `pkg/appfont-cjk.ttf`

Cut from `github.com/notofonts/noto-cjk` @ **`Sans2.004`**,
`Sans/Variable/TTF/NotoSansCJKkr-VF.ttf`, **sha256
`7715af52f5fe77153ce5678546258993982d2da61abea8d25fb89eb5aaec5ca6`**, 36,140,528 bytes — all four
constants asserted before the script reads a byte. Instanced at `wght` 400 with
`updateFontNames=True` (without it the output keeps the variable font's default instance names,
which are **Thin**). Output: 21,185,868 bytes, **44,810 codepoints**, family `Noto Sans CJK KR` /
`Regular`.

**Nothing was subsetted.** What is dropped is four table families this renderer provably cannot
read: `GSUB`+`GPOS`+`GDEF` (SDL2_ttf 2.0.x does no shaping and no feature selection; HarfBuzz
landed in 2.0.18, the device has 2.0.14), `vhea`+`vmtx` (vertical layout), `BASE`, `DSIG`. ~640 KB
of 21 MB — kept because it is free and correct, not because it was needed.

**The cut is byte-reproducible**, and was not at first: fontTools stamps `head.modified` with the
clock on save, so my first two runs over the same pinned input produced two different sha256s.
`recalcTimestamp=False` fixes it — two runs now agree exactly
(`eeb1b524ac15a8bb563dbc70dce392b4b77ad663cb06940bd4a7119636946000`), which is what makes pinning
the *input* worth anything. Same failure shape as the work in `ci/mkipk.py`, and just as silent.

The script's docstring names the four things `cut-inter.py` does that this one deliberately does
**not** (no `opsz` — this font has one axis; no tabular-figure freeze and no `kern` synthesis —
digits and Latin never reach this face, so freezing anything here would freeze it for a code path
that cannot execute; no second weight).

## Licensing

SIL OFL 1.1, the same licence Inter ships under, and the two upstream licence **bodies are
byte-identical** — verified — so one `pkg/OFL.txt` discharges both. `THIRD-PARTY-NOTICES.md` §2.3
gains a Noto Sans CJK KR entry with the copyright, the version, the exact upstream asset, and what
was modified; §5 is corrected to say `OFL.txt` covers both fonts.

One finding worth recording: this font's own copyright notice declares a Reserved Font Name, and
it is **`'Source'`**, not "Noto" — Noto CJK is built from Adobe's Source Han Sans. We use neither
name, so OFL §3 imposes no rename and `Noto Sans CJK KR` is retained, exactly as `Inter` is.
`tools/cut-noto-cjk.py` asserts name IDs 0/7/13/14 survive the cut, because OFL §2 wants the notice
to travel *inside* the Font Software too.

---

## The two size numbers, measured separately

**Package.** `gzip -9` of the font (the level `ci/mkipk.py` uses) is **11,341,401 bytes**.

| | v0.4.1 | this branch |
|---|---|---|
| `.ipk` | 5,758,210 (5.49 MiB) | **~17,099,611 (~16.3 MiB)** — **+11.3 MB, 2.97×** |
| installed, unpacked | — | **+21,185,868 (+20.2 MiB)** |
| `Installed-Size` | 7781 KiB | ~28,470 KiB |

Not prohibitive on either axis I can check: `docs/distribution.md` §"crash" records **207.3 MB
free** on the app partition, and webosbrew hosts far larger packages (Kodi's webOS ipk is ~90 MB).
It is a 3× package, which is a real fact for whoever writes the release note.

**Runtime memory — a different number, and NOT 21 MB.** SDL_ttf opens one `FT_Face` per
(file, ptsize) with no size sharing, so the question is what FreeType makes resident per opened
size. Host-measured through the same FreeType:

| | |
|---|---|
| CJK face, 1 size | **+1.9 MB** |
| CJK face, all 8 rungs of `theme::size` | **+16.8 MB** (~2.1 MB/size) |
| Inter, all 8 rungs (for scale) | +4.3 MB |

Two things bound it: it is **lazy** (an all-Latin library opens none of it — proven above), and
regular/bold **share one face**, so the worst case is 8 faces rather than 16.

**What I could not measure, and the integrator must, before release:** this is a *host* number
(host FreeType, host malloc), and the device figures in `docs/distribution.md` are 35 MB boot /
119 MB browse / **152 MiB playback peak** against `requiredMemory: 160`. Browse + ~17 MB stays
under; **playback + a fully-exercised CJK face would not**. That needs one `VmHWM` reading on a
television with a CJK library. I had no TV in this lane. I did **not** narrow the subset to dodge
it, per instruction.

## RTL is OUT OF SCOPE — stated plainly

**Do not mark #6 or #48 Pass for RTL content on the strength of this unit.** No link of the chain
has Hebrew or Arabic, including the television's own DroidSansFallback (device pre-flight, webOS
4.10.0, 2026-08-23: 11172/11172 Hangul, 20902 Han, Kana — **zero Hebrew, zero Arabic**).

More fundamentally, *"the font contains the codepoint"* is not *"the renderer supports the
script"*. Arabic needs joining and contextual shaping; Hebrew needs bidi reordering; **neither
exists anywhere in `text.rs`** — `TTF_RenderUTF8_Blended` in SDL2_ttf 2.0.x is a left-to-right
advance loop with no shaper behind it. Adding a face without a shaper would turn tofu into
*fluent-looking wrong text*, which is harder to notice and worse to ship.

So `fontcov.rs` asserts the **absence**: `rtl_is_out_of_scope_and_stays_that_way` fails the moment
someone adds an RTL face, and its failure message is the reason not to. The boundary is in the
module doc, in the test, and here.

---

## Verification

- **`make check`: 995 passed, 0 failed, 0.89 s** (976 on `cf6cef7e`; +19: 12 gate, 7 splitter).
  Includes `make lint`.
- **`cargo +nightly check --lib --no-default-features`** clean — the `RELEASE=1` configuration the
  suite cannot see.
- **`python3 ci/check-package.py`** — all tracked-file assertions pass. Note it exits early with no
  staged package, so the three new assertions (payload set, family gate, presence) are in the half
  only a post-`make ipk` run reaches; I verified all three by hand against the same helper
  (`Noto Sans CJK KR` is in `ALLOWED`, size 21,185,868 > floor, notices carry the attribution).
- **Simulator, before/after, same build, same query, only `appfont-cjk.ttf` removed from the app
  dir** — `$HOME/plx-fleet/b4-font/evidence/shot-before.png` vs `shot-cjk.png`. Before: every CJK
  codepoint is a tofu box. After: `오징어 게임 Squid Game 君の名は 東京物語 2016` renders correctly in
  the search field *and* in the bold "No results for …" line, baseline-aligned with the Latin
  around it. That bold line is also the visible evidence for the no-synthetic-bold decision.
- **Home screen unchanged** (`shot-latin.png`) — no Latin regression, and the event log proves the
  fallback was never opened.
- **`fw-compat-reviewer`: PASS.** No new `DT_NEEDED`, no `dynlib!` surface touched, `LIBS_REAL` and
  the link line byte-identical, `ci/expected-dt-needed.txt` correctly unmodified. `TTF_FontAscent`
  and `TTF_FontHeight` present on **14/14**; `libSDL2_ttf-2.0.so.0` SONAME constant on 14/14, which
  is the actual `dynlib!` criterion (I had justified it by symbol presence — corrected in the doc).
  `fontcov.rs` has no FFI, no `unsafe`, and cannot panic on malformed input, which matters because
  it runs on the SDL thread.

  It also surfaced a trap worth recording beyond this PR, now written into `text.rs`'s `extern`
  block: **the repo pins SDL2's core headers in `include/` but not SDL_ttf's**, so a TTF call
  compiles against the NDK's **2.0.18** header and links against the NDK's 2.0.18 `.so`, while every
  television ships 2.0.10 or 2.0.14. **27 `TTF_*` symbols link cleanly here and exist on no
  supported release** — including `TTF_GlyphIsProvided32`, the obvious tool for this very unit. It
  would have compiled, linked, passed `make check`, and died at the first coverage query on every
  set. For this one library, "it builds" is evidence of nothing; grade with
  `tools/fwcompat.py --lib libSDL2_ttf-2.0.so.0 --grep '^NAME$'` first.

**The simulator cannot answer text rasterization** — that is a device question, and it is why the ♪
bug needed a panel capture.

### Device recipe for the integrator

```sh
# 0. wake-tv skill, then take a real SESSION lease (this is several minutes of device work)
tools/tv-lock.sh acquire --why "b4 font fallback chain"

# 1. the font is 21 MB. The FIRST deploy carries it; later ones skip it (the guard is a size
#    compare against the on-TV copy, so a re-cut DOES reach the set).
make FLAVOR=debug deploy

# 2. drive a mixed-script string through the real rasterizer, headless. The `search` seed is the
#    only way to get arbitrary text on screen without typing — the harness cannot type and the
#    TV's own keyboard is raised by a user. `tv-session.sh up --screen` has no `search=<q>` form,
#    so arm it by hand FIRST and bring the app up with --keep so it is not cleared.
RD=$(make -s print-rundir FLAVOR=debug)
sshpass -p alpine ssh root@"$(make -s print-tv)" \
  "printf '%s' '오징어 게임 Squid Game 君の名は 東京物語 2016' > $RD/plxnative-search"
tools/tv-session.sh up   --flavor debug --keep
tools/tv-session.sh shot --flavor debug /tmp/cjk-device.png     # DISPLAY source
```

**What to LOOK at, in order** — this is the half the host cannot answer:

1. **no boxes anywhere** (the defect itself);
2. **the Latin and the CJK sit on ONE baseline** — this is the composite's entire risk, and the
   host measurement that says it fits was FreeType arithmetic, not a panel;
3. **stems are crisp** — light hinting and `gfx::snap` must survive the composite; a half-pixel
   origin on the run buffer would smear every glyph and *only* on the device;
4. the bold "No results for …" line — CJK at regular weight beside bold Latin is **expected**, not
   a bug (see the no-synthetic-bold decision above).

Then the log and the number I could not take:

```sh
# both links must appear, with their counts — this is also how you tell "the font never
# deployed" apart from "the chain is broken"
make -s print-eventlog FLAVOR=debug      # then grep 'font chain'
#   font chain: Base .../appfont.ttf      codepoints=2853
#   font chain: Cjk  .../appfont-cjk.ttf  codepoints=44810

# THE MEASUREMENT THIS LANE COULD NOT TAKE: VmHWM with a CJK library, browsed at several text
# sizes and then PLAYED, against requiredMemory: 160. `pidof plxnative` matches both installs —
# resolve `readlink /proc/<pid>/exe` per pid to pick the right one (see CLAUDE.md).
```

Also worth one device look, since the harness cannot: a **subtitle** with CJK text (#48), and the
`--fps` scenes to confirm the composite has not moved frame pacing on mixed-script screens (it
should not — the composite only runs on a cache MISS, and only for strings Inter cannot draw).

## Review — two real bugs found and fixed

`/code-review high` and `fw-compat-reviewer` between them found five things. Three were mine to fix
and two of those were **bugs the host suite structurally could not catch**:

1. **`fontcov.rs` — a 32-bit `usize` overflow that only exists on the shipped target.** The
   format-12 bounds check was `16 + n.checked_mul(12)? > t.len()`. `usize` is **32 bits on
   `arm-unknown-linux-gnueabi`**, so a `numGroups` of 357,913,941 makes `n * 12` exactly
   `0xFFFF_FFFC` and the `+ 16` **wraps to 12** — under `t.len()`, guard passed, then a panic out
   of the SDL main thread on the second group. Release builds have overflow checks off, so it wraps
   silently. `cargo test` runs on a 64-bit Mac where the same expression is simply true, so my
   `a_truncated_font_is_an_error_not_a_panic` test could never have caught it. Now done in `u64`,
   which is width-independent by construction; the test gained the four wrapping values to pin the
   intent, and the comment names the hazard so it survives.

2. **`fontcov.rs` — `_ => Some(())` counted a SKIPPED subtable as a decoded one.** A font whose
   only Unicode cmap subtables are formats 0/2/14 decoded as `Ok(<empty coverage>)` rather than
   `Err`. Those are not interchangeable downstream: `link_covers` falls back to "the base face
   covers everything" only on `Err` and takes an empty `Ok` as authoritative — so every accented
   Latin, Cyrillic and Greek character would have failed Inter and resolved to the CJK fallback,
   which carries a full Latin set. **The entire interface silently in the wrong typeface, nothing
   logged.** Now `_ => None`, with a new test that I verified fails against the old code.

3. **The deploy guard was a SIZE compare, and my own re-cut defeated it.** Adding
   `recalcTimestamp=False` produced a file of identical size and different bytes, so a developer
   re-cutting for reproducibility would have deployed and kept the old font — exactly the failure
   the `test -f || scp` guard was removed for. Now an MD5 compare, same one ssh round trip.

Also fixed: a dangling `text.rs::fallback_font_at` reference in the cut script (the function is
`link_font`), and the `dynlib!` justification in the FFI doc (symbol presence is necessary; SONAME
stability is the actual criterion).

The reviewer independently re-derived the baseline geometry and swept the whole repertoire: the
fallback's ink reaches 0.842–0.939 em above the baseline against Inter's 0.9688 em ascent, so the
`y < 0` guard discards only blank rows. The one exceeding glyph in the font is **U+3031**, a
vertical-writing kana repeat mark at 1.323 em, which SDL_ttf already clips inside its own run
surface before the compositor sees it. That is now in the module doc.

## Docs this change makes FALSE — handed over, not applied

`doc-claim-auditor` found 6. I fixed the two that are font tooling and unambiguously mine
(`tools/cut-inter.py`'s "the only supported way to change the shipped fonts" — now scoped to the two
Inter faces; `tools/font-hint-audit.py`'s scope, which audits `FONTS` = the Inter pair and would
otherwise read as covering a face it never opens).

**I did not touch the other four**, because they are shared-surface files that a parallel fleet will
conflict on and that the integrator has to reconcile across lanes anyway. Exact wording is in the
audit; the substance:

| File | What is now false |
|---|---|
| `CLAUDE.md:49` | "`make deploy` — … the fonts (**UNCONDITIONALLY**…)". Two of three are; `appfont-cjk.ttf` is behind an MD5 guard, and the Makefile says so three lines below. |
| `CLAUDE.md:294` | "Fonts are `appfont.ttf` / `appfont-bold.ttf` deployed next to the binary." Three fonts now, and the app is a fallback CHAIN, not a single face. |
| `docs/two-installs.md:254`, `:455` | "A second install costs roughly **13 MB** unpacked … the two fonts". It is now ~**34 MB**, and the font alone is larger than the binary + FFmpeg + splash combined. §6.5 grades a `df` against this figure. |
| `docs/lg-self-checklist.md:162` | Says the per-glyph fallback chain is unbuilt and that nothing in the host suite can see it. Both halves are now inverted — **but the RTL clause must SURVIVE the rewrite**, and the auditor's replacement keeps it: "Hebrew, Arabic and Thai still tofu, deliberately — no link carries them, because coverage is not support." |

Also noticed in passing and **not** from this change: `README.md:229` claims the app "links the TV's
own FFmpeg … dynamically rather than bundling", which has been backwards since the webOS 5 port.

## Out of scope / follow-ups

- **`ci/mkmacapp.py:230` is not in this lane's file set** and still stages only
  `appfont.ttf`/`appfont-bold.ttf`, so the sendable macOS bundle will tofu CJK — and link 3 does
  not exist on macOS either, so the chain has one link there. Not a regression (it behaves exactly
  as today, and `link_covers` logs `font chain: Cjk unavailable — <path>: …` rather than failing),
  and **invisible from `make sim`**, which resolves `PLXNATIVE_APP_DIR=pkg` and therefore *does*
  find the font. Adding it is one filename in a tuple, but it triples that zip for a browse-only
  demo — a judgement call for whoever owns the file. Note the bundle also copies
  `THIRD-PARTY-NOTICES.md`, which now attributes a font the bundle does not contain.
- The `deploy` target's CJK copy is **conditional on an MD5 compare**, unlike the other two fonts
  which stay unconditional. 21 MB of scp on every deploy to a television that drops to standby is
  not something the dev loop should pay a hundred times a day; the `.ipk` path (`APP_FILES`) has no
  guard at all and is what a real install uses. This is the `CLAUDE.md:49` correction above.
- **Screenshots**: I have no way to upload images from this lane, so the three PNGs are on disk at
  `$HOME/plx-fleet/b4-font/evidence/` — `shot-before.png` / `shot-cjk.png` (the before/after pair)
  and `cjk-synthetic-bold.png` (the emboldening contact sheet). They are worth attaching to this
  PR; the before/after pair in particular is the whole unit in two frames.
