### PR TITLE
keys: a number key was paging the library, and an unsupported one woke the HUD

### DIFF
--- a/docs/remote-keys.md
+++ b/docs/remote-keys.md
@@ -197,11 +197,12 @@ change rather than a tidy-up, and the sibling codes (`402`, `415`, `413`) come f
 `linux/input.h` does not name — so unlike `33`/`34` there is no positive evidence about them in
 either direction. **Settle all four together, with the §7 capture plus a USB keyboard, in one pass.**
 
-### 4.3 and 4.4
+### 4.3 and 4.4 — `SDLK_SELECT`, and `digit_of`'s `wcode` arm
 
-`SDLK_SELECT` (§9, first bullet) and `profiles::digit_of`'s `wcode` arm (§9, second) are the other
-two. Both are misreadings of the same field and both are recorded rather than changed, for the
-reasons given there.
+The other two are written up in §9, whose first and third bullets they are: `SDLK_SELECT` is
+`SDL_SCANCODE_END`, and `profiles::digit_of` reads ASCII digits out of the scancode field. Both are
+misreadings of the same field, both are recorded rather than changed, and the reasons are there.
+`is_bound` (§6) declines to inherit the second of them.
 
 ---
 

--- a/docs/remote-keys.md
+++ b/docs/remote-keys.md
@@ -1,0 +1,389 @@
+# The remote key map
+
+**Every key this app binds, what field it is matched in, and what it does** — plus the questions
+about keys that only a television can answer, written down as recipes rather than guesses.
+
+This file is what LG's App Self Checklist rows **26** (general / IR remote), **36** (HOME),
+**39** (LIVE), **40** (unsupported keys) and **45** (playback control keys) cite;
+`docs/lg-self-checklist.md` is the status of those rows, this is the evidence under them.
+
+Status taken 2026-08-23. **Nothing below was measured on a television in this pass** — the device
+half is either quoted from a dated earlier session or marked as a recipe still to run. What *was*
+done offline is read out of the television's own harvested `libSDL2`, which is stated where used.
+
+---
+
+## 1. How a press reaches the app
+
+An `SDL_KEYDOWN` / `SDL_KEYUP` from LG's SDL fork is read by raw byte offset, because the fork's
+`SDL_KeyboardEvent` is **shifted four bytes** against the headers (`app.rs::decode_key`, and the
+gotcha in the root `CLAUDE.md`):
+
+| offset | field | the app calls it |
+| --- | --- | --- |
+| +16 | `state` | low byte pressed(1)/released(0), bit `0x100` auto-repeat |
+| +20 | keysym's first word | **`wcode`** |
+| +24 | keysym's second word | **`sym`** |
+
+`sym` is an ordinary **SDL keycode**: ASCII for printable keys (`SDLK_RETURN` = 13), otherwise the
+scancode with `1<<30` set (`SDLK_LEFT` = `80 | (1<<30)`).
+
+### `wcode` is the SDL SCANCODE, not a separate webOS keycode namespace
+
+The name is historical and it misleads. Every pair ever measured off the dev set has `wcode` equal
+to the **SDL scancode** of the key whose keycode is in `sym`:
+
+| key | measured `wcode` | SDL scancode | when |
+| --- | --- | --- | --- |
+| OK | 40 | `SDL_SCANCODE_RETURN` | 2026-08-22 |
+| D-pad L / R / D / U | 80 / 79 / 81 / 82 | `SDL_SCANCODE_LEFT` / `RIGHT` / `DOWN` / `UP` | 2026-08-22 |
+| panel delete | 42 | `SDL_SCANCODE_BACKSPACE` | 2026-08-15 |
+| panel **Clear all** | 156 | `SDL_SCANCODE_CLEAR` | 2026-08-15 |
+| panel `◀` / `▶` | 80 / 79 | `SDL_SCANCODE_LEFT` / `RIGHT` | 2026-08-15 |
+
+So the fork inserts one word ahead of the keysym and leaves an ordinary
+`SDL_Keysym { scancode, sym }` at +20/+24. That one sentence explains the rest of this file:
+
+* **Codes with no `sym` are LG's own scancodes.** SDL's enumeration ends at 286
+  (`SDL_SCANCODE_AUDIOFASTFORWARD`); everything from **300 upwards** here — 300/301 channel, 450
+  play, 451/452 FF/RW, 482 BACK, 505 EXIT — is LG's private extension, for which SDL's keymap has
+  no keycode, so `sym` arrives as 0. That is why the transport arms are matched in `wcode`.
+* **A code below ~290 in `wcode` is a KEYBOARD key**, and reading one as a remote button is the
+  single bug class this map has now hit four times (§4).
+
+### The television's own translation table, readable offline
+
+LG's fork carries the evdev-to-scancode table at **file offset `0x92840`** of
+`libSDL2-2.0.so.0.4.1`: 624 `u32` entries, index = the `linux/input.h` evdev code, value = the
+scancode delivered in `wcode`. It is the authority for "can this set produce that code at all",
+it needs no television, and the `Provenance` column below is read out of it. With a harvested copy
+of the library (the `decompile-tv-lib` skill), unpack it with `struct.unpack_from("<624I", data,
+0x92840)` and print `index -> value` for every non-zero entry.
+
+The table is otherwise byte-for-byte SDL's own standard `linux_scancode_table`, which is what makes
+"scancode 33 is `SDL_SCANCODE_4`" a fact about this firmware rather than an analogy.
+
+---
+
+## 2. The map
+
+`classify` (`ui/consts.rs`) resolves one `(sym, wcode)` pair to one `Key`; the ladder in `app.rs`
+dispatches on that. **Two sets are bound OUTSIDE the classifier** and are listed with the rest —
+being `Key::Other` does not mean unbound (§3).
+
+### Navigation and confirm
+
+| Code | Field | `Key` | What it does | Provenance |
+| --- | --- | --- | --- | --- |
+| `82 \| 1<<30` | `sym` | `Up` | four-way nav; in the player, raise/hide the HUD | evdev 103 `KEY_UP` |
+| `81 \| 1<<30` | `sym` | `Down` | four-way nav; in the player, the HUD | evdev 108 `KEY_DOWN` |
+| `80 \| 1<<30` | `sym` | `Left { alt: false }` | four-way nav; in the player, scrub back | evdev 105 `KEY_LEFT` |
+| `79 \| 1<<30` | `sym` | `Right { alt: false }` | four-way nav; in the player, scrub forward | evdev 106 `KEY_RIGHT` |
+| `13` | `sym` | `Ok` | activate the focused control | evdev 28 `KEY_ENTER` (scancode 40) |
+| `88 \| 1<<30` | `sym` | `Ok` | keypad ENTER | evdev 96 `KEY_KPENTER` |
+| `77 \| 1<<30` | `sym` | `Ok` | named `SDLK_SELECT` — **it is `SDL_SCANCODE_END`, see §9** | evdev 107 `KEY_END` |
+| `27` | `sym` | `Back` | ESC, for dev keyboards | evdev 1 `KEY_ESC` |
+| `113` (`'q'`) | `sym` | `Back` | dev keyboards | — |
+| `482` | `wcode` | `Back` | **the remote's BACK** | evdev 303 |
+| `461` | `wcode` | `Back` | a second BACK, "for other remotes" | **not producible on this firmware** — no table entry yields 461. Defensive and unevidenced. |
+
+BACK reaches the app at all only because `src/main.c` sets `SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`
+before `SDL_Init` (§5).
+
+### Transport (checklist #45, bound 2026-08-22)
+
+| Code | Field | `Key` | What it does | Provenance |
+| --- | --- | --- | --- | --- |
+| `450` | `wcode` only | `Play` | resume, or start playback off a card | evdev 207 `KEY_PLAYCD` |
+| `72` | `wcode` only | `Pause` | pause | evdev 119 `KEY_PAUSE` |
+| `261` | either | `PlayPause` | toggles — its own variant, since `key_play`/`key_pause` are each one direction | evdev 164 `KEY_PLAYPAUSE` |
+| `451` | either | `Right { alt: true }` | fast-forward: scrubs in the player, does nothing elsewhere | evdev 208 `KEY_FASTFORWARD` |
+| `452` | either | `Left { alt: true }` | rewind, likewise | evdev 168 `KEY_REWIND` |
+| `120` | `wcode` only | `Stop` | player only: stop and leave | evdev 128 `KEY_STOP` |
+| `260` | `wcode` only | `Stop` | player only: stop and leave | evdev 166 `KEY_STOPCD` |
+| `505` | either | `Exit` | **terminates the app** (checklist #38); no confirmation, unlike root BACK | evdev 174 `KEY_EXIT` |
+| `19` | either | `Play` | legacy alternate — **this is `SDL_SCANCODE_P`, see §4.2** | evdev 25 `KEY_P` |
+| `402` | either | `Play` | legacy alternate | evdev 472, unnamed in `linux/input.h` |
+| `415` | either | `Pause` | legacy alternate | evdev 541, unnamed |
+| `413` | either | `Stop` | legacy alternate | evdev 534, unnamed |
+
+### Bound outside `classify`
+
+| Code | Field | Where | What it does |
+| --- | --- | --- | --- |
+| `75 \| 1<<30` | `sym` | `page_dir`, Library route only | page the grid up |
+| `78 \| 1<<30` | `sym` | `page_dir`, Library route only | page the grid down |
+| `300` | `wcode` | `page_dir`, Library route only | CH▲ pages up (evdev 402 `KEY_CHANNELUP`) |
+| `301` | `wcode` | `page_dir`, Library route only | CH▼ pages down (evdev 403 `KEY_CHANNELDOWN`) |
+| `8` | `sym` | `ui::search::key`, while editing | backspace |
+| `156 \| 1<<30` | `sym` | `ui::search::key`, while editing | the panel's **Clear all**. **Not producible from the evdev table** — it reaches us through the fork's own text/IME path, which is why it is measured but has no evdev provenance. |
+| `48..=57` | `sym` | `ui::profiles`, PIN keypad | type that digit into the PIN. `profiles::digit_of` also reads the range out of `wcode`, where it is **not** a digit — §9. |
+
+### Swallowed
+
+| Code | Field | `Key` | What it does |
+| --- | --- | --- | --- |
+| `484` (`0x1e4`) | `wcode` | `PointerHidden` | the Magic Remote reporting its pointer auto-hid. The ladder's arm has an empty body — the press is consumed there rather than reaching the arms below. evdev 614, an LG-private code and not a key. |
+
+### Reachable but deliberately unbound
+
+| Code | What it is | Why |
+| --- | --- | --- |
+| `269` | `SDL_SCANCODE_AC_HOME`, evdev 172 `KEY_HOMEPAGE` | §5 |
+| `270` | `SDL_SCANCODE_AC_BACK`, evdev 158 `KEY_BACK` | not the remote's BACK, which is 482. Never observed on this set; adding it needs a capture, not a guess. |
+| `412` / `417` | evdev 524 / 556, unnamed | retired 2026-08-22 — CEA-2014-A *web* keyCodes for RW/FF, absent from 336 real presses |
+| `33` / `34` | `SDL_SCANCODE_4` / `SDL_SCANCODE_5`, evdev 5 / 6 | retired 2026-08-23 — §4.1 |
+
+---
+
+## 3. Three asymmetries that are behaviour, not untidiness
+
+**PAUSE and PLAY are matched in `wcode` ALONE; their alternates, and STOP, in either field.** That
+is how the two `app.rs` arms spelled it before `classify` existed, and it was preserved verbatim.
+Widening or narrowing one of them is a behaviour change and needs its own argument — the codes come
+from two different namespaces (§1, §4), so "make them consistent" is not the tidy-up it looks like.
+
+**`Left`/`Right` carry an `alt` flag, and the two horizontal tests accept different sets.** `alt`
+is `false` for a press that arrived as the plain `SDLK_LEFT`/`SDLK_RIGHT` sym and `true` for one
+that arrived only as `WCODE_REWIND`/`WCODE_FASTFORWARD`. The non-player four-way nav dispatch
+matches `alt: false` alone, so a transport key does nothing on Home; the player's scrub arm and the
+Chapters strip match both. A press carrying BOTH stays plain — `classify` asks `sym` first — which
+is what keeps Home's navigation answering an ordinary arrow that happens to ride beside a transport
+code.
+
+**`Key::Other` is not a synonym for unbound.** The Library pager is a separate predicate
+(`page_dir`), Search's edit keys are read inside the screen, and the PIN keypad reads digits: all
+three classify as `Other` and are then handled. Making the variant inert would break every one of
+them. `is_bound` (§6) is the predicate that answers *is this press one the app binds at all*.
+
+---
+
+## 4. Namespace errors: the same bug, four times
+
+`wcode` is a native scancode (§1). Several constants in this app were instead taken from the
+**CEA-2014-A / LG web keyCode** namespace — the one LG's *web* app documentation describes, which
+is a different world from a native SDL binary. Two are retired; two are open and recorded.
+
+### 4.1 `33` / `34` — the channel rocker that was the digits (FIXED 2026-08-23)
+
+`WCODE_CH_UP` / `WCODE_CH_DOWN` = 33 / 34 were bound in `page_dir` and described as the Magic
+Remote's CH▲/CH▼ rocker, carrying the caveat *"verify the raw wcodes in the event log on a new
+remote"* — a caveat nobody ever spent. In the web keyCode namespace 33/34 really are
+ChannelUp/ChannelDown (they are the browser's PageUp/PageDown). In the **native scancode** namespace
+this app receives, 33 and 34 are `SDL_SCANCODE_4` and `SDL_SCANCODE_5`, produced by evdev 5 `KEY_4`
+and evdev 6 `KEY_5`.
+
+**So pressing `4` or `5` on a number pad paged the Library grid.** Reproduced end to end on the
+simulator before the fix — the digit `5` moved the grid focus a full page, and left every later key
+in the script acting on a different item. The real rocker, 300/301, was already bound beside them,
+so the two constants are **deleted**, not repointed: a constant that silently changes value is how a
+doc or a log predating the change comes to read as the opposite of what it says. `page_dir` now
+answers `SDLK_PAGEUP`/`SDLK_PAGEDOWN` and 300/301 and nothing else.
+
+Graded three ways: `page_dir(digit) == None` and `is_bound(digit) == true` in `ui::consts`' host
+tests, and the `k:53,34` row of `tests/keytable.json`, which is inert on all three recorded screens.
+
+### 4.2 `19` as an alternate PLAY — OPEN, not changed here
+
+`WCODE_PLAY_ALT_A = 19` is matched in **either** field. In `wcode`, **19 is `SDL_SCANCODE_P`**,
+produced by evdev 25 `KEY_P`. A USB keyboard attached to the television would therefore start
+playback on the letter `p`; on the Search screen, where printable characters arrive separately as
+`SDL_TEXTINPUT` and the key event falls through to the ladder, typing `p` would plausibly leave the
+screen for the player.
+
+Left alone deliberately. It is a real finding of the same class as 4.1, but the alternate sets are
+carried as an invariant in `docs/ui-viewtree-plan.md` §C, changing them is a documented behaviour
+change rather than a tidy-up, and the sibling codes (`402`, `415`, `413`) come from evdev entries
+`linux/input.h` does not name — so unlike `33`/`34` there is no positive evidence about them in
+either direction. **Settle all four together, with the §7 capture plus a USB keyboard, in one pass.**
+
+### 4.3 and 4.4
+
+`SDLK_SELECT` (§9, first bullet) and `profiles::digit_of`'s `wcode` arm (§9, second) are the other
+two. Both are misreadings of the same field and both are recorded rather than changed, for the
+reasons given there.
+
+---
+
+## 5. HOME (#36) and LIVE (#39) — analysis, and what a device must still answer
+
+**Nothing is bound, and nothing should be bound on the evidence available.** "HOME appears nowhere
+in the tree" is not itself an argument; these three facts are.
+
+**(1) The app can only ASK for two keys, and neither is HOME or LIVE.** LG's fork gates key
+delivery behind an access policy the app opts into with an environment variable set before
+`SDL_Init` — `src/main.c` sets `SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`, which is why BACK reaches us at
+all. The complete set of those hints, read out of the television's own binary with
+`strings -a … | grep ACCESS_POLICY`, is **three**:
+
+```
+SDL_WEBOS_ACCESS_POLICY_KEYS_BACK
+SDL_WEBOS_ACCESS_POLICY_KEYS_EXIT
+_WEBOS_ACCESS_POLICY_FORCESTRETCH
+```
+
+(the last two also appear without the `SDL_` prefix — those are the shell-surface property names
+the fork forwards). `SDL_webOS.h` in the NDK sysroot declares exactly the same two
+`SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_*` macros and no others. **There is no HOME hint and no LIVE
+hint**, so a native app has no way to request either. A key with a request switch is one the
+platform will hand over if asked; a key with none is one the platform keeps. HOME and LIVE are in
+the second group by construction.
+
+**(2) The fork CAN produce a HOME scancode, which is what makes this worth testing rather than
+assuming.** The table at `0x92840` maps evdev 172 `KEY_HOMEPAGE` to **269**
+(`SDL_SCANCODE_AC_HOME`). So "269 never arrives" is a claim about the compositor and SAM, not about
+SDL — and it is exactly the claim a capture settles.
+
+**(3) LIVE has no identified code at all.** Nothing in this project has ever recorded which evdev
+code LG's *LIVE TV* / *Live Menu* button emits. The table can produce several plausible candidates,
+and **`KEY_TV` (evdev 377) maps to 0, i.e. is not delivered at all** — which is enough to show that
+guessing from an evdev name would be wrong. Binding anything for LIVE today would be a guess.
+
+**A consideration that outranks all three.** Even if 269 arrived, it is not obvious the app *should*
+act on it: HOME and LIVE are the television's own navigation, and an app that intercepted them would
+be taking over the set's global controls, which is the opposite of what the checklist asks. So the
+bar is not "can we receive it" but **"does LG's Native SDK, or a Seller Lounge QA requirement, say
+the app is expected to receive it"** — and nothing consulted here says so. Public web-app Home/Back
+documentation is QA context for the *requirement* and never proof about native SDL delivery.
+
+**Verdict: leave unbound. #36 and #39 need one device observation, not code.** That observation is
+§7, run once with HOME and LIVE among the buttons pressed. Until then neither row is markable, in
+LG's own sense — "we never tested it" is not a markable state.
+
+---
+
+## 6. The unconsumed-press invariant (#40)
+
+**A press consumed by neither a route-specific handler nor the global key ladder must produce no
+global side effect.**
+
+The hazard was structural rather than a missing arm. `app.rs::begin_fresh_press` runs for **every**
+fresh press, *before* the ladder decides whether anything takes it, and two of the things it does
+belong to no arm:
+
+* `hud.note_fresh_press(now)` — un-dismisses the player HUD, so an unsupported key raised the
+  transport over a film the viewer was watching;
+* the armed-click abort — so an unsupported key cancelled a tvOS press in flight.
+
+Both are now behind **`ui::consts::is_bound(sym, wcode)`**, which is §2's map expressed as one
+predicate: `classify` names a `Key`, **or** `page_dir` answers, **or** the sym is backspace/Clear,
+**or** the **sym** is an ASCII digit. The guarded half lives in `app.rs::note_global_press`, split
+out so `make check` can grade it — `begin_fresh_press` itself calls `hide_cursor`, a webOS-only SDL
+symbol, and a host test that reaches it fails at `ld` rather than at an assertion.
+
+**The digit term reads `sym` and not `wcode`, diverging from `profiles::digit_of`, on purpose.**
+48–57 in the scancode field are `]` `\` `#` `;` `'` `` ` `` `,` `.` `/` and CapsLock (the digits'
+scancodes are 30–39, which is how 33/34 turned out to be `4` and `5` in the first place). Mirroring
+`digit_of` would have put the retired mis-reading straight back inside the gate that exists to stop
+it. The consequence is that `is_bound` is not a strict superset of `digit_of` for a wcode-only
+punctuation press — which is harmless, because the PIN pad has neither a HUD nor an armed click.
+
+Three things stay unconditional, each for its own reason. `held.down_sym` is bookkeeping about the
+physical key: without it, a held unsupported key's auto-repeats would each arrive as a fresh press.
+The D-pad cursor gate is already narrower than `is_bound` — it takes the four plain direction syms
+and nothing else. And the caller's `last_input` stamp is a local, read only by arms that run in the
+same loop iteration, so an unbound press cannot carry it anywhere.
+
+**The one place it deliberately over-approximates.** The digits count as bound *everywhere*, because
+the who's-watching PIN keypad types from them, so a number press on Home or during playback still
+un-dismisses the HUD. Narrowing that means making the predicate route-aware, i.e. a second copy of
+the ladder's own order — the duplication `page_dir` exists to have ended. A number key is also,
+unlike a colour button, a key this app really does bind, so calling it bound is honest.
+
+Graded twice, because neither half implies the other: `app.rs`'s `unsupported_key_tests` covers the
+two global effects (invisible to any focus fingerprint), and `tools/keytable.py` covers "moves
+nothing on any screen" — its `k:0,269` (HOME) and `k:53,34` (the digit 5) rows are inert on Home,
+Library and Search in `tests/keytable.json`.
+
+**What neither covers**: the player route. The simulator has no video path, so no fingerprint in
+that table was taken with a HUD on screen. The HUD half of this invariant has been graded as a unit
+test and never on a television.
+
+---
+
+## 7. The recipe: capture a remote's real scancodes
+
+**This is the only way to learn what any remote sends, and it needs a television.** An IR remote's
+codes are not derivable from anything on a desk: the table in §1 says what the fork *can* produce
+from a given evdev code, never which evdev code a given physical button emits.
+
+The app logs every keyboard event's raw bytes unconditionally, as
+`[<ticks>] key type=0x300 raw=<48 bytes of hex>`.
+
+1. Take the television's lock (`tv-lock` skill) and wake it (`wake-tv`).
+2. `make FLAVOR=debug deploy && make FLAVOR=debug run RUN_SECS=180`
+3. Press **every physical button** on the remote under test, slowly, one at a time, writing each one
+   down as you go — the log gives you codes in order and nothing else, so that order is the only
+   label they will ever have.
+4. Pull `make -s print-eventlog FLAVOR=debug` and decode each line's `+20` (`wcode`) and `+24`
+   (`sym`) as little-endian `u32`.
+5. Do it **once per remote**: the **Magic Remote** (done 2026-08-22, 336 lines) and a **standard IR
+   remote** (checklist #26, never done — everything in this file has only ever been driven by the
+   Magic Remote, which is exactly why that row is not a formality).
+
+Rehearse the *handling* of any code you find against the simulator first. The remote-FIFO token
+**`k:<sym>,<wcode>`** presses an arbitrary pair — the only way to drive a key the mnemonic token map
+does not name, and therefore the only way to exercise an unsupported key headlessly at all.
+
+Four things one run should settle: **HOME** (does 269 arrive, §5), **LIVE** (what code, if any, §5),
+whether **461** and **412 / 417 / 413 / 415 / 402** ever fire (§2, §4.2), and the whole of #26.
+
+---
+
+## 8. Known QA blocker: BACK on the entry page
+
+**Recorded here, not changed.** LG's submission UX rules include, as quoted in
+`docs/distribution.md` §2, that
+
+> every selectable element must respond to 4-way + OK + Back, and on webOS 23–25 Back on the entry
+> page must show the Home screen.
+
+That is `distribute/*` submission and QA policy, so it is **presumed to apply to native apps** and
+cannot be waved off as web-app-facing the way an API page under `develop/*` can.
+
+**What the app does today:** BACK at Home's own root does not leave. It raises the app's one
+decision alert (`ui/exit_alert.rs`) — *Cancel* focused, *Exit* in the destructive control face — and
+only *Exit* ends the process. `/tmp/plxnative-noexitconfirm` restores the old quit-on-the-press
+behaviour for a script that wants it.
+
+**Verdict: known QA blocker, pending native-specific evidence.** Reconciling it needs Seller Lounge
+or Native SDK evidence about whether native apps differ from the web-runtime rule this sentence was
+written for, and that evidence is still being sought. Do not "fix" it by deleting the confirmation
+on the strength of the quotation alone: the alert was added deliberately on 2026-08-21, nothing
+automated depends on the old behaviour (`make kill`, `tests/run.py` and `tools/tv-session.sh` all
+close through SAM's `closeByAppId`), and reverting it silently is how a considered decision gets
+lost.
+
+---
+
+## 9. Open, and worth knowing before trusting this file
+
+* **`SDLK_SELECT` is misnamed: `77 | 1<<30` is `SDLK_END`.** `SDL_SCANCODE_SELECT` is 119; 77 sits
+  in the `INSERT`/`HOME`/`PAGEUP`/`DELETE`/`END`/`PAGEDOWN` run at 73–78, and the television's table
+  confirms it — entry 107 (`KEY_END`) is what produces 77. So `is_ok` accepts a keyboard's **End**
+  key and would NOT accept a remote's real SELECT. Left as-is: the name is read from
+  `ui/profiles.rs`'s test, and repointing the value would make `is_ok` answer a different key on no
+  evidence that any remote sends 119 either. OK itself is unaffected — the remote's OK is
+  `SDL_SCANCODE_RETURN`, captured and bound.
+* **§4.2** — `19` is `SDL_SCANCODE_P` and is bound to PLAY. Untested on a device; needs a USB
+  keyboard as well as §7.
+* **`ui::profiles`' `digit_of` reads the digit range in `wcode` too**, where 48–57 are not digits at
+  all but `]` `\` `#` `;` `'` `` ` `` `,` `.` `/` and CapsLock — and its own test asserts
+  `digit_of(0, 55) == Some(b'7')`, where scancode 55 is a full stop. No remote has those keys, so it
+  is harmless in practice and `profiles.rs` is left alone here; a USB keyboard on the PIN screen
+  would type digits from punctuation. `is_bound` deliberately does **not** mirror it (§6). The same
+  capture settles both.
+* **`461` and `156` are not producible from the evdev table.** 156 is explained — the panel's *Clear
+  all* comes through the fork's text path, and is device-measured. 461 is not explained: it is a
+  defensive second BACK code with no evidence behind it on this firmware.
+* **The `Provenance` column is about ONE firmware**, the dev set's (webOS 4.5,
+  `libSDL2-2.0.so.0.4.1`). The inventories `tools/fwcompat.py` reads are symbol lists and can say
+  nothing about a table in `.rodata`; comparing another release means harvesting its `libSDL2`.
+* **The simulator's key path is not the television's.** On the host, a synthetic press carries its
+  `wcode` in `SDL_Keysym.mod` under a marker in `windowID`, because macOS `libSDL2` is sdl2-compat
+  forwarding into SDL3 and the fields it preserves across `SDL_PushEvent` are not the obvious ones —
+  `keysym.scancode` and `keysym.unused` are both discarded (`decode_key`'s doc has the measured
+  table). Until 2026-08-23 the carrier was `unused`, so **every wcode-only FIFO token was silently
+  dead in the simulator** and three rows of `tests/keytable.json` recorded "did nothing" for presses
+  that never arrived. Anything read off `make sim` about *which* code arrives is a fact about that
+  shim, not about a remote.

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -1356,8 +1356,9 @@ impl HudState {
     /// ([`crate::ui::up_next::countdown_may_run`]) read as the user walking away — latching the
     /// countdown off for the whole segment. The tile appeared only if the HUD was raised by hand,
     /// with its auto-advance already dead: exactly as reported. A dismissal is a "not now" that any
-    /// key clears; a segment beginning is that same kind of event, arriving from the player instead
-    /// of the remote, and it must clear it too — which is also what makes an offer behave the same
+    /// key the app BINDS clears (an unsupported one clears nothing — `note_global_press`); a segment
+    /// beginning is that same kind of event, arriving from the player instead of the remote, and it
+    /// must clear it too — which is also what makes an offer behave the same
     /// whether the HUD auto-hid or was hidden on purpose.
     ///
     /// Parking is only ever from REST: a user who walked to the Subtitles disc or an Info tab keeps
@@ -1366,17 +1367,23 @@ impl HudState {
     /// ([`crate::ui::player_hud::ControlSlot::primary_btn`]) — item 0 for a Skip pill, the
     /// RIGHT-hand one for Up Next, where parking on item 0 would disarm the timer on the frame
     /// after it armed.
-    /// A fresh key has arrived: record what the transport LOOKED like to the user, then clear the
-    /// dismissal it may have been carrying.
+    /// A fresh key the app BINDS has arrived: record what the transport LOOKED like to the user,
+    /// then clear the dismissal it may have been carrying.
     ///
     /// The two are one operation and the ORDER is the whole point — `dismissed` outranks the timer
     /// inside [`hud_visible`], so sampling after the clear reports a hand-hidden transport as being
     /// on screen (see [`visible_at_press`](Self::visible_at_press)). Written down as one function
-    /// rather than two lines in [`begin_fresh_press`] so that the order is a thing a test can hold
-    /// still, instead of a convention a later edit can quietly transpose.
+    /// rather than two lines in its caller so that the order is a thing a test can hold still,
+    /// instead of a convention a later edit can quietly transpose.
+    ///
+    /// That caller is [`note_global_press`], NOT [`begin_fresh_press`] as it once was, and the
+    /// difference is the point of the split: an unsupported key never gets here at all.
     fn note_fresh_press(&mut self, now: u32) {
         self.visible_at_press = hud_visible(now, hud_until(), paused(), self.dismissed);
-        self.dismissed = false; // any fresh key un-dismisses the HUD (UP-hide re-sets it)
+        // Any BOUND fresh key un-dismisses the HUD (UP-hide re-sets it). "Bound" and not "any" is
+        // the whole of `note_global_press`, the ONLY caller: an unsupported press never reaches
+        // here, so a colour button over a film no longer raises the transport.
+        self.dismissed = false;
     }
 
     fn raise_for_offer(&mut self, now: u32, primary: c_int) {

--- a/rust-modules/src/app.rs
+++ b/rust-modules/src/app.rs
@@ -71,9 +71,9 @@ pub(crate) const SDL_TEXTINPUT: u32 = 0x303;
 // keysyms, the OK/BACK predicates and `classify` — the key VOCABULARY the ladder below dispatches
 // on — live in ui::consts (the single keycode home)
 use crate::ui::consts::{
-    classify, is_back, is_ok, Key, SDLK_DOWN, SDLK_ESCAPE, SDLK_LEFT, SDLK_PAGEDOWN, SDLK_PAGEUP,
-    SDLK_RETURN, SDLK_RIGHT, SDLK_UP, WCODE_CH_DOWN, WCODE_CH_UP, WCODE_PAUSE, WCODE_PLAY,
-    WCODE_POINTER_HIDDEN, WCODE_STOP,
+    classify, is_back, is_bound, is_ok, Key, SDLK_DOWN, SDLK_ESCAPE, SDLK_LEFT, SDLK_PAGEDOWN,
+    SDLK_PAGEUP, SDLK_RETURN, SDLK_RIGHT, SDLK_UP, WCODE_CH_DOWN_KEY, WCODE_CH_UP_KEY, WCODE_PAUSE,
+    WCODE_PLAY, WCODE_POINTER_HIDDEN, WCODE_STOP,
 };
 // The window we ASK SDL for. `surface::probe` then reads back what we actually got.
 const SCR_W: c_int = crate::surface::LOGICAL_W as c_int;
@@ -262,6 +262,45 @@ fn rd_u32(ev: &[u8], off: usize) -> u32 {
 /// `cfg!` rather than `#[cfg]` deliberately: both arms stay compiled on both platforms, so
 /// the one nobody is currently building cannot rot. This is the single site that knows the
 /// layout — `rd_u32`'s callers elsewhere read pointer events, whose offsets already agree.
+///
+/// **The `wcode` this returns is LG's SCANCODE**, which is worth saying because the name suggests
+/// otherwise. Every field measured off the dev set is the SDL scancode of the key beside it —
+/// backspace 42, Clear 156, ◀/▶ 80/79, OK 40 — so the fork's shift puts an ordinary
+/// `SDL_Keysym { scancode, sym }` at +20/+24 rather than inventing a webOS keycode namespace. That
+/// is why the codes above SDL's own range (450 play, 482 back, 505 exit) carry no sym at all: they
+/// are LG-private scancodes the keymap has no keycode for. `docs/remote-keys.md` has the account.
+///
+/// # The simulator's carrier moved, because the old one was silently DEAD
+///
+/// A synthetic press from the remote FIFO has to get its wcode across `SDL_PushEvent`, and on the
+/// host that queue is not SDL2's: macOS `libSDL2` is **sdl2-compat forwarding into SDL3**, so every
+/// pushed event is converted out and back. Measured 2026-08-23 by dumping the polled bytes of a
+/// press whose every spare field carried a distinct value:
+///
+/// | field                        | offset | survives |
+/// |------------------------------|--------|----------|
+/// | `windowID`                   |  +8    | yes      |
+/// | `padding2` / `padding3`      | +14/15 | no       |
+/// | `keysym.scancode`            | +16    | **no** — comes back 0 |
+/// | `keysym.mod`                 | +24    | yes      |
+/// | `keysym.unused`              | +28    | **no** — comes back 1 |
+///
+/// It used to be `unused`, so **every wcode-ONLY token was dead**: `play`, `pause`, `stop`, `ff`,
+/// `rew`, `playpause`, `exit`, `chup`, `chdown` all decoded as wcode 1 and did nothing at all, and
+/// `tests/keytable.json` recorded three of them as `moved: false` — which reads as "that key does
+/// nothing on that screen" and actually meant the press never arrived. An instrument silent by
+/// construction: prove it can see the thing before reading its silence.
+///
+/// `scancode` would have been the honest home (it is what a wcode IS) and it is the one field the
+/// compat layer recomputes. So a synthetic press carries the value in `mod` and a MARKER in
+/// `windowID` ([`SYNTH_WINDOW`]) — two fields, because the value alone cannot say whether it is
+/// one: a real press puts its modifier bitmask in `mod`, so `mod != 0` means "shift is down" at
+/// least as often as it means "injected". The marker restores the priority the `unused` field used
+/// to express — **injected first, the desktop stand-in only as a fallback** — which is load-bearing
+/// and not a preference: `host_wcode(8)` is BACK, while `remote_token_key`'s `backspace` token is
+/// `(8, 42)`, so asking the stand-in first turns the panel's delete key into a navigation.
+/// Clobbering `windowID` is safe here and nowhere else: this arm is `hostsim`-only, the simulator
+/// has one window, and nothing in the event loop reads that field.
 #[inline]
 fn decode_key(ev: &[u8]) -> (u32, u32, u32) {
     if cfg!(feature = "hostsim") {
@@ -271,15 +310,28 @@ fn decode_key(ev: &[u8]) -> (u32, u32, u32) {
         // Rebuild the fork's packed state byte-for-byte: low byte pressed(1)/released(0),
         // bit 0x100 auto-repeat. Everything downstream tests exactly those two.
         let state = pressed | if repeat != 0 { 0x100 } else { 0 };
-        // A synthetic event from the remote FIFO parks its webOS keycode in the spare `unused`
-        // field; a real keypress leaves it zero, and then the keyboard mapping supplies one.
-        let injected = rd_u32(ev, 28);
+        let injected = if rd_u32(ev, 8) == SYNTH_WINDOW {
+            u32::from(u16::from_ne_bytes([ev[24], ev[25]]))
+        } else {
+            0 // a real desktop press: `mod` there is the modifier bitmask, not a wcode
+        };
+        // The stand-in is the only way a physical Mac keyboard reaches a key the remote has and a
+        // keyboard does not (space = PAUSE), and it applies to real presses alone.
         let wcode = if injected != 0 { injected } else { host_wcode(sym) };
         (state, wcode, sym)
     } else {
         (rd_u32(ev, 16), rd_u32(ev, 20), rd_u32(ev, 24))
     }
 }
+
+/// The `windowID` a SYNTHETIC key event carries on the host, marking it as one — see [`decode_key`]
+/// for why the wcode needs a marker beside it rather than standing on its own. Any value no real
+/// window can have; SDL numbers windows from 1.
+///
+/// Defined unconditionally, like both halves of [`decode_key`]: the arm that uses it is behind
+/// `cfg!` rather than `#[cfg]`, precisely so the configuration nobody is currently building cannot
+/// rot.
+const SYNTH_WINDOW: u32 = 0x504c_584b; // "PLXK"
 
 /// The Magic Remote button a desktop keyboard stands in for, or 0.
 ///
@@ -314,12 +366,13 @@ fn encode_key(sym: c_uint, wcode: c_uint, down: bool) -> [u8; 128] {
         ev[12] = u8::from(down); // state
         ev[13] = 0; // repeat
         ev[20..24].copy_from_slice(&sym.to_ne_bytes());
-        // Stock SDL_Keysym ends in a spare `unused` u32 (event offset +28). A webOS keycode has
-        // nowhere else to go on this layout, and several tokens carry ONLY a wcode (`pause` is
-        // sym 0, wcode 72), so deriving it from the sym would lose them. `decode_key` prefers
-        // this field and falls back to the keyboard mapping when it is zero — which is what a
-        // real desktop keypress leaves it as.
-        ev[28..32].copy_from_slice(&wcode.to_ne_bytes());
+        // The wcode rides `SDL_Keysym.mod` (event offset +24, a `Uint16`), under a marker in
+        // `windowID` that says this press is synthetic at all. Several tokens carry ONLY a wcode
+        // (`pause` is sym 0, wcode 72), so deriving it from the sym is not an option.
+        // `decode_key`'s doc has the measurement behind both fields — the short version is that of
+        // the spare places to put a value, these two are the ones sdl2-compat does not discard.
+        ev[8..12].copy_from_slice(&SYNTH_WINDOW.to_ne_bytes());
+        ev[24..26].copy_from_slice(&(wcode as u16).to_ne_bytes());
     } else {
         ev[16..20].copy_from_slice(&if down { 1u32 } else { 0 }.to_ne_bytes()); // state
         ev[20..24].copy_from_slice(&wcode.to_ne_bytes());
@@ -359,7 +412,21 @@ fn rd_i32(ev: &[u8], off: usize) -> i32 {
 /// real Magic-Remote press would carry — the pair the ONE key handler already matches
 /// (see `ui::consts`). Returns None for an unknown token. Kept deliberately small: the
 /// core nav set + OK/BACK + the transport keys that testing needs.
+///
+/// **Plus one escape hatch, `k:<sym>,<wcode>`, which is the only way to press a key this map does
+/// NOT name.** That is not a convenience: the whole point of LG checklist item 40 is what an
+/// *unsupported* key does, and a named-token map can by construction never send one. It also
+/// covers the keys that are bound but have no business getting a mnemonic — the digits, the
+/// channel rocker's raw codes — and lets a device question be rehearsed against the simulator
+/// first (`k:0,269` is HOME, `k:53,34` is the digit `5` exactly as the television spells it).
+/// Both fields are DECIMAL and both are required, because a pair with one field guessed is the
+/// bug class `decode_key` exists to prevent. `tools/keytable.py` drives its unsupported-key and
+/// pager rows through this.
 fn remote_token_key(tok: &str) -> Option<(c_uint, c_uint)> {
+    if let Some(rest) = tok.strip_prefix("k:") {
+        let (s, w) = rest.split_once(',')?;
+        return Some((s.parse().ok()?, w.parse().ok()?));
+    }
     Some(match tok {
         "up" => (SDLK_UP, 0),
         "down" => (SDLK_DOWN, 0),
@@ -367,8 +434,15 @@ fn remote_token_key(tok: &str) -> Option<(c_uint, c_uint)> {
         "right" => (SDLK_RIGHT, 0),
         "ok" | "enter" | "select" => (SDLK_RETURN, 0), // is_ok()
         "back" | "esc" => (SDLK_ESCAPE, 0),            // is_back()
-        "pageup" | "chup" => (SDLK_PAGEUP, WCODE_CH_UP),
-        "pagedown" | "chdown" => (SDLK_PAGEDOWN, WCODE_CH_DOWN),
+        // The pager's two spellings, and they are two tokens now rather than one pair carrying
+        // both: a PAGE key is a keyboard's and arrives as a sym alone, the rocker is the remote's
+        // and arrives as a wcode alone. The single pair they shared was `(SDLK_PAGEUP, 33)` — a
+        // shape no real press has, since 33 is the digit `4` (`ui::consts`, where they were
+        // retired), so half of what it drove was never the pager answering the rocker at all.
+        "pageup" => (SDLK_PAGEUP, 0),
+        "pagedown" => (SDLK_PAGEDOWN, 0),
+        "chup" => (0, WCODE_CH_UP_KEY),
+        "chdown" => (0, WCODE_CH_DOWN_KEY),
         "play" => (0, WCODE_PLAY),
         "pause" => (0, WCODE_PAUSE),
         "stop" => (0, WCODE_STOP),
@@ -2537,9 +2611,34 @@ unsafe fn on_auto_repeat(
 /// spelled-out `sym ==` comparisons here took. Whether the alternate D-pad codes BELONG in it is an
 /// open behavioural question — the Chapters strip accepts them and does not hide the cursor — and
 /// naming the identity did not settle it.
+///
+/// # The unsupported-key invariant (LG checklist item 40)
+///
+/// **This function runs BEFORE the ladder has decided whether anything takes the press**, and two
+/// of the things it does are GLOBAL rather than local to an arm: un-dismissing the player HUD, and
+/// aborting a tvOS click in flight. So until 2026-08-23 an unsupported key — a colour button,
+/// GUIDE, INFO, a universal remote's extra half — raised the transport over playback and cancelled
+/// a press the user was in the middle of, and neither is a thing "the app ignored that key" is
+/// allowed to mean. Both are now gated on [`is_bound`], whose doc carries the whole map and the one
+/// place it deliberately over-approximates.
+///
+/// **The invariant is about CONSUMPTION, not about [`Key::Other`].** `Other` is a legitimate
+/// identity for real, handled keys — the Library pager (a separate `page_dir` predicate) and
+/// Search's Backspace/Clear both classify as `Other` and are then taken by hand — so making the
+/// variant inert would break all of them. `is_bound` is the superset that answers the actual
+/// question.
+///
+/// Three things stay UNCONDITIONAL and each for its own reason. `held.down_sym` is bookkeeping
+/// about the physical key, not a side effect: without it a held unsupported key's auto-repeats
+/// would each arrive as a fresh press (`state & 0x100 != 0 && sym == held.down_sym` in the
+/// caller). The D-pad cursor gate is already narrower than `is_bound` — it takes the four plain
+/// direction syms and nothing else — so it needs no second guard. And the caller's `last_input`
+/// stamp is a local read only by arms that run in the same iteration, so an unbound press cannot
+/// carry it anywhere.
 unsafe fn begin_fresh_press(
     key: Key,
     sym: c_uint,
+    wcode: c_uint,
     now: u32,
     held: &mut HeldKey,
     hud: &mut HudState,
@@ -2547,17 +2646,7 @@ unsafe fn begin_fresh_press(
     ok_armed: &mut bool,
 ) {
     held.down_sym = sym;
-    // What the user could SEE, and only then the un-dismiss — one operation, because the order is
-    // load-bearing (`HudState::note_fresh_press`). Taken for every key on every screen: it is one
-    // cheap predicate, and the alternative is each player arm remembering to ask first, which is
-    // exactly the ordering the pointer path had to be fixed for once already.
-    hud.note_fresh_press(now);
-    // a fresh non-OK key (navigation / BACK) while a click is armed aborts the press —
-    // spring the card back to rest WITHOUT activating (you "slid off" the control).
-    if *ok_armed && !is_ok(sym) {
-        crate::ui::press::cancel();
-        *ok_armed = false;
-    }
+    note_global_press(sym, wcode, now, hud, ok_armed);
     if matches!(key, Key::Up | Key::Down | Key::Left { alt: false } | Key::Right { alt: false }) {
         if !ptr.dpad_mode || !ptr.cur_hidden {
             hide_cursor();
@@ -2565,6 +2654,91 @@ unsafe fn begin_fresh_press(
         ptr.dpad_mode = true;
         ptr.cur_hidden = true;
         ptr.mot_accum = 0.0;
+    }
+}
+
+/// **The two GLOBAL effects of a fresh press, and the guard that decides whether they happen** —
+/// the half of [`begin_fresh_press`] that LG checklist item 40 is about, and its only caller.
+///
+/// Split out for one blunt reason: `begin_fresh_press` calls `hide_cursor`, which names a
+/// webOS-only SDL symbol, so a host test that reaches it fails at `ld` rather than at an assertion
+/// (the boundary the testing section of the root `CLAUDE.md` describes — the crate links today only
+/// because nothing reachable from a test calls it and the linker dead-strips it). This half touches
+/// no SDL at all, so the invariant is gradeable by `make check` instead of only by a television.
+fn note_global_press(sym: c_uint, wcode: c_uint, now: u32, hud: &mut HudState, ok_armed: &mut bool) {
+    if !is_bound(sym, wcode) {
+        return; // an unsupported key is not input the app acted on — see `begin_fresh_press`
+    }
+    // What the user could SEE, and only then the un-dismiss — one operation, because the order is
+    // load-bearing (`HudState::note_fresh_press`). Taken for every BOUND key on every screen: it is
+    // one cheap predicate, and the alternative is each player arm remembering to ask first, which
+    // is exactly the ordering the pointer path had to be fixed for once already.
+    hud.note_fresh_press(now);
+    // a fresh non-OK key (navigation / BACK) while a click is armed aborts the press — spring the
+    // card back to rest WITHOUT activating (you "slid off" the control). A key the app does not
+    // bind is not sliding off anything: nothing moved, so nothing is abandoned.
+    if *ok_armed && !is_ok(sym) {
+        crate::ui::press::cancel();
+        *ok_armed = false;
+    }
+}
+
+/// **The unsupported-key invariant, graded.** `tools/keytable.py` grades the other half — that an
+/// unbound press moves no focus on any screen — and cannot see either of these two, because neither
+/// appears in a focus fingerprint.
+#[cfg(test)]
+mod unsupported_key_tests {
+    use super::*;
+
+    /// Drive one fresh press through [`note_global_press`] and report what it left behind:
+    /// `(a click is still armed, the HUD is still dismissed)`. `press::*`, `hud_until()` and
+    /// `paused()` are all crate globals, so every caller holds `testlock::serial()`.
+    fn press(sym: c_uint, wcode: c_uint) -> (bool, bool) {
+        let mut hud = HudState::IDLE;
+        let mut ok_armed = true; // a click is in flight, as if OK were still down on a card
+        hud.dismissed = true; // …and the transport was hidden by hand (UP from the control row)
+        crate::ui::press::begin(1_000);
+        note_global_press(sym, wcode, 1_000, &mut hud, &mut ok_armed);
+        let out = (crate::ui::press::is_active() && ok_armed, hud.dismissed);
+        crate::ui::press::cancel();
+        out
+    }
+
+    /// A key the app binds behaves exactly as it always has: it un-dismisses the HUD and aborts the
+    /// click it slid off. BACK is the case to use — it is not OK, so it takes the abort branch.
+    #[test]
+    fn a_bound_key_still_wakes_the_hud_and_aborts_the_click() {
+        let _g = crate::testlock::serial();
+        let (armed, dismissed) = press(SDLK_ESCAPE, 0);
+        assert!(!armed, "BACK slides off the control — the press is cancelled");
+        assert!(!dismissed, "…and any key un-dismisses the transport");
+    }
+
+    /// **The regression.** An unsupported key must do NEITHER — it is not input the app acted on,
+    /// so it may not raise the transport over playback and it may not abandon a press in flight.
+    /// 269 is HOME (`SDL_SCANCODE_AC_HOME`, evdev 172 `KEY_HOMEPAGE`); every other unbound
+    /// scancode takes the same branch.
+    #[test]
+    fn an_unsupported_key_wakes_nothing_and_abandons_nothing() {
+        let _g = crate::testlock::serial();
+        for (sym, wcode, what) in
+            [(0, 269, "HOME"), (0, 270, "AC_BACK"), (b'a' as c_uint, 4, "a letter")]
+        {
+            let (armed, dismissed) = press(sym, wcode);
+            assert!(armed, "{what} must not cancel the armed click");
+            assert!(dismissed, "{what} must not un-dismiss the HUD");
+        }
+    }
+
+    /// The digits are the one place [`is_bound`] deliberately over-approximates (its doc argues
+    /// it): the who's-watching PIN keypad types from them, so they count as bound everywhere.
+    /// Pinned so the trade-off stays a decision on record rather than something a reader finds.
+    #[test]
+    fn a_number_key_counts_as_bound_because_the_pin_keypad_types_from_it() {
+        let _g = crate::testlock::serial();
+        let (armed, dismissed) = press(b'5' as c_uint, 34);
+        assert!(!armed);
+        assert!(!dismissed);
     }
 }
 
@@ -4428,7 +4602,7 @@ pub extern "C" fn plex_run(pms_host: *const c_char, pms_port: c_int) -> c_int {
                     }
                     // From here down this IS a fresh press, whatever the driver stamped on it.
                     last_input = SDL_GetTicks();
-                    begin_fresh_press(key, sym, last_input, &mut held_key, &mut hud, &mut ptr, &mut ok_armed);
+                    begin_fresh_press(key, sym, wcode, last_input, &mut held_key, &mut hud, &mut ptr, &mut ok_armed);
 
                     // ---- the route-scoped arms, each of which `continue`s once it has taken the
                     // press. That makes the chain itself the priority statement: an earlier guard
@@ -6896,7 +7070,23 @@ mod key_layout_tests {
     fn key_bytes_round_trip() {
         // The wcode-only case is the one that breaks a sym-derived mapping, and the one a naive
         // host layout loses: `pause` carries no sym at all.
-        for (sym, wcode) in [(SDLK_DOWN, 0), (SDLK_RETURN, 0), (0, WCODE_PAUSE), (8, WCODE_BACK)] {
+        //
+        // **`(8, 42)` is the case that MATTERS and it was missing.** It is the `backspace` token,
+        // and 8 is one of the four syms `host_wcode` maps a desktop key onto — to `WCODE_BACK`.
+        // The only sym-plus-wcode case here used to be `(8, WCODE_BACK)`, the single pair where
+        // the stand-in and the carrier agree, so a decode that consulted the stand-in FIRST passed
+        // this test while turning the panel's delete key into a navigation. Every one of those
+        // four syms belongs here for the same reason.
+        for (sym, wcode) in [
+            (SDLK_DOWN, 0),
+            (SDLK_RETURN, 0),
+            (0, WCODE_PAUSE),
+            (8, WCODE_BACK),
+            (8, 42),    // backspace: sym 8, SDL_SCANCODE_BACKSPACE — NOT BACK
+            (32, 44),   // space, 'p', 's': the other three syms the stand-in claims, each
+            (112, 19),  // beside its own real scancode, which must survive unchanged
+            (115, 22),
+        ] {
             for down in [true, false] {
                 let ev = encode_key(sym, wcode, down);
                 let (state, got_wcode, got_sym) = decode_key(&ev);
@@ -6910,6 +7100,25 @@ mod key_layout_tests {
                 assert_eq!(state & 0x100, 0, "a synthetic edge must never look like auto-repeat");
             }
         }
+    }
+
+    /// **`k:<sym>,<wcode>` — the only token that can press a key the map does NOT name**, which is
+    /// what LG checklist item 40 needs: a named-token map can by construction never send an
+    /// unsupported key. Both fields are required and decimal; a half-parsed pair must be REFUSED
+    /// rather than silently become a press of something else, because the drain's `else` logs an
+    /// unknown token and a wrong pair would log nothing at all.
+    #[test]
+    fn the_raw_key_token_carries_both_fields_or_none() {
+        use super::remote_token_key;
+        assert_eq!(remote_token_key("k:0,269"), Some((0, 269)), "HOME, which nothing else can send");
+        assert_eq!(remote_token_key("k:53,34"), Some((53, 34)), "the digit 5 as the TV spells it");
+        for bad in ["k:", "k:1", "k:1,", "k:,1", "k:a,1", "k:1,b", "k:1,2,3", "k:-1,2", "k: 1,2"] {
+            assert_eq!(remote_token_key(bad), None, "{bad:?} must not become a keypress");
+        }
+        // …and it must not shadow the named tokens or the other prefixed ones.
+        assert!(remote_token_key("ck:10,20").is_none(), "a click token is not a key token");
+        assert_eq!(remote_token_key("chup"), Some((0, crate::ui::consts::WCODE_CH_UP_KEY)));
+        assert_eq!(remote_token_key("pageup"), Some((crate::ui::consts::SDLK_PAGEUP, 0)));
     }
 }
 

--- a/rust-modules/src/ui/consts.rs
+++ b/rust-modules/src/ui/consts.rs
@@ -46,6 +46,14 @@ pub const SDLK_DOWN: c_uint = 81 | (1 << 30);
 pub const SDLK_UP: c_uint = 82 | (1 << 30);
 pub const SDLK_RETURN: c_uint = 13;
 pub const SDLK_KP_ENTER: c_uint = 88 | (1 << 30);
+/// **The name is wrong and the value is left alone deliberately: 77 is `SDL_SCANCODE_END`.**
+/// `SDL_SCANCODE_SELECT` is 119; 77 sits in the `INSERT`/`HOME`/`PAGEUP`/`DELETE`/`END`/`PAGEDOWN`
+/// run at 73–78, and the television's own evdev table confirms it — entry 107 (`KEY_END`) is what
+/// produces 77. So [`is_ok`] accepts a keyboard's **End** key and would NOT accept a remote's real
+/// SELECT. Renaming it is the honest fix and is not this change's to make: the name is read from
+/// `ui/profiles.rs`'s test, and repointing the value would make `is_ok` answer a different key on
+/// no evidence that any remote sends 119 either. Recorded in `docs/remote-keys.md` §9, to be
+/// settled by the capture in §7 — with everything else of its kind, in one pass.
 pub const SDLK_SELECT: c_uint = 77 | (1 << 30);
 pub const SDLK_ESCAPE: c_uint = 27;
 pub const SDLK_PAGEUP: c_uint = 75 | (1 << 30);
@@ -61,10 +69,24 @@ pub const SDLK_PAGEDOWN: c_uint = 78 | (1 << 30);
 /// them has a keyboard whose buttons visibly do nothing, which is exactly how this shipped.
 pub const SDLK_BACKSPACE: c_uint = 8;
 pub const SDLK_CLEAR: c_uint = 156 | (1 << 30);
-/// Magic-Remote CH▲/CH▼ rocker — webOS keyCodes 33/34 (page the Library grid). Matched
-/// alongside the SDLK_PAGE* syms; verify the raw wcodes in the event log on a new remote.
-pub const WCODE_CH_UP: c_uint = 33;
-pub const WCODE_CH_DOWN: c_uint = 34;
+// **`WCODE_CH_UP` / `WCODE_CH_DOWN` = 33 / 34 USED TO LIVE HERE, and they were the DIGITS.**
+// They are deleted rather than kept-but-unused, and this note stays because the next reader will
+// otherwise re-derive them from the same public table that produced them.
+//
+// They entered as "Magic-Remote CH▲/CH▼ rocker — webOS keyCodes 33/34", carrying the caveat
+// *"verify the raw wcodes in the event log on a new remote"* — a caveat nobody ever spent. 33/34
+// really are ChannelUp/ChannelDown, but in the CEA-2014-A / LG **web** keyCode namespace, where
+// they are the browser's PageUp/PageDown. This app receives native SCANCODES: the same namespace
+// error that retired 412/417 (see [`WCODE_REWIND`]). In THAT namespace 33 and 34 are
+// `SDL_SCANCODE_4` and `SDL_SCANCODE_5`, produced by evdev 5 `KEY_4` and evdev 6 `KEY_5` — which
+// is a fact about the television, readable offline in its own table (`libSDL2-2.0.so.0.4.1`, file
+// offset `0x92840`, entries 5 and 6), not an inference.
+//
+// So [`page_dir`] answered a NUMBER KEY: pressing `5` on a remote keypad paged the Library grid.
+// The real rocker is [`WCODE_CH_UP_KEY`]/[`WCODE_CH_DOWN_KEY`] (300/301) and was already bound
+// beside them, so nothing is lost. Those two do NOT inherit the freed names: a constant that
+// silently changes value is how a doc or a log predating the change comes to read as the opposite
+// of what it says.
 /// Magic-Remote transport keys. The ONE home for these wcodes: [`classify`] below resolves them
 /// for the key handler, and `app.rs`'s remote-injection token map and desktop-keyboard stand-in
 /// both build presses from these names.
@@ -119,10 +141,12 @@ pub const WCODE_STOP_CD: c_uint = 260;
 pub const WCODE_PLAYPAUSE: c_uint = 261;
 /// evdev 174 `KEY_EXIT` -> 505. LG's checklist item 38 wants the app terminated on this press.
 pub const WCODE_EXIT: c_uint = 505;
-/// The channel rocker as the table spells it — evdev 402/403 `KEY_CHANNELUP`/`KEY_CHANNELDOWN` ->
-/// **300/301**. [`WCODE_CH_UP`]/[`WCODE_CH_DOWN`] (33/34) are kept beside these and are almost
-/// certainly NOT the rocker: 33 and 34 are `SDL_SCANCODE_4` and `SDL_SCANCODE_5`, produced by
-/// evdev 5/6, i.e. the DIGITS 4 and 5. Harmless to keep, wrong to rely on.
+/// **The channel rocker, and since 2026-08-23 the ONLY spelling of it** — evdev 402/403
+/// `KEY_CHANNELUP`/`KEY_CHANNELDOWN` -> **300/301** in the television's own table. The digits
+/// 33/34 used to sit beside these in [`page_dir`], described as the rocker and hedged as "almost
+/// certainly NOT"; the note where they were deleted, a few dozen lines up, is why. The `_KEY`
+/// suffix is evdev's (`KEY_CHANNELUP`) and is kept precisely so these names stay distinct from the
+/// retired pair.
 pub const WCODE_CH_UP_KEY: c_uint = 300;
 pub const WCODE_CH_DOWN_KEY: c_uint = 301;
 
@@ -144,9 +168,12 @@ pub fn is_back(sym: c_uint, wcode: c_uint) -> bool {
 /// the webOS `wcode` at +20; the raw-offset reading is a gotcha in the root `CLAUDE.md`).
 ///
 /// [`Key::Other`] is every press `classify` does not name, which includes spellings the ladder
-/// still tests by hand where it needs them: the CH▲/CH▼ rocker ([`WCODE_CH_UP`]/[`WCODE_CH_DOWN`]
-/// and the `SDLK_PAGE*` syms, in the Library's paging arm) and the system keyboard's edit keys
-/// ([`SDLK_BACKSPACE`]/[`SDLK_CLEAR`], read inside the Search screen).
+/// still tests by hand where it needs them: the CH▲/CH▼ rocker ([`WCODE_CH_UP_KEY`]/
+/// [`WCODE_CH_DOWN_KEY`] and the `SDLK_PAGE*` syms, in the Library's paging arm via [`page_dir`]),
+/// the system keyboard's edit keys ([`SDLK_BACKSPACE`]/[`SDLK_CLEAR`], read inside the Search
+/// screen) and the digits the who's-watching PIN keypad types from. **So `Other` does NOT mean
+/// unbound and must never be made inert** — [`is_bound`] is the predicate that answers *is this
+/// press one the app binds at all*, and it is a strict superset of `classify != Other`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Key {
     Up,
@@ -261,15 +288,63 @@ pub fn classify(sym: c_uint, wcode: c_uint) -> Key {
 /// (300/301 — see [`WCODE_CH_UP_KEY`]) beside the digits meant editing both, which is the shape
 /// that goes wrong on the third code. Here it is one edit, next to [`classify`], and the test table
 /// below can see it.
+///
+/// **It is a separate predicate from [`classify`] and not a [`Key`] variant, which is the thing to
+/// understand before "making [`Key::Other`] inert".** A paging press classifies as `Other` and is
+/// then taken by the ladder's own Library arm — so `Other` is not a synonym for *unbound*, and
+/// [`is_bound`] is the predicate that answers that question.
 #[inline]
 pub fn page_dir(sym: c_uint, wcode: c_uint) -> Option<c_int> {
-    if sym == SDLK_PAGEUP || matches!(wcode, WCODE_CH_UP | WCODE_CH_UP_KEY) {
+    if sym == SDLK_PAGEUP || wcode == WCODE_CH_UP_KEY {
         return Some(-1);
     }
-    if sym == SDLK_PAGEDOWN || matches!(wcode, WCODE_CH_DOWN | WCODE_CH_DOWN_KEY) {
+    if sym == SDLK_PAGEDOWN || wcode == WCODE_CH_DOWN_KEY {
         return Some(1);
     }
     None
+}
+
+/// **Is this press one the app binds ANYWHERE — the whole key map, as one predicate.**
+///
+/// It exists for a single caller and a single rule: `app.rs`'s `begin_fresh_press` runs for EVERY
+/// fresh press, *before* the ladder has decided whether anything takes it, and two of the things it
+/// does are global — it un-dismisses the player HUD and it aborts an armed tvOS click. So an
+/// unsupported key (LG checklist item 40: the colour buttons, GUIDE, INFO, the number pad on a
+/// screen with no keypad, a universal remote's whole extra half) woke the transport and cancelled a
+/// press in flight. The invariant is *a press consumed by neither a route-specific handler nor the
+/// global key ladder must produce no global side effect*, and this is its guard.
+///
+/// **Four sources, because the map has four and not one:**
+/// 1. [`classify`] — every named [`Key`].
+/// 2. [`page_dir`] — the Library pager, a SEPARATE predicate (see its doc).
+/// 3. [`SDLK_BACKSPACE`] / [`SDLK_CLEAR`] — the television keyboard's own edit keys, read inside
+///    the Search screen (`ui::search::key`), which the classifier never sees.
+/// 4. An ASCII digit **in `sym`** — the who's-watching PIN keypad types straight from the remote's
+///    number buttons (`ui::profiles`' own `digit_of`, which owns that behaviour).
+///
+/// **The `sym` field ONLY, and that is a deliberate divergence from `digit_of`, which also reads
+/// the range out of `wcode`.** `wcode` is a SCANCODE (`app.rs::decode_key`), and 48–57 there are
+/// not digits at all: they are `]` `\` `#` `;` `'` `` ` `` `,` `.` `/` and CapsLock. The digits'
+/// scancodes are 30–39 — which is exactly why 33/34 turned out to be `4` and `5` a few dozen lines
+/// up. Mirroring `digit_of` would put the retired mis-reading straight back into the gate this
+/// function exists to be, so this takes the spelling the evidence supports: a remote's number key
+/// arrives with its ASCII keycode in `sym` (evdev 5 -> scancode 33 -> `SDLK_4` = 52). The cost is
+/// that `is_bound` is no longer a strict superset of `digit_of` for a wcode-only punctuation press
+/// — which reaches no HUD and no armed click, because the PIN pad has neither. `profiles` is not
+/// this module's to edit; `docs/remote-keys.md` §9 carries it as an open finding for the capture
+/// that settles both.
+///
+/// **It still OVER-approximates in one place** and the alternative is worse. A digit is bound only
+/// on the PIN pad, so a number press on Home or during playback answers `true` here and still wakes
+/// the HUD. Narrowing that means making this route-aware, i.e. a second copy of the ladder's own
+/// order — the exact duplication [`page_dir`] was written to end. A number key is also, unlike a
+/// colour button, a key this app really does bind, so calling it bound is honest.
+pub fn is_bound(sym: c_uint, wcode: c_uint) -> bool {
+    classify(sym, wcode) != Key::Other
+        || page_dir(sym, wcode).is_some()
+        || sym == SDLK_BACKSPACE
+        || sym == SDLK_CLEAR
+        || (b'0' as c_uint..=b'9' as c_uint).contains(&sym)
 }
 
 // spring stiffnesses (from ui_home.c, redistributed 1:1 to their owning views)
@@ -286,12 +361,78 @@ mod tests {
     fn the_pager_answers_both_spellings_and_nothing_else() {
         assert_eq!(page_dir(SDLK_PAGEUP, 0), Some(-1));
         assert_eq!(page_dir(SDLK_PAGEDOWN, 0), Some(1));
-        assert_eq!(page_dir(0, WCODE_CH_UP), Some(-1));       // the digits 4/5, kept
-        assert_eq!(page_dir(0, WCODE_CH_DOWN), Some(1));
-        assert_eq!(page_dir(0, WCODE_CH_UP_KEY), Some(-1));   // evdev 402/403, the real rocker
+        assert_eq!(page_dir(0, WCODE_CH_UP_KEY), Some(-1)); // evdev 402/403, the real rocker
         assert_eq!(page_dir(0, WCODE_CH_DOWN_KEY), Some(1));
         assert_eq!(page_dir(SDLK_UP, 0), None, "the D-pad is not the pager");
         assert_eq!(page_dir(0, WCODE_FASTFORWARD), None);
+    }
+
+    /// **The mis-binding this file shipped with until 2026-08-23, pinned from both sides.** 33/34
+    /// are `SDL_SCANCODE_4`/`SDL_SCANCODE_5`, so the pager was answering the remote's NUMBER KEYS;
+    /// they are the CEA-2014-A **web** keyCodes for the channel rocker, the same namespace error as
+    /// 412/417. A digit must reach no arm of the ladder — and must still be `is_bound`, because the
+    /// PIN keypad types from it.
+    #[test]
+    fn a_number_key_does_not_page_the_library() {
+        for (sym, wcode, what) in [
+            (b'4' as c_uint, 33, "the digit 4"),
+            (b'5' as c_uint, 34, "the digit 5"),
+        ] {
+            assert_eq!(page_dir(sym, wcode), None, "{what} is not the channel rocker");
+            assert_eq!(classify(sym, wcode), Key::Other, "{what} names no Key either");
+            assert!(is_bound(sym, wcode), "{what} IS bound — the who's-watching PIN keypad");
+        }
+        // …and the bare scancodes, in case a future remote sends one with no sym beside it.
+        assert_eq!(page_dir(0, 33), None);
+        assert_eq!(page_dir(0, 34), None);
+    }
+
+    /// [`is_bound`] is a strict SUPERSET of `classify != Other`, and the three things it adds are
+    /// exactly the three the ladder handles outside the classifier. Getting this wrong in either
+    /// direction is a real bug: too narrow and a real key stops un-dismissing the HUD, too wide and
+    /// item 40's whole point is lost.
+    #[test]
+    fn the_bound_set_is_the_whole_map_and_no_more() {
+        // every named Key
+        for (sym, wcode) in [
+            (SDLK_UP, 0),
+            (SDLK_LEFT, 0),
+            (SDLK_RETURN, 0),
+            (SDLK_ESCAPE, 0),
+            (0, WCODE_BACK),
+            (0, WCODE_PLAY),
+            (0, WCODE_PAUSE),
+            (0, WCODE_PLAYPAUSE),
+            (0, WCODE_STOP_KEY),
+            (0, WCODE_EXIT),
+            (0, WCODE_REWIND),
+            (0, WCODE_FASTFORWARD),
+            (0, WCODE_POINTER_HIDDEN),
+        ] {
+            assert!(is_bound(sym, wcode), "sym={sym} wcode={wcode} names a Key");
+        }
+        // the three sets `classify` does NOT name and the ladder still binds
+        assert!(is_bound(SDLK_PAGEDOWN, 0) && is_bound(0, WCODE_CH_UP_KEY), "the pager");
+        assert!(is_bound(SDLK_BACKSPACE, 42) && is_bound(SDLK_CLEAR, 156), "the panel's edit keys");
+        assert!(is_bound(b'0' as c_uint, 39) && is_bound(b'9' as c_uint, 38), "the PIN digits");
+        // and the ones that must stay unbound. 269 is `SDL_SCANCODE_AC_HOME` (evdev 172
+        // `KEY_HOMEPAGE`) and 270 `AC_BACK`; 412/417 are the retired web-namespace codes.
+        for (sym, wcode, what) in [
+            (0, 269, "HOME"),
+            (0, 270, "AC_BACK — not the remote's BACK, which is 482"),
+            (0, 412, "the retired 412"),
+            (0, 417, "the retired 417"),
+            (0, 0, "nothing at all"),
+            (b'a' as c_uint, 4, "a letter"),
+            // THE `is_bound` counterpart of the 33/34 retirement: 48-57 in the SCANCODE field are
+            // `]` `\` `;` `'` `,` `.` `/` and CapsLock, not digits (the digits are 30-39). Reading
+            // ASCII out of `wcode` is the one namespace error this whole change exists to stop.
+            (0, 49, "scancode 49, which is backslash and NOT the digit 1"),
+            (0, 55, "scancode 55, which is a full stop and NOT the digit 7"),
+        ] {
+            assert!(!is_bound(sym, wcode), "{what} must reach no arm");
+            assert_eq!(classify(sym, wcode), Key::Other, "{what}");
+        }
     }
 
     /// **The transport codes settled from LG's own evdev->scancode table**, and the two that were
@@ -376,12 +517,15 @@ mod tests {
     #[test]
     fn the_arms_that_still_spell_their_own_keys_classify_as_other() {
         for (sym, wcode) in [
-            (SDLK_PAGEUP, WCODE_CH_UP),
-            (SDLK_PAGEDOWN, WCODE_CH_DOWN),
+            (SDLK_PAGEUP, 0),
+            (SDLK_PAGEDOWN, 0),
+            (0, WCODE_CH_UP_KEY),
+            (0, WCODE_CH_DOWN_KEY),
             (SDLK_BACKSPACE, 42),
             (SDLK_CLEAR, 156),
         ] {
             assert_eq!(classify(sym, wcode), Key::Other, "sym={sym} wcode={wcode}");
+            assert!(is_bound(sym, wcode), "…and every one of them is still BOUND");
         }
     }
 

--- a/tests/keytable.json
+++ b/tests/keytable.json
@@ -1,57 +1,85 @@
 {
  "home": [
   {
-   "after": "focus route=home snapt=0 snapp=0 hf=-1 row=0 col=0 sid=0 rk=2108 press=0",
-   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2108 press=0",
+   "after": "focus route=home snapt=0 snapp=0 hf=-1 row=0 col=0 sid=0 rk=2056 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2056 press=0",
    "key": "up",
    "moved": true,
    "route": "home"
   },
   {
-   "after": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2108 press=0",
-   "before": "focus route=home snapt=0 snapp=0 hf=-1 row=0 col=0 sid=0 rk=2108 press=0",
+   "after": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2056 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=-1 row=0 col=0 sid=0 rk=2056 press=0",
    "key": "down",
    "moved": true,
    "route": "home"
   },
   {
-   "after": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2032 press=0",
-   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2108 press=0",
+   "after": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2056 press=0",
    "key": "left",
    "moved": true,
    "route": "home"
   },
   {
-   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2032 press=0",
-   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2032 press=0",
+   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=0 row=0 col=0 sid=0 rk=2029 press=0",
    "key": "right",
    "moved": true,
    "route": "home"
   },
   {
-   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
-   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2032 press=0",
+   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "key": "k:53,34",
+   "moved": false,
+   "route": "home"
+  },
+  {
+   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "key": "k:0,301",
+   "moved": false,
+   "route": "home"
+  },
+  {
+   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "key": "k:0,300",
+   "moved": false,
+   "route": "home"
+  },
+  {
+   "after": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
+   "key": "k:0,269",
+   "moved": false,
+   "route": "home"
+  },
+  {
+   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
+   "before": "focus route=home snapt=0 snapp=0 hf=1 row=0 col=0 sid=0 rk=2029 press=0",
    "key": "ok",
    "moved": true,
    "route": "home"
   },
   {
-   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
-   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
+   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
+   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
    "key": "play",
    "moved": false,
    "route": "detail"
   },
   {
-   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
-   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
+   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
+   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
    "key": "pause",
    "moved": false,
    "route": "detail"
   },
   {
-   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
-   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2032 ep=- epwatched=- press=0",
+   "after": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
+   "before": "focus route=detail sec=0 col=0 eptext=0 season=- saved=0,0,0,0,0,0 card=0 alt=0 show=0 sid=0 rk=2029 ep=- epwatched=- press=0",
    "key": "stop",
    "moved": false,
    "route": "detail"
@@ -84,6 +112,34 @@
    "before": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=1 press=0",
    "key": "right",
    "moved": true,
+   "route": "library"
+  },
+  {
+   "after": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "before": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "key": "k:53,34",
+   "moved": false,
+   "route": "library"
+  },
+  {
+   "after": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=1924 press=0",
+   "before": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "key": "k:0,301",
+   "moved": true,
+   "route": "library"
+  },
+  {
+   "after": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "before": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=1924 press=0",
+   "key": "k:0,300",
+   "moved": true,
+   "route": "library"
+  },
+  {
+   "after": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "before": "focus route=library pill=-1 card=1 menu=0 sid=0 rk=2 press=0",
+   "key": "k:0,269",
+   "moved": false,
    "route": "library"
   },
   {
@@ -141,6 +197,34 @@
    "after": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
    "before": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
    "key": "right",
+   "moved": false,
+   "route": "search"
+  },
+  {
+   "after": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "before": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "key": "k:53,34",
+   "moved": false,
+   "route": "search"
+  },
+  {
+   "after": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "before": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "key": "k:0,301",
+   "moved": false,
+   "route": "search"
+  },
+  {
+   "after": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "before": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "key": "k:0,300",
+   "moved": false,
+   "route": "search"
+  },
+  {
+   "after": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "before": "focus route=search zone=Field editing=0 row=0 col=0 recent=0 pill=-1 card=0 below=Results clear=0 press=0",
+   "key": "k:0,269",
    "moved": false,
    "route": "search"
   },

--- a/tools/keytable.py
+++ b/tools/keytable.py
@@ -15,8 +15,23 @@ the evidence the refactor did not change behaviour, and a non-empty one names th
     tools/keytable.py --out tests/keytable.json          # record
     tools/keytable.py --check tests/keytable.json        # re-record and diff against it
 
-Requires `make sim` to have been built. Never touches the television. Each screen gets its own
-instance root, so several of these can run at once (that is the whole point of `SIM_DIR`).
+Requires `make sim` to have been built (honouring `SIM_TDIR` if the lane set one). Never touches
+the television. Each screen gets its own instance root, so several of these can run at once (that
+is the whole point of `SIM_DIR`).
+
+**What it can and cannot see.** A row is the FOCUS fingerprint before and after, so this grades
+where a key moved the user and nothing else. It is blind to the two effects a press has on state no
+screen owns — the player HUD's dismissal and an armed tvOS click — which is why the unsupported-key
+invariant is graded twice: here for "moves nothing on any screen", and in `app.rs`'s
+`unsupported_key_tests` for "touches nothing global". Neither half implies the other.
+
+**A fingerprint carries RATING KEYS, so part of this table is a fact about one library and one
+moment, not about the ladder.** Two rows drift on their own: `home` samples whichever hero the 8 s
+auto-flip has landed on, and any row is keyed to whatever the server's hubs held when it was
+recorded. A re-record on another day, or against another PMS, therefore diffs on `rk=` while every
+structural field (`route`, `hf`, `row`, `col`, `zone`, `card`, `sec`) is identical — read that as
+noise, and read a change in a STRUCTURAL field as the regression. Diffing the two by eye is the
+job; nothing here is asserted by `make check`.
 
 Two triggers are armed in every root:
   * `plxnative-focus`  — the fingerprint itself (`crate::focusprobe`)
@@ -36,11 +51,34 @@ import sys
 import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SIM = os.path.join(REPO, "rust-modules", "target-sim", "debug", "plxnative-sim")
+# `SIM_TDIR` is the Makefile's own knob for where the simulator's build tree lives, and a parallel
+# lane sets it to keep two checkouts off one `target/`. Read it here rather than hardcoding the
+# default, or this harness looks for a binary that lane never wrote — which reads as "run `make
+# sim` first" for a tree where `make sim` has just succeeded.
+SIM = os.path.join(
+    os.environ.get("SIM_TDIR") or os.path.join(REPO, "rust-modules", "target-sim"),
+    "debug",
+    "plxnative-sim",
+)
+if not os.path.isabs(SIM):
+    SIM = os.path.join(REPO, SIM)
 
 # The keys the ladder dispatches on. `okdown`/`okup` are the split halves — the only way to drive a
 # press-and-hold past `press::LONG_MS`, which is a different arm from a tap and has to be recorded
 # as one.
+#
+# **`k:<sym>,<wcode>` presses a RAW pair** (`app.rs`'s `remote_token_key`), which is the only way to
+# reach a key the mnemonic map does not name — and therefore the only way this harness can grade
+# what an UNSUPPORTED key does, which is LG checklist item 40. The four in the middle of the script
+# are there for one question each, and they are placed between `right` and `ok` so that the screen
+# they are asked on is still the one the trigger booted:
+#   k:53,34   the digit `5`, sym '5' + `SDL_SCANCODE_5` — exactly as the television spells it.
+#             Until 2026-08-23 `page_dir` read scancode 34 as the channel rocker, so this PAGED the
+#             Library grid. It must now move nothing, anywhere.
+#   k:0,301   the real CH-down rocker (evdev 403), which must still page the Library…
+#   k:0,300   …and the real CH-up, which pages back, so the script's later rows are unperturbed.
+#   k:0,269   HOME — `SDL_SCANCODE_AC_HOME`, evdev 172. Unbound by decision, not by omission
+#             (`docs/remote-keys.md` §HOME); the row that records it staying inert is the evidence.
 #
 # `back` is NOT here, and the comment that used to explain why said it "is last in every script
 # because at a screen's root it EXITS the app" — which described neither the list (there was no
@@ -49,7 +87,11 @@ SIM = os.path.join(REPO, "rust-modules", "target-sim", "debug", "plxnative-sim")
 # in SCREENS, and the ladder's whole BACK cascade is currently uncharacterised — but it costs a
 # re-record of `tests/keytable.json`, and a script that ends on the alert has to answer it (`back`
 # again, or arm `/tmp/plxnative-noexitconfirm`) before the next screen's run.
-KEYS = ["up", "down", "left", "right", "ok", "play", "pause", "stop"]
+KEYS = [
+    "up", "down", "left", "right",
+    "k:53,34", "k:0,301", "k:0,300", "k:0,269",
+    "ok", "play", "pause", "stop",
+]
 
 # screen name -> (trigger file, trigger content or None)
 SCREENS = {


### PR DESCRIPTION
Unit **B6** of the LG Content Store submission fleet: checklist rows **26** (general/IR remote),
**36** (HOME), **39** (LIVE) and **40** (unsupported keys).

Two code fixes, two device questions answered as far as a desk can answer them, one silently broken
instrument found on the way, and `docs/remote-keys.md` — the map the checklist cites.

---

## 1. A number key was paging the Library grid

`wcode` is a **scancode**. Every constant in this app taken from LG's *web* keyCode namespace is
therefore a different key, and this is the third time it has bitten. `WCODE_CH_UP`/`WCODE_CH_DOWN`
= 33/34 were bound in `page_dir` as the CH▲/CH▼ rocker and **hedged in their own comment** as
"almost certainly NOT" the rocker. They are `SDL_SCANCODE_4` and `SDL_SCANCODE_5`, from evdev 5
`KEY_4` and evdev 6 `KEY_5` — verifiable offline in the television's own evdev→scancode table at
file offset `0x92840` of `libSDL2-2.0.so.0.4.1`, which is otherwise byte-for-byte SDL's standard
`linux_scancode_table`.

Reproduced end to end on the simulator before the fix (`tools/keytable.py`, library screen):

```
    with 33/34 still bound          after
    ----------------------          -----
    k:53,34  rk:2→1924   ← paged!    k:53,34  —          the digit 5, inert
    k:0,301  rk:1924→2153            k:0,301  rk:2→1924  the real rocker, still pages
    k:0,300  rk:2153→1924            k:0,300  rk:1924→2  …and pages back
```

The real rocker (300/301) was already bound beside them, so the two constants are **deleted, not
repointed** — a constant that silently changes value is how a doc predating the change comes to read
as the opposite of what it says.

## 2. The unconsumed-press invariant (#40)

**Not** "make `Key::Other` inert" — that variant legitimately carries the Library pager, Search's
Backspace/Clear and the PIN digits, and declaring it inert would break all three. The real
invariant is about *consumption*:

> A press consumed by neither a route-specific handler nor the global key ladder must produce no
> global side effect.

`begin_fresh_press` runs for **every** fresh press, before the ladder decides whether anything takes
it, and two of the things it does belong to no arm: `hud.note_fresh_press` (un-dismisses the player
HUD) and the armed-click abort. So an unsupported key raised the transport over a film and abandoned
a tvOS press in flight. Both now sit behind a new `consts::is_bound(sym, wcode)`, in a split-out
`note_global_press` — split because `begin_fresh_press` itself calls `hide_cursor`, so a host test
that reaches it fails at `ld` rather than at an assertion.

`held.down_sym`, the D-pad cursor gate and the caller's `last_input` stamp stay unconditional; the
reasons are on the function.

## 3. HOME (#36) and LIVE (#39) — analysis, not a binding

No television in this lane, so this is the analysis plus a recipe, as scoped.

**The app can only ASK for two keys and neither is HOME or LIVE.** LG's fork gates key delivery
behind an access policy the app opts into before `SDL_Init` (`src/main.c` sets
`SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`, which is why BACK arrives at all). The complete set of those
hints, read out of the television's own binary, is **three** — `KEYS_BACK`, `KEYS_EXIT` and
`FORCESTRETCH`. `SDL_webOS.h` in the NDK sysroot declares the same two `KEYS_*` macros and no
others. A key with a request switch is one the platform hands over if asked; a key with none is one
it keeps.

**But the fork CAN produce 269**, which is what makes it worth capturing rather than assuming: evdev
172 `KEY_HOMEPAGE` → 269 `SDL_SCANCODE_AC_HOME`. So "269 never arrives" is a claim about the
compositor and SAM, not about SDL.

**LIVE has no identified code at all** — and `KEY_TV` (evdev 377) maps to **0**, i.e. is not
delivered, which is enough to show that guessing from an evdev name would be wrong.

**Verdict: bind nothing.** Even if 269 arrived it is not obvious the app should act on it — HOME and
LIVE are the set's own navigation. The bar is "does LG's Native SDK or a Seller Lounge QA
requirement say the app is expected to receive them", and nothing consulted says so. Public web-app
Home/Back documentation is QA context for the requirement, never proof about native SDL delivery.

## 4. `docs/remote-keys.md`

Every bound code, the field it is matched in, what it does, and its evdev provenance; the
asymmetries (`WCODE_PAUSE`/`WCODE_PLAY` taken in `wcode` alone while their alternates and
`WCODE_STOP` are taken in either — widening one is a behaviour change, not a tidy-up; and the `alt`
flag on `Left`/`Right`); the `is_bound` invariant; the HOME/LIVE analysis; the capture recipe; and
§9's open findings.

It also records the finding that makes the rest legible: **`wcode` is the SDL scancode, not a
separate webOS keycode namespace.** Every pair ever measured off the dev set has `wcode` equal to
the SDL scancode of the key whose keycode is in `sym` (OK 40, D-pad 80/79/81/82, backspace 42, Clear
156, ◀/▶ 80/79). That is why codes ≥ 300 carry no `sym` — they are LG's private extension of the
scancode space, past SDL's own last entry at 286.

## 5. Found on the way: an instrument that was silent by construction

A synthetic press from the remote FIFO carried its wcode in `SDL_Keysym.unused`. macOS `libSDL2` is
sdl2-compat forwarding into SDL3, which has no counterpart for that field — **so every wcode-only
token was DEAD in the simulator**: `play`, `pause`, `stop`, `ff`, `rew`, `playpause`, `exit`,
`chup`, `chdown` all decoded as wcode `1` and did nothing, and three rows of `tests/keytable.json`
recorded `moved: false` for presses that never arrived.

Measured which fields survive `SDL_PushEvent` by pushing a distinct value into each:

| field | offset | survives |
| --- | --- | --- |
| `windowID` | +8 | yes |
| `padding2`/`padding3` | +14/15 | no |
| `keysym.scancode` | +16 | **no** — returns 0 |
| `keysym.mod` | +24 | yes |
| `keysym.unused` | +28 | **no** — returns 1 |

Carrier moved to `mod`, with a marker in `windowID` so that *injected first, desktop stand-in as
fallback* is preserved. That priority is load-bearing and a review caught me inverting it:
`host_wcode(8)` is BACK while the `backspace` token is `(8, 42)`, so asking the stand-in first turns
the panel's delete key into a navigation. `key_bytes_round_trip` now carries `(8, 42)` and the other
three stand-in syms beside their real scancodes — its only sym-plus-wcode case used to be the single
pair where the two agree.

## 6. Recorded, NOT changed

Each needs a device capture this lane could not take. All four are in `docs/remote-keys.md`.

- **`WCODE_PLAY_ALT_A = 19` is `SDL_SCANCODE_P`** (evdev 25 `KEY_P`), matched in either field. A USB
  keyboard's `p` starts playback; on Search, where printables arrive separately as `SDL_TEXTINPUT`
  and the key event falls through, typing `p` would plausibly leave for the player. Same bug class
  as §1 — but the alternate sets are an invariant in `docs/ui-viewtree-plan.md` §C, and the siblings
  (`402`, `415`, `413`) come from evdev entries `linux/input.h` does not name, so unlike 33/34 there
  is no positive evidence either way. Settle all four in one pass with §7's capture.
- **`SDLK_SELECT` is misnamed**: `77 | 1<<30` is `SDLK_END` (`SDL_SCANCODE_SELECT` is 119; evdev 107
  `KEY_END` is what produces 77). `is_ok` accepts a keyboard's End key and would not accept a real
  SELECT. Left alone: the name is read from `ui/profiles.rs`'s test, and repointing the value would
  make `is_ok` answer a different key on no evidence that any remote sends 119. OK itself is
  unaffected — the remote's OK is `SDL_SCANCODE_RETURN`, captured and bound.
- **`profiles::digit_of` reads the digit range out of `wcode` too**, where 48–57 are `]` `\` `#` `;`
  `'` `` ` `` `,` `.` `/` and CapsLock, not digits (those are scancodes 30–39). Its own test asserts
  `digit_of(0, 55) == Some(b'7')`, and 55 is a full stop. `profiles.rs` is not this unit's file;
  `is_bound` deliberately does **not** mirror it and reads the digit range from `sym` only, so the
  gate does not re-import the mis-reading it exists to stop.
- **Entry-page BACK → Home.** LG's submission UX rules state that *"on webOS 23–25 Back on the entry
  page must show the Home screen"* (`docs/distribution.md` §2). That is `distribute/*` policy, so it
  is presumed to apply to native apps. Today BACK at Home's root raises `ui/exit_alert.rs` instead.
  **Recorded as a known QA blocker pending native-specific evidence; the behaviour is unchanged.**
  Do not "fix" it by deleting the confirmation on the strength of the quotation alone — the alert
  was added deliberately on 2026-08-21 and nothing automated depends on the old behaviour.

## 7. The recipe the integrator needs: capture a remote's real scancodes

**This needs a television and could not be run here.** An IR remote's codes are not derivable from
anything on a desk: the firmware table says what the fork *can* produce from an evdev code, never
which evdev code a physical button emits. The app already logs every key event's raw bytes as
`[<ticks>] key type=0x300 raw=<48 bytes hex>`.

1. Take the TV lock (`tv-lock` skill) and wake it (`wake-tv`).
2. `make FLAVOR=debug deploy && make FLAVOR=debug run RUN_SECS=180`
3. Press **every physical button**, slowly, one at a time, writing each one down — the log gives you
   codes in order and nothing else, so that order is the only label they will ever have.
4. Pull `make -s print-eventlog FLAVOR=debug`; decode each line's `+20` (`wcode`) and `+24` (`sym`)
   as little-endian `u32`.
5. Do it **once per remote**: the Magic Remote (done 2026-08-22, 336 lines) and a **standard IR
   remote** — never done, which is exactly why row 26 is not a formality.

One run settles four things: HOME (does 269 arrive), LIVE (what code, if any), whether 461 and
412/417/413/415/402 ever fire, and the whole of #26. Rehearse the *handling* of anything found
against the simulator first — the new **`k:<sym>,<wcode>`** FIFO token presses an arbitrary pair,
which is the only way to drive a key the mnemonic token map does not name, and therefore the only
way to exercise an unsupported key headlessly at all.

## 8. Golden table

`tests/keytable.json` re-recorded with four new rows per screen (`k:53,34` the digit 5, `k:0,301`
and `k:0,300` the real rocker, `k:0,269` HOME). Diff against the committed table:

- **library and search: purely additive.** Every pre-existing row is byte-identical — the change
  disturbed nothing.
- **home: every pre-existing row differs only in `rk=`** (`2108→2056`, `2032→2029`). Every
  structural field (`route`, `hf`, `row`, `col`, `sec`, …) is identical. That is the hero's 8 s
  auto-flip and live hub content, not the ladder; `tools/keytable.py`'s doc now warns about it
  explicitly so the next re-record is not misread.
- New rows: `k:53,34` and `k:0,269` are **inert on all three screens**; `k:0,301`/`k:0,300` page the
  Library and page back, leaving the script's later rows unperturbed.

`tools/keytable.py` also now honours `SIM_TDIR`, so a fleet lane with its own build tree can run it.

## Verification

- `make check` — **982 pass** (976 on base; +6). Also green under `--features hostsim`.
- `cargo +nightly check --lib --no-default-features` — the `RELEASE=1` feature set type-checks.
- `tools/keytable.py` on all three screens against a real PMS, before and after, plus targeted
  simulator probes for the pager, the rocker and the `backspace`-token regression.
- `code-review` at effort `high`: two findings, both real, both fixed (the inverted `decode_key`
  priority in §5, and `is_bound` reading ASCII out of the scancode field in §6).
- **No television was touched.** Playback, the HUD half of §2, and everything in §6 remain
  unverified on device.

## Doc audit

`doc-claim-auditor` over the diff: **2 findings**, across all 72 tracked `.md` files, the 110 `//!`
module docs and the prose headers of the tools.

**Fixed here** (`08ca8984`): `app.rs` had come to assert both "any key" and "every bound key" about
the same call. `HudState::note_fresh_press` is now reachable only through `note_global_press`, which
returns early for an unbound press — so *"a dismissal is a 'not now' that any key clears"* and
*"any fresh key un-dismisses the HUD"* described exactly the behaviour §2 removed. Read as written
they say the new gate is a bug, and they sit where somebody debugging "why didn't that button raise
the transport" would land. Its doc also still named `begin_fresh_press` as its caller.

**For the integrator to apply** — `docs/lg-self-checklist.md:67` is not this unit's file, and its
row 40 is now false in all three clauses:

> `| 40 | Unsupported keys | Key::Other swallows them so it is *probably* safe, but unproven. |`

The mechanism is **inverted**, not merely understated: `Key::Other` is not the guard and never was,
and a reader acting on that row reaches for "make `Key::Other` inert" — the exact change this PR's
tests exist to refuse. Suggested replacement:

> `| 40 | Unsupported keys | `consts::is_bound` gates the two GLOBAL effects of a fresh press (HUD
> un-dismiss, armed-click abort); `app.rs::unsupported_key_tests` and `keytable.py`'s `k:0,269` row
> grade it. `Key::Other` is NOT the guard — the pager, the panel's edit keys and the PIN digits all
> classify as `Other` and are bound. Device half (a real colour/GUIDE press) still unobserved. |`

Rows 26/36/39 now have `docs/remote-keys.md` under them and could cite it.

**Two stale claims the audit found that this PR did not cause**, passed on rather than fixed:

- Root `CLAUDE.md:441` still lists **"D-pad L/R alt 412/417"** among the Magic-Remote wcodes. Those
  were retired one commit *before* this branch (2026-08-22) and `consts.rs` now says "That was never
  true and those codes have never fired". Same web-keyCode namespace defect as §1 — inverted, in the
  root file.
- `docs/parity-gaps.md` names `WCODE_CH_UP`/`WCODE_CH_DOWN` at `:811`, `:1318`, `:1319`, `:1592`.
  All four sit inside dated `*Verified:*` blocks that the file's own header pins to 2026-07-29, and
  all four were already stale before this commit — dated-record shape, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GovTtrsD9P7Ld7DnLCMK2G
