### PR TITLE
ui: the overscan frame becomes a bound, and six screens were outside it

### DIFF
--- a/docs/lg-self-checklist.md
+++ b/docs/lg-self-checklist.md
@@ -76,9 +76,9 @@ Not failures — *unknowns*, and unmarkable. Every one of these is a device sess
 
 | # | Item | Basis |
 | --- | --- | --- |
-| 1, 2 | Execution, main screen | Launches and reaches Home; UI authored at 1920×1080 with `MARGIN_X` 90 (4.7%), inside the 5% overscan frame. Splash is 1920×1080 PNG. |
+| 1, 2 | Execution, main screen | Launches and reaches Home; UI authored at 1920×1080 inside a 5% overscan frame (`consts::MARGIN_X` 96 / `MARGIN_Y` 54), asserted per screen by `no_required_content_enters_the_safe_area_exclusion_zone`. Splash is 1920×1080 PNG. **This row claimed a pass on the wrong arithmetic until 2026-08-23** — see §4. |
 | 6 | Correct text | `text::elide` for overflow, `ui/text_view.rs` for long-form scroll. **Was failing until 2026-08-22** — see §4. |
-| 7 | Focus / mouse-over | Idle, focused and pressed states are distinct (focus scale spring, glow, `ui/press.rs`). |
+| 7 | Focus / mouse-over | Idle, focused and **selected** states are distinct, and as of 2026-08-23 that is an OBSERVATION rather than a belief: audited screen by screen in the simulator at 1920×1080. The tab strip carries all three at once (idle = bare label, focused = bright white capsule, selected = subtle plated capsule); a `TableView` row does the same (idle plain, selected ✓, focused white pill); a card separates idle from focused by scale, drop shadow and the caption band that only the focused tile draws. Nothing needed changing. |
 | 8 | Flickering | No known flicker; the Dolby Vision Profile 5 pulse is fixed (`docs/dolby-vision.md` §4). |
 | 9 | Full-size video | Video track and video plane are both full-panel 1920×1080; no margins. |
 | 21 | Sign out | `ui/account_menu.rs` → `auth::sign_out`. |
@@ -117,6 +117,45 @@ which also makes the splash match the first frame the app draws.
 **Not a numbered item, but it was wrong:** `requiredMemory` was 60 against a measured 152 MiB peak,
 and webOS substitutes a default of **120** when the field is absent — so 60 asked for less headroom
 than declaring nothing. Now 160. `docs/distribution.md` §6.10 has the measurements.
+
+---
+
+## 4b. #2's OTHER half, and how it read as a pass for a year (2026-08-23)
+
+**The overscan row of §3 was marked Pass on arithmetic that says the opposite of what it claims.**
+It read *"`MARGIN_X` 90 (4.7%), inside the 5% overscan frame"* — but a 4.7% margin puts content
+NEARER the edge than a 5% one, i.e. six pixels inside the exclusion zone, on every screen at once.
+The sentence is the whole failure: nobody had ever measured a screen, so a number that sounded
+reassuring stood in for a measurement, exactly as the splash's "63% black" did until somebody looked.
+
+**And the vertical bound did not exist at all.** There was no `MARGIN_Y` anywhere in the tree, so
+nothing bounded the top or bottom of anything, and four places were outside the frame by more than
+the horizontal margin ever was: the shared top tab bar and profile chip (18px), the detail page's
+pinned compact title (14px, and 32 for a square clearLogo, which spills upward as paint), the
+Library's A–Z rail (**32px**, the worst in the app), and the Home / Library / Person scroll reveals,
+which settled a focused card's caption 24 / 16 / 40px off the bottom edge.
+
+Both margins are now `ui/consts.rs` tokens (96 / 54) and — the half that matters — the requirement
+is a host test rather than a literal:
+`no_required_content_enters_the_safe_area_exclusion_zone` grades the COMPOSED rect of every screen
+and panel against `consts::SAFE`, so a future audit can move a token, or give one screen a
+correction of its own, without the test having to be rewritten to permit it. "Required" is doing
+work in that sentence: a full-bleed backdrop, a page ground, a scrim, a focus glow and a shelf
+peeking off the bottom edge are all *supposed* to reach the panel edge.
+
+**One design cost, recorded because it is a trade rather than a fix.** Dropping the top bar 18px
+grows the tab band's backdrop-blur region by the same 18 rows of a ~1470px-wide grab, which is
+enough to put `widgets::GLASS_TRACK_MAX` outside `gfx::GLASS_REGION_BUDGET`. That constant is now
+the `min` of its two constraints instead of the "must not touch" rule alone, so the glass material
+comes off a strip wider than ~656px rather than ~848. The product's own strip is 572px, so today's
+bar is unaffected and a library with one more section still keeps it; two more would drop to the
+flat capsule, which is a designed, shipped alternative rather than a break. If that is judged too
+tight, the lever is the measured budget (`docs/glass-hardware-budget.md` §11, which already records
+the region term as ~4x conservative on the direct source path), not the frame.
+
+**LG publishes two numbers and they disagree.** The developer guide's overscan page states a **20px**
+margin; the checklist item says "overscan frame", which by broadcast convention is **5%**. This app
+is graded against 5%, because a layout that satisfies 5% satisfies 20px and not the other way round.
 
 ---
 

--- a/rust-modules/src/ui/account_menu.rs
+++ b/rust-modules/src/ui/account_menu.rs
@@ -167,12 +167,25 @@ fn action_at(rows: &[Action], sel: i32) -> Action {
 }
 
 /// Top-left popover, tucked under the profile chip.
+///
+/// `px` is the app's own side margin: it was a literal 80, which sat 16px outside the 5% overscan
+/// frame — and the chip it hangs off is at `MARGIN_X`, so aligning the two is what the design meant
+/// anyway. `py` clears `widgets::TOP_BAR_BOTTOM` (130) by a `space::MD`.
 fn panel_rect() -> Rect {
     let pw = 440.0f32;
-    let px = 80.0f32;
-    let py = 150.0f32;
+    let px = crate::ui::consts::MARGIN_X;
+    let py = 154.0f32;
     let ph = table().measured_height().clamp(120.0, 440.0);
     Rect::new(px, py, pw, ph)
+}
+
+/// The panel at its TALLEST, for the overscan audit ([`crate::ui::consts::SAFE`]) — the clamp
+/// ceiling rather than this session's measured height, since the audit grades the widest state a
+/// surface can be in and the height comes from a `TableView` no host test can measure.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, crate::ui::Rect)>) {
+    let r = panel_rect();
+    out.push(("account menu panel", crate::ui::Rect::new(r.x, r.y, r.w, 440.0)));
 }
 
 pub fn update(dt: f32) {

--- a/rust-modules/src/ui/alt_sources.rs
+++ b/rust-modules/src/ui/alt_sources.rs
@@ -129,7 +129,11 @@ const PANEL_RAD: f32 = 20.0;
 /// Air between the button that opened the panel and the panel itself — one `space` rung.
 const BTN_GAP: f32 = theme::space::MD;
 /// Keep-out from the screen edges, so a panel opened low on the page is still whole.
+///
+/// Per AXIS, for `item_menu::EDGE`'s reason: `space::XL` 64 clears `MARGIN_Y` vertically and misses
+/// `MARGIN_X` horizontally by 32px.
 const EDGE: f32 = theme::space::XL;
+const EDGE_X: f32 = crate::ui::consts::MARGIN_X;
 /// Scrim peak alpha — the LIBRARY toolbar chip menu's (`ui::library`), deliberately, because this
 /// is the same object one page over: a chip-shaped control on a live page opening a list over it.
 /// The page recedes; it is not blanked, and the hero behind stays readable.
@@ -485,7 +489,7 @@ fn panel_at(a: Rect, content_h: f32) -> Rect {
     let h = content_h.clamp(120.0, SCR_H - 2.0 * EDGE);
     let below = a.y + a.h + BTN_GAP;
     let y = if below + h <= SCR_H - EDGE { below } else { (a.y - BTN_GAP - h).max(EDGE) };
-    let x = a.x.clamp(EDGE, (SCR_W - EDGE - PANEL_W).max(EDGE));
+    let x = a.x.clamp(EDGE_X, (SCR_W - EDGE_X - PANEL_W).max(EDGE_X));
     Rect::new(x, y, PANEL_W, h)
 }
 
@@ -918,14 +922,14 @@ mod tests {
     /// The panel hangs off the control that opened it, and is never over it or off the screen.
     #[test]
     fn the_panel_hangs_off_its_button_and_stays_on_screen() {
-        let btn = Rect::new(90.0, 300.0, 300.0, 60.0);
+        let btn = Rect::new(crate::ui::consts::MARGIN_X, 300.0, 300.0, 60.0);
         let r = panel_at(btn, 224.0);
         assert_eq!(r.w, PANEL_W);
         assert_eq!(r.y, btn.y + btn.h + BTN_GAP, "under the button when there is room");
         assert_eq!(r.x, btn.x, "and aligned to its left edge");
 
         // a button low on the page flips the panel ABOVE it rather than off the bottom
-        let low = Rect::new(90.0, 900.0, 300.0, 60.0);
+        let low = Rect::new(crate::ui::consts::MARGIN_X, 900.0, 300.0, 60.0);
         let r = panel_at(low, 224.0);
         assert!(r.y + r.h <= low.y - BTN_GAP + 0.01, "flipped above the button");
         assert!(r.y >= EDGE);
@@ -933,9 +937,17 @@ mod tests {
         // a button near the right edge pulls the panel back inside the keep-out
         let right = Rect::new(SCR_W - 200.0, 300.0, 180.0, 60.0);
         let r = panel_at(right, 224.0);
-        assert!(r.x + r.w <= SCR_W - EDGE + 0.01, "a panel must not run off the panel");
+        assert!(r.x + r.w <= SCR_W - EDGE_X + 0.01, "a panel must not run off the panel");
         // …and a list taller than the screen is clamped rather than drawn past both edges
         let tall = panel_at(btn, 4000.0);
         assert!(tall.y >= EDGE && tall.y + tall.h <= SCR_H - EDGE + 0.01);
+
+        // Every one of those worst cases is inside the overscan frame — the keep-out is per AXIS
+        // precisely so that the horizontal clamp is `MARGIN_X` and not the `space::XL` the vertical
+        // one uses. `ui::consts::SAFE` is the frame; this is that predicate on this panel's own
+        // extremes, since a panel placed against an ANCHOR has no fixed rect a table could carry.
+        for (what, p) in [("under", r), ("tall", tall), ("right-edge", panel_at(right, 224.0))] {
+            assert!(crate::ui::consts::inside_safe(p), "the {what} panel leaves the safe area: ({}, {}) {}x{}", p.x, p.y, p.w, p.h);
+        }
     }
 }

--- a/rust-modules/src/ui/consts.rs
+++ b/rust-modules/src/ui/consts.rs
@@ -12,7 +12,33 @@ use std::os::raw::{c_int, c_uint};
 pub const CARD_W: f32 = 250.0;
 pub const CARD_H: f32 = 375.0;
 pub const GAP: f32 = 30.0;
-pub const MARGIN_X: f32 = 90.0;
+/// **The safe area's LEFT/RIGHT keep-out — 5% of [`SCR_W`], and the reason it is 96 rather than 90.**
+///
+/// A television overscans: the panel shows less than the frame it is handed, by a margin the set
+/// decides and the app cannot query. LG's App Self Checklist item #2 asks that *"buttons, texts and
+/// logos on the main page are placed within the overscan frame"*, and the broadcast convention that
+/// phrase names is **5% of each edge** — 96px horizontally and [`MARGIN_Y`] 54px vertically on this
+/// 1920×1080 canvas. (LG's current *developer* guide states a laxer 20px; the 5% frame is the
+/// stricter of the two published numbers and is the one this app is graded against, because a
+/// margin that satisfies 5% satisfies 20px and not the other way round.)
+///
+/// It was **90** until 2026-08-23 — 4.7%, i.e. six pixels INSIDE the exclusion zone, on every screen
+/// in the app at once. `docs/lg-self-checklist.md` recorded that as passing, reading "4.7% against a
+/// 5% frame" as clearance when it is the opposite: a smaller margin puts content NEARER the edge.
+/// Nothing had ever measured it, which is why
+/// `tests::no_required_content_enters_the_safe_area_exclusion_zone` now does — it grades the
+/// composed rects, not this literal, so a future audit is free to move this number again without
+/// rewriting the test.
+pub const MARGIN_X: f32 = 96.0;
+/// **The safe area's TOP/BOTTOM keep-out — 5% of [`SCR_H`].** [`MARGIN_X`]'s missing twin: until
+/// 2026-08-23 the vertical bound was simply unstated, so nothing in the tree bounded it and nothing
+/// could check it. It bit in four places — the shared top bar sat at y=44, the detail page's pinned
+/// compact title at 40 (its tallest logo reaching 22), and the Home/Library/Person scroll reveals
+/// left 24/16/40px under a focused card.
+///
+/// Smaller than [`MARGIN_X`] because it is 5% of the SHORTER axis; the frame is a percentage of each
+/// dimension, not one distance.
+pub const MARGIN_Y: f32 = 54.0;
 pub const ROW_TITLE_H: f32 = 30.0;
 pub const ROW_PITCH: f32 = CARD_H + ROW_TITLE_H + 144.0; // 549: room for the shelf title above + the focused card's title AND caption below (clears the next shelf's title)
 /// Hub-title cap top above the shelf's `row_y` origin — the heading draws at `row_y − TITLE_DY`,
@@ -28,6 +54,30 @@ pub const CONTENT_Y: f32 = 200.0;
 pub const GLOW_PAD: f32 = 48.0;
 pub(crate) use crate::surface::{LOGICAL_H as SCR_H, LOGICAL_W as SCR_W};
 
+/// **The safe area itself** — the box every piece of REQUIRED content has to fit inside, as one
+/// value so no caller re-derives it from the two margins and gets a sign wrong.
+///
+/// "Required" is the whole content of the rule and the reason this is a predicate rather than a
+/// clip: a full-bleed hero backdrop, a shelf peeking off the bottom edge, a scrim, the page ground —
+/// all of those are *supposed* to reach the panel edge, and clipping them would be the bug. What
+/// must be inside is what the viewer has to read or press: text, controls, marks, logos.
+pub const SAFE: crate::ui::Rect =
+    crate::ui::Rect::new(MARGIN_X, MARGIN_Y, SCR_W - 2.0 * MARGIN_X, SCR_H - 2.0 * MARGIN_Y);
+
+/// Is `r` wholly inside [`SAFE`]? The one test the audit's table asks, per rect.
+///
+/// A hair of tolerance (`EPS`) because several of the rects handed here are the result of an f32
+/// derivation that lands on the boundary exactly — `SCR_W - MARGIN_X - w` then `+ w` is not bit-for-
+/// bit `SCR_W - MARGIN_X` — and a control flush against the frame is compliant, not a violation.
+#[inline]
+pub fn inside_safe(r: crate::ui::Rect) -> bool {
+    const EPS: f32 = 0.01;
+    r.x >= SAFE.x - EPS
+        && r.y >= SAFE.y - EPS
+        && r.x + r.w <= SAFE.x + SAFE.w + EPS
+        && r.y + r.h <= SAFE.y + SAFE.h + EPS
+}
+
 // hero <-> grid continuum
 /// Shelf top in hero view. Re-derived once the peek row stopped magnifying its focused cell: the
 /// peek used to be judged off that popped tile, whose 1.09 scale about its centre lifted its top
@@ -36,8 +86,11 @@ pub(crate) use crate::surface::{LOGICAL_H as SCR_H, LOGICAL_W as SCR_W};
 /// hero view was tuned to (828 → 811; card top = `PEEK_Y + CARD_DY` = 837, as the popped one was).
 pub const PEEK_Y: f32 = 811.0;
 // shelf top in grid view — leaves the first hub title (row_y − TITLE_DY, lifted up to ~10 more when its
-// leftmost card magnifies) a clear space::MD under the profile chip (bottom edge 108)
-pub const GRID_TOP_Y: f32 = 176.0;
+// leftmost card magnifies) a clear space::MD under the profile chip (bottom edge 126).
+// 176 until 2026-08-23: it moved with the top bar, which dropped 18px so its track clears MARGIN_Y
+// (`widgets::TOP_BAR_Y`). The clearance under the chip is what this number IS, so it follows the bar
+// rather than staying put and letting the heading crowd it.
+pub const GRID_TOP_Y: f32 = 194.0;
 
 // SDL keycodes (scancode | SDLK_SCANCODE_MASK, or ASCII)
 pub const SDLK_RIGHT: c_uint = 79 | (1 << 30);
@@ -280,6 +333,113 @@ pub const K_SNAP: f32 = 200.0;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::Rect;
+
+    /// **The frame itself.** 5% of each axis at the authored canvas, and the two margins are not the
+    /// same number — the frame is a percentage of each DIMENSION, not one distance, which is the
+    /// mistake a single `MARGIN` would bake in.
+    #[test]
+    fn the_safe_area_is_five_percent_of_each_axis() {
+        assert_eq!(MARGIN_X, SCR_W * 0.05);
+        assert_eq!(MARGIN_Y, SCR_H * 0.05);
+        assert_eq!((SAFE.x, SAFE.y, SAFE.w, SAFE.h), (96.0, 54.0, 1728.0, 972.0));
+        assert!(inside_safe(SAFE), "the frame contains itself");
+        assert!(!inside_safe(Rect::new(SAFE.x - 1.0, SAFE.y, 10.0, 10.0)), "one px left of it does not");
+        assert!(!inside_safe(Rect::new(SAFE.x, SAFE.y - 1.0, 10.0, 10.0)), "nor one px above");
+        assert!(!inside_safe(Rect::FULL), "nor the whole panel");
+    }
+
+    /// **NO REQUIRED CONTENT ENTERS THE OVERSCAN EXCLUSION ZONE, ON EITHER AXIS.**
+    ///
+    /// LG's App Self Checklist item #2 asks that the buttons, texts and logos on the main page sit
+    /// inside the overscan frame; this is that sentence, executable, over the outermost rect of
+    /// every screen and panel in the app.
+    ///
+    /// **It grades the composed geometry, never the tokens.** There is deliberately no
+    /// `assert_eq!(MARGIN_X, 96.0)` here: that passes today and forbids the next audit from moving
+    /// the margin, or from giving one screen a correction of its own, which is the fix such an audit
+    /// most often needs. What is asserted is the requirement — so a future change that moves a token
+    /// AND keeps every screen inside the frame passes without this test being rewritten to permit
+    /// it, and one that moves a screen's own y by hand fails without anyone remembering to come
+    /// here. Six of the rows below were OUTSIDE the frame when this was written; the ones that were
+    /// worst — the A–Z rail at 32px, the detail page's pinned logo at 32, the top bar at 18 — were
+    /// all in geometry no token could have described.
+    ///
+    /// **"Required" is doing real work in that sentence.** A full-bleed hero backdrop, a page
+    /// ground, a scrim, a shelf peeking off the bottom edge and the focus GLOW that overflows a
+    /// poster are all supposed to reach the panel edge; bounding them would be the bug. What is
+    /// graded is what a viewer has to read or press.
+    ///
+    /// **So tiles are entered at REST, and that is a decision rather than an oversight.** A focused
+    /// card is drawn `RowStyle::HOME`'s 1.09 about its own centre, which puts the first column's
+    /// painted edge ~11px past the margin, and `GLOW_PAD` spills 48 further. Neither is new content:
+    /// the pop MAGNIFIES ink already inside the frame, strictly containing its resting rect
+    /// (`widgets`' own note on the control pop), and the caption under it — the TEXT — does not
+    /// scale at all. The line this draws is between decoration that overflows and *the thing
+    /// itself*: the detail page's pinned compact logo IS graded at its upward spill, because there
+    /// the spill is the logo, and a clearLogo is one of the three things item #2 names.
+    ///
+    /// **What it cannot see**, so that a green run is not read as more than it is: text is graded by
+    /// the box a screen lays it out in, not by rasterized ink (the host suite cannot link
+    /// SDL2_ttf — the boundary `StatusOverlay::bands` documents), so a run that overflows its own
+    /// column is `text::elide`'s business and not this test's. Rects whose width is a measured
+    /// label are entered degenerate, with the EDGE that matters and a zero extent the other way.
+    #[test]
+    fn no_required_content_enters_the_safe_area_exclusion_zone() {
+        let mut r: Vec<(&'static str, Rect)> = Vec::new();
+
+        // **A probe that quietly stops contributing is a screen that quietly stops being audited**,
+        // and an `assert!` loop over an empty table passes. So each one is required to contribute,
+        // individually: a table-wide floor cannot see one probe of eight going silent, which is what
+        // a `r.len() >= N` guard was actually doing here.
+        let mut probe = |name: &str, f: &dyn Fn(&mut Vec<(&'static str, Rect)>)| {
+            let before = r.len();
+            f(&mut r);
+            assert!(r.len() > before, "the {name} probe contributed nothing — it stopped being audited");
+        };
+
+        // ---- the shared chrome, and the screens composed on it ------------------------------
+        probe("widgets", &crate::ui::widgets::overscan_rects);
+        probe("library", &crate::ui::library::overscan_rects);
+        probe("detail", &crate::ui::detail::overscan_rects);
+        probe("player_hud", &crate::ui::player_hud::overscan_rects);
+
+        // ---- the panels, each at the widest/tallest state its own clamp admits ---------------
+        probe("account_menu", &crate::ui::account_menu::overscan_rects);
+        probe("track_menu", &crate::ui::track_menu::overscan_rects);
+        probe("more_menu", &crate::ui::more_menu::overscan_rects);
+        probe("stats", &crate::ui::stats::overscan_rects);
+        drop(probe);
+
+        // ---- the screens whose outermost geometry is already public here --------------------
+        // Home: the hero's text column and its action row start at the margin; the grid view's
+        // first shelf heading is the highest ink the page draws under the bar.
+        r.push(("home hero text column", Rect::new(MARGIN_X, 380.0, crate::ui::home::HERO_COL_W, 400.0)));
+        r.push(("home first shelf heading (grid view)", Rect::new(MARGIN_X, GRID_TOP_Y - TITLE_DY, 400.0, TITLE_DY)));
+        r.push(("home first shelf card (grid view)", Rect::new(MARGIN_X, GRID_TOP_Y + CARD_DY, CARD_W, CARD_H)));
+        // …and the focused card's block at the BOTTOM of its reveal: card + the 96px label band,
+        // which is what `home::update`'s and `library`'s reveal rules keep clear of the edge.
+        r.push(("home focused card block, revealed", Rect::new(MARGIN_X, SCR_H - MARGIN_Y - CARD_H - 96.0, CARD_W, CARD_H + 96.0)));
+
+        // Search: the query capsule, and the scope line beside it.
+        r.push(("search field", crate::ui::search::FIELD));
+        r.push(("search first shelf heading", Rect::new(MARGIN_X, crate::ui::search::CONTENT_TOP, 400.0, 40.0)));
+
+        // Person: the portrait at the margin, and the air the reveal keeps under a shelf.
+        r.push(("person portrait", Rect::new(MARGIN_X, 96.0, 320.0, 320.0)));
+        r.push(("person shelf block, revealed", Rect::new(MARGIN_X, SCR_H - MARGIN_Y - CARD_H, CARD_W, CARD_H)));
+
+        // Onboarding + login: both centre or hang off the same margin.
+        r.push(("onboard copy column", Rect::new(MARGIN_X, 150.0, crate::ui::home::HERO_COL_W, 500.0)));
+
+        for (name, rect) in r {
+            assert!(
+                inside_safe(rect),
+                "{name} at ({}, {}) {}x{} leaves the {}x{} safe area at ({}, {})",
+                rect.x, rect.y, rect.w, rect.h, SAFE.w, SAFE.h, SAFE.x, SAFE.y,
+            );
+        }
+    }
 
     /// The Library pager's key set, which used to be spelled twice in `app.rs` in two shapes.
     #[test]

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -358,18 +358,30 @@ const FACTS_SEP_PAD: f32 = theme::space::SM;
 // per-section Y to keep in sync. A block's height is content-derived (e.g. the Related block tracks
 // REL_H → the shared home poster size), so resizing one block reflows everything below it. The
 // container's scroll lifts the focused block's top to TOP_MARGIN under the compact title.
-const TOP_MARGIN: f32 = 120.0;
-/// The pinned compact title's top edge — the literal the old top-anchored logo draw used, now named.
-const COMPACT_TITLE_TOP: f32 = 40.0;
-/// …and its anchor line: the compact logo's BOTTOM EDGE and the text fallback's BASELINE both sit
-/// here. [`TOP_MARGIN`] (120) is where the first scrolled section lifts to, so this leaves 26px of
-/// air under it — and `theme::logo::COMPACT_H_MAX` (72) is set by exactly that clearance rather than
-/// by the area rule.
-const COMPACT_TITLE_BOT: f32 = COMPACT_TITLE_TOP + theme::logo::COMPACT_H_MIN; // 94
+const TOP_MARGIN: f32 = COMPACT_TITLE_BOT + COMPACT_TITLE_AIR; // 152
+/// The pinned compact title's ANCHOR LINE: the compact logo's BOTTOM EDGE and the text fallback's
+/// BASELINE both sit here.
+///
+/// **Solved from the overscan frame, and it is the TALLEST logo that sets it.** The band a caller
+/// reserves is `COMPACT_H_MIN` (54), but a squarer mark spills UPWARD as paint to
+/// `COMPACT_H_MAX` (72) — so the line that has to clear `consts::MARGIN_Y` is `BOT − 72`, not
+/// `BOT − 54`. This was a literal top edge of **40** until 2026-08-23, which put a wordmark 14px and
+/// a square emblem 32px inside the top exclusion zone, on the one screen where a LOGO is the
+/// content LG's checklist item #2 names by name.
+const COMPACT_TITLE_BOT: f32 = crate::ui::consts::MARGIN_Y + theme::logo::COMPACT_H_MAX; // 126
+/// The pinned title's top edge — the reserved BAND's top, which is where a wordmark actually draws.
+/// It has no reader (the draw derives its own y from [`COMPACT_TITLE_BOT`] and the band `hero_logo`
+/// hands back) and is kept as the other end of the strip's stated extent; the module's
+/// `allow(dead_code)` is why nothing warns.
+#[allow(dead_code)]
+const COMPACT_TITLE_TOP: f32 = COMPACT_TITLE_BOT - theme::logo::COMPACT_H_MIN; // 72
+/// Air between the pinned title and the first scrolled section under it. Unchanged at 26; it is
+/// [`TOP_MARGIN`] that follows the title now rather than the title being fitted into a fixed 120.
+const COMPACT_TITLE_AIR: f32 = 26.0;
 const CONTENT_TOP: f32 = 920.0; // nominal flow top; update() re-derives it from the hero buttons
 const SECTION_GAP: f32 = theme::space::XL; // vertical padding between top-level blocks (64)
 const TAB_EP_GAP: f32 = theme::space::MD; // season tabs → their episode row (they read as one unit)
-const SCROLLED: f32 = CONTENT_TOP - TOP_MARGIN; // backdrop-dim saturation reference (= 800)
+const SCROLLED: f32 = CONTENT_TOP - TOP_MARGIN; // backdrop-dim saturation reference (= 768; it was 800 while `TOP_MARGIN` was 120)
 const BTN_CONTENT_GAP: f32 = theme::space::XL; // hero button row → first below-hero block (64)
 const HERO_FADE: f32 = 400.0; // px of scroll over which the hero fades out (draw + pointer share it)
 const HERO_HIT_MIN_A: f32 = 0.5; // a hero control must be at least this opaque to be CLICKABLE
@@ -3185,6 +3197,23 @@ fn compact_title_vis(scroll: f32) -> f32 {
         })
         .unwrap_or(f32::MAX);
     ((hide_at - scroll) / 300.0).clamp(0.0, 1.0)
+}
+
+/// **This page's outermost drawn chrome, for the overscan audit** ([`crate::ui::consts::SAFE`]).
+///
+/// The pinned compact title is graded at `COMPACT_H_MAX`, not at the band it RESERVES: a logo
+/// taller than its band spills upward as paint (`hero_logo`'s constant-area rule), so the band alone
+/// would grade a rect nothing draws and miss the case that was 32px outside the frame.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    let tall = theme::logo::COMPACT_H_MAX;
+    out.push((
+        "detail pinned compact title (tallest logo)",
+        Rect::new(MARGIN_X, COMPACT_TITLE_BOT - tall, SCR_W - 2.0 * MARGIN_X, tall),
+    ));
+    out.push(("detail hero text column", Rect::new(MARGIN_X, TITLE_BOTTOM - 200.0, HERO_TEXT_W, 200.0)));
+    out.push(("detail people column (right edge)", Rect::new(SCR_W - MARGIN_X - PEOPLE_W, 700.0, PEOPLE_W, 100.0)));
+    out.push(("detail below-hero flow, at rest", Rect::new(MARGIN_X, TOP_MARGIN, SCR_W - 2.0 * MARGIN_X, 100.0)));
 }
 
 /// small centered clearLogo/title shown at the top once the page is scrolled. The band spans the

--- a/rust-modules/src/ui/home.rs
+++ b/rust-modules/src/ui/home.rs
@@ -1259,7 +1259,9 @@ impl View for Grid {
         // move the page when the focused row's block — title band above, card + focused label
         // below — would clip the viewport; a fully visible row never re-seats the page.
         let top = env.fr as f32 * ROW_PITCH;
-        let lo = top + GRID_TOP_Y + CARD_DY + CARD_H + 96.0 - (SCR_H - 24.0); // card + title/caption metadata visible
+        // card + title/caption metadata visible, and a MARGIN_Y clear of the bottom edge — it was a
+        // bare 24, which settled a focused tile's caption inside the overscan frame
+        let lo = top + GRID_TOP_Y + CARD_DY + CARD_H + 96.0 - (SCR_H - MARGIN_Y);
         let hi = top + GRID_TOP_Y - 66.0 - 96.0; // hub title band clear below the chip row
         self.scroll_y.step(card_row::reveal(self.scroll_y.pos, lo, hi, max_y), K_SCROLL, env.dt);
     }

--- a/rust-modules/src/ui/item_menu.rs
+++ b/rust-modules/src/ui/item_menu.rs
@@ -99,7 +99,12 @@ const PANEL_RAD: f32 = 20.0;
 /// Air between the focused card's drawn edge and the panel — one `space` rung, like every other gap.
 const CARD_GAP: f32 = theme::space::MD;
 /// Keep-out from the screen edges, so a shelf near the bottom still gets a fully-visible panel.
+///
+/// Per AXIS, because the overscan frame is: `space::XL` 64 already cleared `MARGIN_Y` 54 vertically,
+/// but the horizontal clamp is what a panel opened over the LAST column lands on, and 64 is 32px
+/// outside `MARGIN_X`.
 const EDGE: f32 = theme::space::XL;
+const EDGE_X: f32 = crate::ui::consts::MARGIN_X;
 /// Scrim peak alpha. Deliberately LIGHTER than the in-player panels' 0.58: the design's whole point
 /// is that the card and the shelf stay legible behind the popover, so this recesses them rather than
 /// blanking them.
@@ -471,8 +476,8 @@ pub(crate) fn click(mx: f32, my: f32) -> Action {
 fn panel_at(a: Rect, content_h: f32) -> Rect {
     let h = content_h.clamp(120.0, SCR_H - 2.0 * EDGE); // same floor the profile popover uses
     let right = a.x + a.w + CARD_GAP;
-    let x = if right + PANEL_W <= SCR_W - EDGE { right } else { a.x - CARD_GAP - PANEL_W };
-    let x = x.clamp(EDGE, (SCR_W - EDGE - PANEL_W).max(EDGE));
+    let x = if right + PANEL_W <= SCR_W - EDGE_X { right } else { a.x - CARD_GAP - PANEL_W };
+    let x = x.clamp(EDGE_X, (SCR_W - EDGE_X - PANEL_W).max(EDGE_X));
     let y = a.y.clamp(EDGE, (SCR_H - EDGE - h).max(EDGE));
     Rect::new(x, y, PANEL_W, h)
 }
@@ -923,8 +928,16 @@ mod tests {
         assert!(r.x + r.w <= a.x, "flipped panel overlaps its card: x={} w={} card.x={}", r.x, r.w, a.x);
         assert!(r.x >= EDGE - 0.5);
         // a card near the bottom keeps the whole panel on screen
-        let r = panel_at(Rect::new(MARGIN_X, SCR_H - 120.0, CARD_W, CARD_H), h);
-        assert!(r.y + r.h <= SCR_H - EDGE + 0.5, "panel ran off the bottom: y={} h={}", r.y, r.h);
-        assert!(r.y >= EDGE - 0.5);
+        let low = panel_at(Rect::new(MARGIN_X, SCR_H - 120.0, CARD_W, CARD_H), h);
+        assert!(low.y + low.h <= SCR_H - EDGE + 0.5, "panel ran off the bottom: y={} h={}", low.y, low.h);
+        assert!(low.y >= EDGE - 0.5);
+
+        // …and "on screen" means inside the OVERSCAN frame, which is why the keep-out is per axis:
+        // `space::XL` 64 clears `MARGIN_Y` and misses `MARGIN_X` by 32. A panel placed against an
+        // anchor has no fixed rect a table could carry, so the frame is graded on its extremes here.
+        let tall = panel_at(Rect::new(MARGIN_X, 300.0, CARD_W, CARD_H), 4000.0);
+        for (what, p) in [("flipped", r), ("low", low), ("tall", tall)] {
+            assert!(crate::ui::consts::inside_safe(p), "the {what} panel leaves the safe area: ({}, {}) {}x{}", p.x, p.y, p.w, p.h);
+        }
     }
 }

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -41,11 +41,30 @@ use std::ptr::{addr_of, addr_of_mut};
 
 // ---- geometry -------------------------------------------------------------------------------
 const COLS: usize = 6;
-/// 6×250 + 5×LGAP fills the 1740px between the margins exactly.
-const LGAP: f32 = (SCR_W - 2.0 * MARGIN_X - COLS as f32 * CARD_W) / (COLS as f32 - 1.0);
-const TOOL_Y: f32 = 134.0;
+/// **The A–Z rail's own band, reserved on the grid's right whether or not the rail is drawn.**
+///
+/// The rail used to hang in the OUTER margin, at `SCR_W - 64` — 32px past the 5% overscan frame, the
+/// worst horizontal violation in the app, and unfixable by moving the rail alone: with the grid
+/// filling `SCR_W - 2*MARGIN_X` exactly there is no room inside the frame for a 44px control to its
+/// right. So the grid gives the band up instead.
+///
+/// **Reserved unconditionally**, which costs 48px on a section whose letters the server never sent.
+/// The alternative — widening the grid when [`rail_drawn`] is false — moves every column between two
+/// sections of one library, and a grid that reflows as you change tab is a worse answer than a
+/// slightly narrower one that never does. It is the same argument [`draw_rail`] makes for
+/// top-anchoring the rail rather than centring it.
+const RAIL_BAND: f32 = RAIL_TRACK_W + theme::space::XS;
+/// The grid's right edge — the rail's band inside the safe area's own right edge.
+const GRID_R: f32 = SCR_W - MARGIN_X - RAIL_BAND;
+/// 6×250 + 5×LGAP fills the space between the left margin and [`GRID_R`] exactly.
+const LGAP: f32 = (GRID_R - MARGIN_X - COLS as f32 * CARD_W) / (COLS as f32 - 1.0);
+// TOOL_Y/GRID_TOP each moved down 18px on 2026-08-23 with `widgets::TOP_BAR_Y`, which dropped so the
+// tab track clears `consts::MARGIN_Y`. They are clearances under that bar (22px and, after the
+// chips, 28px), so they follow it — holding them still would have left the Sort chip 4px under the
+// track instead of 22.
+const TOOL_Y: f32 = 152.0;
 const TOOL_H: f32 = 52.0;
-pub(crate) const GRID_TOP: f32 = 214.0;
+pub(crate) const GRID_TOP: f32 = 232.0;
 // The top-chrome scrim's own numbers used to live here — a knee at 188, its .40 alpha, and a 56px
 // scroll-linked appear. They are `widgets::nav_scrim`'s now, DERIVED from `GRID_TOP` rather than
 // spelled: the design system tokenises this treatment for every full-screen route that scrolls a
@@ -623,6 +642,17 @@ const MAX_LETTERS: usize = 64;
 /// what fits at this pitch the rail scrolls ([`RAIL_SCROLL`]) — so every section's rail has the
 /// same spacing, for the same reason it is top-anchored rather than centred.
 const RAIL_PITCH: f32 = 34.0;
+/// The rail's capsule track width — the widest thing the rail draws, and so what [`RAIL_BAND`]
+/// reserves and what [`rail_geom`]'s `cx` is placed from. Named because those three used to be the
+/// literal `44` / `22` / `SCR_W - 64` spelled in three places with no arithmetic tying them.
+const RAIL_TRACK_W: f32 = 44.0;
+/// The rail's first letter-slot top, below [`GRID_TOP`] — the letters line up with the grid's first
+/// row rather than with its card tops.
+const RAIL_TOP_OFF: f32 = 8.0;
+/// How far the capsule track overhangs the letter WINDOW at each end. It is the difference between
+/// what the rail measures its scroll against (the window) and what it draws (the capsule), and so
+/// the term the safe-area bound in [`rail_geom`] has to carry.
+const RAIL_CAP_PAD: f32 = 10.0;
 static mut RAIL_F: usize = 0;
 static mut RAIL_RECTS: [Rect; MAX_LETTERS] = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_LETTERS];
 static mut RAIL_N: usize = 0;
@@ -657,7 +687,9 @@ static mut RAIL_SCROLL: Spring = Spring::at(0.0);
 /// block centred on the panel says the APP failed. Centring it on the content region says this
 /// section did, and leaves the live chrome above it saying so.
 fn content_region() -> Rect {
-    Rect::new(MARGIN_X, GRID_TOP, SCR_W - 2.0 * MARGIN_X, SCR_H - GRID_TOP - theme::space::LG)
+    // bottom on `MARGIN_Y` rather than a `space::LG` rung: the read-out and its Try again pill are
+    // CENTRED in this band, so the band itself is what has to sit inside the overscan frame
+    Rect::new(MARGIN_X, GRID_TOP, SCR_W - 2.0 * MARGIN_X, SCR_H - GRID_TOP - MARGIN_Y)
 }
 
 /// How many toolbar chips are DRAWN — [`chips`]'s length, and nothing else. The whole decision
@@ -1094,11 +1126,35 @@ fn letter_of(idx: usize) -> usize {
 /// scroll step in [`update`] and [`draw_rail`] must agree about the window — a reveal rule aimed
 /// at a window that is not the one on screen parks the focused letter off the end of it.
 fn rail_geom(n: usize) -> (f32, f32, f32, f32) {
-    // the band the fit-to-fill divisor used, so a rail that DID fit sits exactly where it did
-    let vis = ((SCR_H - GRID_TOP - 40.0) / RAIL_PITCH).floor().max(1.0);
+    // How many letters fit: the band from the rail's own top down to the OVERSCAN FRAME, less the
+    // capsule's overhang past the last letter. It was `SCR_H - GRID_TOP - 40` — the band the old
+    // fit-to-fill divisor used — which is a bare inset rather than a bound, and once `GRID_TOP`
+    // moved down 18px it put the capsule's bottom cap 6px outside the frame.
+    let vis = ((SCR_H - MARGIN_Y - (GRID_TOP + RAIL_TOP_OFF) - RAIL_CAP_PAD) / RAIL_PITCH).floor().max(1.0);
     let win_h = vis.min(n as f32) * RAIL_PITCH;
-    (GRID_TOP + 8.0, SCR_W - 64.0, win_h, (n as f32 * RAIL_PITCH - win_h).max(0.0))
+    // cx puts the track's RIGHT edge on the safe area's, which is what `RAIL_BAND` bought
+    (GRID_TOP + RAIL_TOP_OFF, SCR_W - MARGIN_X - RAIL_TRACK_W * 0.5, win_h, (n as f32 * RAIL_PITCH - win_h).max(0.0))
 }
+/// **This screen's outermost drawn chrome, for the overscan audit** ([`crate::ui::consts::SAFE`]).
+///
+/// The full-width A–Z rail, the first and last grid columns, the toolbar's leading chip and the
+/// right-aligned item count — the four rects that reach furthest, at the widest state each can be
+/// in. It lives here rather than in the test that grades it because these are private constants and
+/// because the rects have to be the DRAWN ones: a table in another module would be a second copy of
+/// the layout, which is exactly the shape that let a 90px margin pass for a 5% frame.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    let (y0, cx, win_h, _) = rail_geom(MAX_LETTERS);
+    out.push(("library A–Z rail track", Rect::new(cx - RAIL_TRACK_W * 0.5, y0 - RAIL_CAP_PAD, RAIL_TRACK_W, win_h + 2.0 * RAIL_CAP_PAD)));
+    out.push(("library grid, first column", Rect::new(MARGIN_X, GRID_TOP, CARD_W, CARD_H)));
+    let last = MARGIN_X + (COLS as f32 - 1.0) * (CARD_W + LGAP);
+    out.push(("library grid, last column", Rect::new(last, GRID_TOP, CARD_W, CARD_H)));
+    out.push(("library toolbar, leading chip", Rect::new(MARGIN_X, TOOL_Y, 200.0, TOOL_H)));
+    // the count is right-ALIGNED on this edge, so the rect is degenerate on purpose
+    out.push(("library item count (right edge)", Rect::new(SCR_W - MARGIN_X, TOOL_Y, 0.0, TOOL_H)));
+    out.push(("library failure read-out band", content_region()));
+}
+
 /// Where the rail's scroll wants to be with letter `drive` in hand: the grid's own reveal rule in
 /// letter units, keeping one whole letter clear on each side so the driver never sits in the edge
 /// fade. Pure, so the window invariant is assertable off-device.
@@ -1203,8 +1259,14 @@ pub(crate) fn update(dt: f32) {
 
         // vertical scroll: reveal the focused row (label band included), never above its slot
         let row_top = GR as f32 * PITCH;
-        let max_y = (n_rows() as f32 * PITCH - (SCR_H - GRID_TOP) + 20.0).max(0.0);
-        let lo = row_top + CARD_H + 96.0 - (SCR_H - GRID_TOP - 16.0);
+        // The scroll CEILING carries the same bound as `lo` below, or the last row cannot reach it:
+        // `reveal` clamps its target to `max_y`, so a trailing air of 20 pinned the final row's
+        // caption 20px off the panel however much the reveal asked for. It is the pair that has to
+        // agree, which is why this line moved with that one.
+        let max_y = (n_rows() as f32 * PITCH - (SCR_H - GRID_TOP) + MARGIN_Y).max(0.0);
+        // …and the reveal leaves the card + its label band a MARGIN_Y clear of the bottom edge: a
+        // focused tile's caption used to settle 16px off the panel, i.e. inside the overscan frame
+        let lo = row_top + CARD_H + 96.0 - (SCR_H - GRID_TOP - MARGIN_Y);
         let hi = row_top;
         let want = if matches!(area(), Area::Grid | Area::Rail) {
             card_row::reveal((*addr_of!(SCROLL)).pos, lo, hi, max_y) // rail jumps scroll the grid too
@@ -2501,7 +2563,7 @@ fn draw_rail(p: Painter) {
     let scroll = unsafe { (*addr_of!(RAIL_SCROLL)).pos };
     // a slim capsule track behind the letters — the tab-track family, minimized: makes the
     // rail read as a CONTROL to discover, not stray typography
-    let track = Rect::new(cx - 22.0, y0 - 10.0, 44.0, win_h + 20.0);
+    let track = Rect::new(cx - RAIL_TRACK_W * 0.5, y0 - RAIL_CAP_PAD, RAIL_TRACK_W, win_h + 2.0 * RAIL_CAP_PAD);
     p.rect_sheened(track, 22.0, theme::scrim_black(0.30), theme::scrim_black(0.40));
     let in_rail = area() == Area::Rail;
     let cur_letter = letter_of(focus_idx());
@@ -2527,7 +2589,7 @@ fn draw_rail(p: Painter) {
         // belt and braces under the edge fade: a glyph reaches α0 before it reaches the window
         // edge, so this only catches the rounding — but without it a letter could paint over the
         // capsule's rounded cap while the spring is mid-flight.
-        p.clip(Rect::new(cx - 22.0, y0, 44.0, win_h));
+        p.clip(Rect::new(cx - RAIL_TRACK_W * 0.5, y0, RAIL_TRACK_W, win_h));
     }
     for (i, label) in labels.iter().enumerate() {
         let cy = y0 + (i as f32 + 0.5) * RAIL_PITCH - scroll;
@@ -2548,7 +2610,7 @@ fn draw_rail(p: Painter) {
         // false on it — so a click can only reach a letter that is actually legible.
         unsafe {
             (*addr_of_mut!(RAIL_RECTS))[i] = if a > 0.5 {
-                Rect::new(cx - 22.0, cy - RAIL_PITCH * 0.5, 44.0, RAIL_PITCH)
+                Rect::new(cx - RAIL_TRACK_W * 0.5, cy - RAIL_PITCH * 0.5, RAIL_TRACK_W, RAIL_PITCH)
             } else {
                 Rect::new(0.0, 0.0, 0.0, 0.0)
             }
@@ -2830,6 +2892,31 @@ mod tests {
     /// (music and photos only) ANSWERED, so there is no section, no state, and both of the section
     /// accessors fall through to their defaults — `Loading` and `-1`, i.e. the spinner again. It is
     /// `Empty`, because the server told us; catching only the FAILED table would have left this
+    /// **The LAST row's caption reaches the overscan frame and no further** — the reveal's two
+    /// halves (`lo` and the scroll ceiling `max_y`) graded as the pair they are.
+    ///
+    /// `card_row::reveal` clamps its target to `max_y`, so the bound this screen asks for is only
+    /// what it gets while the ceiling is at least as generous. They disagreed by 34px when only `lo`
+    /// was moved onto `MARGIN_Y`: every row but the last obeyed the frame and the last one settled
+    /// 20px off the panel, which is the state a grid is actually left in more often than any other.
+    /// Pure arithmetic, so it needs no store and no mutex.
+    #[test]
+    fn the_last_grid_rows_caption_settles_on_the_overscan_frame() {
+        for n_rows in [1usize, 2, 3, 7, 40] {
+            let row_top = (n_rows - 1) as f32 * PITCH;
+            let max_y = (n_rows as f32 * PITCH - (SCR_H - GRID_TOP) + MARGIN_Y).max(0.0);
+            let lo = row_top + CARD_H + 96.0 - (SCR_H - GRID_TOP - MARGIN_Y);
+            // scrolled to the very bottom already, then asked to reveal the last row
+            let scroll = card_row::reveal(max_y, lo, row_top, max_y);
+            let caption_bottom = GRID_TOP + row_top + CARD_H + 96.0 - scroll;
+            assert!(
+                caption_bottom <= SCR_H - MARGIN_Y + 0.01,
+                "{n_rows} rows: the last caption settles at {caption_bottom}, past the frame at {}",
+                SCR_H - MARGIN_Y,
+            );
+        }
+    }
+
     /// spinning exactly as before.
     #[test]
     fn a_table_that_answered_with_no_browsable_library_is_empty_not_a_spinner() {

--- a/rust-modules/src/ui/more_menu.rs
+++ b/rust-modules/src/ui/more_menu.rs
@@ -155,12 +155,21 @@ fn action_at(rows: &[Action], sel: i32) -> Action {
     usize::try_from(sel).ok().and_then(|i| rows.get(i)).copied().unwrap_or(Action::None)
 }
 
+/// The panel at its TALLEST, for the overscan audit ([`crate::ui::consts::SAFE`]).
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    let (pw, ph) = (448.0f32, 320.0f32);
+    let bottom = SCR_H - 316.0;
+    out.push(("… overflow menu panel", Rect::new(crate::ui::player_hud::CTRL_RIGHT - pw, bottom - ph, pw, ph)));
+}
+
 /// Bottom-right, above the control row — anchored to the `…` disc that opened it, the way the
-/// track menu is anchored to the pair beside it. Shares the track menu's right margin (80) and its
-/// bottom edge, so opening one after the other does not make the panel hop.
+/// track menu is anchored to the pair beside it. Shares the track menu's right margin
+/// (`player_hud::CTRL_RIGHT`, the discs' own edge) and its bottom edge, so opening one after the
+/// other does not make the panel hop.
 fn panel_rect() -> Rect {
     let pw = 448.0f32;
-    let px = SCR_W - 80.0 - pw;
+    let px = crate::ui::player_hud::CTRL_RIGHT - pw;
     let bottom = SCR_H - 316.0; // ~28px above the discs, as track_menu
     let ph = table().measured_height().clamp(120.0, 320.0);
     Rect::new(px, bottom - ph, pw, ph)

--- a/rust-modules/src/ui/onboard.rs
+++ b/rust-modules/src/ui/onboard.rs
@@ -38,7 +38,7 @@ use crate::ui::{theme, Env, Painter, Rect, View};
 use std::os::raw::c_uint;
 use std::ptr::{addr_of, addr_of_mut};
 
-/// **The one top guide both columns hang from** (`--route-top`). Clear of the 112px top chrome the
+/// **The one top guide both columns hang from** (`--route-top`). Clear of the 130px top chrome the
 /// bar-wearing screens use, which this route does not draw — the alignment is what makes the copy
 /// and the list read as one screen rather than two panes.
 const ROUTE_TOP: f32 = 150.0;

--- a/rust-modules/src/ui/person.rs
+++ b/rust-modules/src/ui/person.rs
@@ -130,7 +130,11 @@ const SHELF_STYLE: RowStyle = RowStyle { title_lines: 2, ..RowStyle::HOME };
 /// A focused shelf lifts no higher than this from the screen top — [`HEADER_TOP`]'s twin.
 const TOP_MARGIN: f32 = HEADER_TOP;
 /// Air kept under the lowest visible content when a shelf is revealed by scrolling.
-const BOTTOM_PAD: f32 = theme::space::LG;
+///
+/// The OVERSCAN keep-out rather than a `space` rung (it was `LG` 40): what this bounds is a focused
+/// tile's own caption against the bottom edge of the panel, so the number that belongs here is the
+/// safe area's, not a gap from the spacing ladder.
+const BOTTOM_PAD: f32 = crate::ui::consts::MARGIN_Y;
 
 /// The condense spring's rate — the scroll rate, because the band's resize IS a scroll-scale
 /// motion (the mock gives both the same `.42s` curve).
@@ -1383,17 +1387,32 @@ mod tests {
     #[test]
     fn the_first_shelf_fits_at_rest_under_either_band_state() {
         let h = shelf_block_h();
-        for band in [H_CON, EXP_HEADER_H] {
+        let scroll = |band: f32| {
             let top = HEADER_TOP + band + SHELF_GAP;
-            let content = top + h + BOTTOM_PAD;
+            reveal_block(0.0, top, h, top + h + BOTTOM_PAD)
+        };
+        // The two bands the page can actually BE in: condensed, and the portrait-bound expanded one.
+        for band in [H_CON, PORTRAIT_EXP] {
             assert_eq!(
-                reveal_block(0.0, top, h, content),
+                scroll(band),
                 0.0,
                 "band {band}: focusing the first shelf scrolled the page (block bottom {}, floor {})",
-                top + h,
+                HEADER_TOP + band + SHELF_GAP + h,
                 SCR_H - BOTTOM_PAD
             );
         }
+        // [`EXP_HEADER_H`] is a MODELLING bound, not a band — it substitutes point sizes for cap
+        // heights, so it stands 4px above anything the text stack can produce. Since `BOTTOM_PAD`
+        // became the overscan keep-out (54, from 40) the expanded band clears the floor by 3px, so
+        // those 4 phantom pixels buy one pixel of scroll. Asserted as a BOUND rather than dropped:
+        // what this test is for is the packing dividend, and a bound that grows past its own
+        // pessimism is the regression to catch.
+        assert!(
+            scroll(EXP_HEADER_H) <= EXP_HEADER_H - PORTRAIT_EXP,
+            "the pessimistic bound costs {}px of scroll, more than the {}px it is pessimistic by",
+            scroll(EXP_HEADER_H),
+            EXP_HEADER_H - PORTRAIT_EXP,
+        );
     }
 
     /// ...and a SECOND shelf, which cannot fit alongside the first, does scroll — by exactly

--- a/rust-modules/src/ui/player_hud.rs
+++ b/rust-modules/src/ui/player_hud.rs
@@ -219,7 +219,9 @@ pub(crate) fn draw_subtitle_bitmap(hud_up: bool) {
 }
 
 // ---- HUD geometry (shared by draw_hud + the pointer hit-tests in app.rs) ----
-const SB_X: f32 = 90.0; // scrubber (and title) left margin
+// scrubber (and title, and the bottom tab pills) left margin — the app's own, not a second copy of
+// it: this was a literal 90 and so stayed put when `MARGIN_X` moved to the overscan-safe 96
+const SB_X: f32 = crate::ui::consts::MARGIN_X;
 pub(crate) const fn sb_w() -> f32 {
     SCR_W - 2.0 * SB_X
 }
@@ -236,8 +238,12 @@ const BTN_Y: f32 = SCR_H - 288.0;
 pub(crate) const CTRL_H: f32 = BTN_S;
 /// control-row top
 pub(crate) const CTRL_Y: f32 = BTN_Y;
-/// control-row right edge — 80px margin, matching the track-menu panel (right:80)
-pub(crate) const CTRL_RIGHT: f32 = SCR_W - 80.0;
+/// control-row right edge — the app's side margin, matching the track-menu panel.
+///
+/// The mock's `right: 80` put the Subtitles/Audio/`…` discs 16px past the 5% overscan frame, and the
+/// track and `…` panels were aligned to the same 80 (`track_menu`/`more_menu`). All three moved onto
+/// `MARGIN_X` together on 2026-08-23 — they are one right edge by design, so they take one number.
+pub(crate) const CTRL_RIGHT: f32 = SCR_W - crate::ui::consts::MARGIN_X;
 /// how many control discs the row holds: Subtitles, Audio, More
 const BTN_N: i32 = 3;
 
@@ -1114,6 +1120,24 @@ pub(crate) fn draw_hud(slot: ControlSlot, busy: Busy, focus: i32, btn: i32, tab:
         }
         px += pw + 16.0;
     }
+}
+
+/// **The transport's outermost drawn chrome, for the overscan audit**
+/// ([`crate::ui::consts::SAFE`]). Private geometry, so the rects are built where they are drawn
+/// rather than restated in the module that grades them.
+///
+/// The bottom tab row is measured at its widest — `Info` + `Chapters`, the pair an item with
+/// chapters draws — because a pill's width is the label's and the audit has to grade the widest
+/// state a screen can be in, not the one a screenshot happened to catch. That measurement needs a
+/// font, which the host suite cannot link, so it is bounded by the row's OWN height instead: what
+/// the audit is about here is the row's left edge and its BOTTOM, and both are font-independent.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    out.push(("player scrubber", Rect::new(SB_X, SB_Y, sb_w(), SB_H)));
+    out.push(("player control row", Rect::new(CTRL_RIGHT - CTRL_ROW_W, CTRL_Y, CTRL_ROW_W, CTRL_H)));
+    let py = (SB_Y + SCR_H) * 0.5 - BTN_S * 0.5;
+    out.push(("player bottom tab row", Rect::new(SB_X, py, 0.0, BTN_S)));
+    out.push(("player title / elapsed clock", Rect::new(SB_X, SCR_H - 312.0, 0.0, 0.0)));
 }
 
 #[cfg(test)]

--- a/rust-modules/src/ui/search/mod.rs
+++ b/rust-modules/src/ui/search/mod.rs
@@ -73,9 +73,10 @@ pub(crate) mod field;
 pub(crate) mod recents;
 pub(crate) mod results;
 
-/// Field bottom (148 + one control height) plus one 40 rung — where every state's content starts,
-/// and what a scrolled shelf returns to.
-pub(crate) const CONTENT_TOP: f32 = 248.0;
+/// Field bottom (166 + one control height) plus one 40 rung — where every state's content starts,
+/// and what a scrolled shelf returns to. It moved down 18px with [`FIELD`] on 2026-08-23; the
+/// raised keyboard's clearance absorbed it (`recents`' block test still passes with 48px to spare).
+pub(crate) const CONTENT_TOP: f32 = 266.0;
 /// Shelf heading to the top of its row: the 30px heading plus a 30px gap, as `home.rs` draws it.
 pub(crate) const HEAD_TO_ROW: f32 = 60.0;
 /// The caption pair reserved under every tile. Reserved whether or not it is drawn, so nothing
@@ -96,7 +97,14 @@ pub(crate) const LABEL_BLOCK: f32 = 114.0;
 /// panel up, scan a column for the discontinuity) — everything else on this screen is derived.
 pub(crate) const KEYBOARD_H: f32 = 324.0;
 /// The field: 820 wide at the app's own side margin, on the one control height.
-pub(crate) const FIELD: Rect = Rect { x: 90.0, y: 148.0, w: 820.0, h: 60.0 };
+///
+/// `x` is `consts::MARGIN_X` rather than a literal 90 — it always MEANT the app's side margin, and
+/// spelling it twice is how it stayed at 90 when the margin moved to the overscan-safe 96. `y` is
+/// 36px under `widgets::TOP_BAR_BOTTOM` (130), and moved down 18px with that bar on 2026-08-23; it
+/// is still a hand-maintained literal, which is the same shape the `x` above just stopped being —
+/// derive it the next time this screen is opened for anything else.
+pub(crate) const FIELD: Rect =
+    Rect { x: crate::ui::consts::MARGIN_X, y: 166.0, w: 820.0, h: 60.0 };
 /// Where the app's own chrome ends and the result band begins — the field's bottom edge.
 ///
 /// It is the navigation scrim's OPAQUE floor: [`crate::ui::widgets::nav_scrim`] fills flat from the

--- a/rust-modules/src/ui/search/results.rs
+++ b/rust-modules/src/ui/search/results.rs
@@ -120,7 +120,11 @@ const COUNT_GAP: f32 = theme::space::SM;
 /// third spacing.
 const SOURCE_PAD: f32 = theme::space::XS;
 /// Air kept under the lowest visible content when a shelf is revealed by scrolling.
-const BOTTOM_PAD: f32 = theme::space::LG;
+///
+/// The OVERSCAN keep-out rather than a `space` rung (it was `LG` 40) — `person::BOTTOM_PAD`'s twin
+/// and for its reason: what this bounds is a focused tile's own caption against the bottom edge of
+/// the panel, so the number is the safe area's and not one from the spacing ladder.
+const BOTTOM_PAD: f32 = crate::ui::consts::MARGIN_Y;
 /// Headroom between the field's bottom edge and where scrolled content is cut. It is not spacing —
 /// nothing is drawn in it at rest — it is the allowance for the two things that paint above a
 /// shelf's own block top: the focused heading's `CardRow::lift()` and a magnified tile's glow.
@@ -817,8 +821,9 @@ mod tests {
             assert!(bottom <= floor, "{k:?}: the first row ends at {bottom}, under the keyboard at {floor}");
         }
         // The ACTUAL numbers `super`'s layout note quotes, so a doc claim nobody can reproduce
-        // cannot come back: a poster shelf ends at 683 against a MEASURED panel edge of 756.
-        assert_eq!(stack_top(&[Kind::Movie], 0) + HEAD_TO_ROW + CARD_H, 683.0);
+        // cannot come back: a poster shelf ends at 701 against a MEASURED panel edge of 756.
+        // (683 until 2026-08-23, when the field and `CONTENT_TOP` moved down 18px with the top bar.)
+        assert_eq!(stack_top(&[Kind::Movie], 0) + HEAD_TO_ROW + CARD_H, 701.0);
         assert_eq!(floor, 756.0);
     }
 

--- a/rust-modules/src/ui/stats.rs
+++ b/rust-modules/src/ui/stats.rs
@@ -575,7 +575,17 @@ fn panel_rect() -> Rect {
     // a panel that resizes as rows come and go is a panel that moves under the camera.
     let w = 2.0 * FIELD_COL_W + theme::space::MD + 2.0 * PAD;
     let h = HEAD_H + FieldList::height(COLUMN_ROWS) + PAD;
-    Rect::new(MARGIN, MARGIN, w, h)
+    // x on the app's own side margin, not [`MARGIN`]: the panel's whole output format is a
+    // PHOTOGRAPH of a television, so it is the one overlay that must sit inside the overscan frame
+    // even though nothing on it is pressable. 60 cleared it vertically and missed it by 36 across.
+    Rect::new(crate::ui::consts::MARGIN_X, MARGIN, w, h)
+}
+
+/// The read-out's frame, for the overscan audit ([`crate::ui::consts::SAFE`]). Fixed at the row
+/// budget by [`panel_rect`], so this is the whole state space.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    out.push(("stats read-out panel", panel_rect()));
 }
 
 pub(crate) fn draw() {
@@ -717,8 +727,12 @@ mod tests {
             "panel bottom {bottom} overlaps the control row at {}",
             crate::ui::player_hud::CTRL_Y
         );
-        let right = MARGIN + 2.0 * FIELD_COL_W + theme::space::MD + 2.0 * PAD;
-        assert!(right < SCR_W, "panel is wider than the screen: {right}");
+        // through `panel_rect` itself, not a restatement of its arithmetic: its x is `MARGIN_X`
+        // (the overscan side margin) while its y is `MARGIN`, and a copy here would have kept
+        // spelling 60 for both.
+        let p = panel_rect();
+        assert!(p.x + p.w < SCR_W, "panel is wider than the screen: {}", p.x + p.w);
+        assert!(crate::ui::consts::inside_safe(p), "the read-out is photographed — it must clear the overscan frame");
     }
 
     /// **The chart can be deleted by a green suite.** `draw_chart` returns silently below 40 px,

--- a/rust-modules/src/ui/theme.rs
+++ b/rust-modules/src/ui/theme.rs
@@ -219,8 +219,14 @@ pub mod logo {
     /// so a wordmark in the pinned strip is pixel-identical to today.
     pub const COMPACT_H_MIN: f32 = 54.0;
     /// Set by the BAND, not by the area rule (which would want 121 here): the pinned strip has to
-    /// clear the screen top and stop short of `detail::TOP_MARGIN` (120), where the first scrolled
-    /// section lifts to. 72 leaves 22px of head room above the logo and 26px below it.
+    /// clear the screen top and stop short of `detail::TOP_MARGIN`, where the first scrolled
+    /// section lifts to.
+    ///
+    /// Since 2026-08-23 the strip is solved from this number rather than fitted around it — "clear
+    /// the screen top" now means clear the OVERSCAN frame (`consts::MARGIN_Y` 54), so
+    /// `detail::COMPACT_TITLE_BOT` is `54 + this` and `TOP_MARGIN` is that plus 26px of air. Pulling
+    /// this down (still the one knob to pull if a device capture says a square emblem crowds the
+    /// pinned title) now lifts the whole strip with it instead of only shrinking the mark.
     pub const COMPACT_H_MAX: f32 = 72.0;
 }
 

--- a/rust-modules/src/ui/track_menu.rs
+++ b/rust-modules/src/ui/track_menu.rs
@@ -6,7 +6,7 @@
 //! from the previous procedural version — only the presentation moved onto the table.
 #![allow(dead_code)]
 use crate::metadata;
-use crate::ui::consts::{SCR_H, SCR_W, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_UP};
+use crate::ui::consts::{SCR_H, SDLK_DOWN, SDLK_LEFT, SDLK_RIGHT, SDLK_UP};
 use crate::ui::popover::Popover;
 use crate::ui::table::{Badge, Row, Section, TableView};
 use crate::ui::theme;
@@ -365,11 +365,25 @@ fn rebuild(tab: c_int, slide: bool) {
     table().set_sections(vec![sec], sel_for_tab(tab), slide);
 }
 
+/// The panel at its WIDEST and TALLEST, for the overscan audit ([`crate::ui::consts::SAFE`]) — the
+/// audio tab's 560 and the full `top_min`→`bottom` span, since the measured height comes from a
+/// `TableView` no host test can measure.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    let pw = 560.0f32;
+    let (bottom, top_min) = (SCR_H - 316.0, 60.0);
+    out.push((
+        "track menu panel",
+        Rect::new(crate::ui::player_hud::CTRL_RIGHT - pw, top_min, pw, bottom - top_min),
+    ));
+}
+
 // ---- panel geometry (shared by update + draw so scrolling math matches) ----
 fn panel_rect() -> Rect {
     let tab = unsafe { addr_of!(TAB).read() };
     let pw = if tab == 0 { 560.0f32 } else { 448.0f32 }; // audio / subtitles (mockup panel widths)
-    let px = SCR_W - 80.0 - pw; // right:80 (mockup)
+    // the transport control row's own right edge — one number for the discs and both panels
+    let px = crate::ui::player_hud::CTRL_RIGHT - pw;
     // Bottom-anchored just above the control-button row (buttons top at SCR_H-288) with a clear gap.
     // The panel grows UPWARD from this fixed bottom edge, and its height is capped so the top never
     // crosses `top_min` — so a long list (an item with many audio dubs) SCROLLS inside the panel

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -1374,8 +1374,8 @@ pub(crate) fn art_scrim(p: Painter, card: Rect, rad: f32, h: f32, a: f32) {
 /// completely alone: that is the side of the picture the composition is usually about.
 const HERO_SCRIM_W: f32 = 0.80 * crate::ui::consts::SCR_W; // 1536
 
-/// Where the wedge starts feathering in. Clears the tab track's own band ([`TOP_BAR_Y`] 44 +
-/// [`TAB_PILL_H`] 60 + [`TAB_TRACK_PAD`] 8 = 112) by 50px: the top chrome owns its legibility with
+/// Where the wedge starts feathering in. Clears the tab track's own band ([`TOP_BAR_Y`] 62 +
+/// [`TAB_PILL_H`] 60 + [`TAB_TRACK_PAD`] 8 = 130) by 32px: the top chrome owns its legibility with
 /// its own dark capsule (`draw_tab_row`) and must not get a second treatment stacked under it.
 const HERO_SCRIM_TOP: f32 = 0.15 * crate::ui::consts::SCR_H; // 162
 /// Where the wedge reaches full strength — and the seam between its two quads, named once so the
@@ -1607,7 +1607,12 @@ const CHIP_NAME_MAX: f32 = 320.0;
 /// `home.rs`, `library.rs` and `search/mod.rs` — and only the first of the three also recorded it
 /// for a hit test, which is exactly how a control drawn on three screens came to be clickable on
 /// one.
-pub(crate) const CHIP_FRAME: Rect = Rect::new(crate::ui::consts::MARGIN_X, TOP_BAR_Y, CHIP_D, CHIP_D);
+/// **It is the CAPSULE that lands on the margin, not the avatar** — the chip is a control in the
+/// top BAND, and the band's own material (the tab track) is inset the same [`TAB_TRACK_PAD`] from
+/// its pills. Written as `MARGIN_X` flat until 2026-08-23, which put the focused capsule's left edge
+/// at 88, i.e. 8px into the overscan exclusion zone, on the three screens that wear this bar.
+pub(crate) const CHIP_FRAME: Rect =
+    Rect::new(crate::ui::consts::MARGIN_X + TAB_TRACK_PAD, TOP_BAR_Y, CHIP_D, CHIP_D);
 
 /// **The focused capsule's rect — the ONE expression, drawn and priced from the same place.**
 ///
@@ -3633,7 +3638,13 @@ const TAB_ICON_PILL_W: f32 = TAB_PILL_H;
 /// `--btn-icon-ratio`, the same ratio every icon-and-label control in the app uses.
 const TAB_ICON_D: f32 = 32.0;
 /// The top chrome band's y — the chip and the pills sit on it (Home and Library alike).
-pub(crate) const TOP_BAR_Y: f32 = 44.0;
+///
+/// **Derived from the overscan safe area, not chosen.** It was a bare `44.0` until 2026-08-23, which
+/// put the pills 10px and the track behind them ([`TAB_TRACK_PAD`] higher still) 18px inside the top
+/// exclusion zone — on the three screens that wear this bar, i.e. exactly the "main page" LG's
+/// checklist item #2 names. The band is measured from its OUTERMOST ink (the track, not the pills),
+/// so the whole control clears the frame rather than only the part you press.
+pub(crate) const TOP_BAR_Y: f32 = crate::ui::consts::MARGIN_Y + TAB_TRACK_PAD;
 /// SAME element, SAME geometry as the detail season tabs (user directive): one control height
 /// (the 60px circle-button CD family) and the season tabs' ±18 label padding — the two rows
 /// must be indistinguishable as a control.
@@ -3649,7 +3660,7 @@ pub(crate) const TAB_TRACK_PAD: f32 = 8.0;
 /// edge ([`TOP_BAR_Y`] + the pill height + the track's inset). Exposed so a screen that lets art
 /// overflow UPWARD out of its layout band ([`crate::ui::hero_logo`]) can ASSERT its clearance in a
 /// host test instead of leaving it to a device capture.
-pub(crate) const TOP_BAR_BOTTOM: f32 = TOP_BAR_Y + TAB_PILL_H + TAB_TRACK_PAD; // 112
+pub(crate) const TOP_BAR_BOTTOM: f32 = TOP_BAR_Y + TAB_PILL_H + TAB_TRACK_PAD; // 130
 /// Inter-pill air ≈ the season tabs' rhythm (their `TAB_ADVANCE` 52 minus the 2×18 pad the pills
 /// here already carry — pill edge to pill edge reads the same). Doubles as the scroll-into-view
 /// context margin, exactly as the season tabs use their advance.
@@ -3657,8 +3668,31 @@ const TAB_GAP: f32 = 16.0;
 /// How wide the pill strip may grow before it starts scrolling. The row stays CENTERED, but it
 /// must never reach the profile chip (a focus stop of its own at `MARGIN_X`), so the viewport is
 /// the screen less a symmetric chip-clearing margin, less the track's own inset on both ends.
-const TAB_SIDE_CLEAR: f32 = crate::ui::consts::MARGIN_X + CHIP_D + theme::space::MD;
+const TAB_SIDE_CLEAR: f32 = CHIP_FRAME.x + CHIP_D + theme::space::MD;
 const TAB_VIEW_MAX: f32 = crate::ui::consts::SCR_W - 2.0 * (TAB_SIDE_CLEAR + TAB_TRACK_PAD);
+/// **The shared top bar's outermost drawn chrome, for the overscan audit**
+/// ([`crate::ui::consts::SAFE`]) — the one band Home, the Library and Search all wear, i.e. the
+/// "main page" LG's checklist item #2 is about.
+///
+/// Each rect is the widest/tallest state the thing can be in: the track at [`TAB_VIEW_MAX`] (past
+/// which the strip scrolls rather than growing), and the chip at full unfurl with a name at its
+/// budget. The chip's own capsule is the rect that matters rather than the avatar — it is the
+/// focused control's visible edge, and it sits [`TAB_TRACK_PAD`] outside the avatar on every side.
+#[cfg(test)]
+pub(crate) fn overscan_rects(out: &mut Vec<(&'static str, Rect)>) {
+    let tw = TAB_VIEW_MAX + 2.0 * TAB_TRACK_PAD;
+    out.push((
+        "top tab track (widest)",
+        Rect::new((crate::ui::consts::SCR_W - tw) * 0.5, TOP_BAR_Y - TAB_TRACK_PAD, tw, TAB_PILL_H + 2.0 * TAB_TRACK_PAD),
+    ));
+    out.push((
+        "top tab pill row",
+        Rect::new((crate::ui::consts::SCR_W - TAB_VIEW_MAX) * 0.5, TOP_BAR_Y, TAB_VIEW_MAX, TAB_PILL_H),
+    ));
+    out.push(("profile chip", CHIP_FRAME));
+    out.push(("profile chip, focused capsule", chip_cap(1.0, CHIP_NAME_MAX)));
+}
+
 /// The strip's scroll stiffness. The detail page's season-tab row springs at the same 240 — same
 /// control, same overflow problem, so the two rows must move alike (the user directive that keeps
 /// the tab pills and the season tabs in step covers their motion, not just their geometry).
@@ -4195,15 +4229,21 @@ const CHIP_CAP_MAX_R: f32 = {
 /// together:
 ///
 /// * **The BUDGET is the UNION.** Two glass surfaces in a frame converge on one grab
-///   (`gfx::blur_region_union`), so the bar costs one snapshot — but that snapshot spans both. The
-///   chip's capsule starts at x=82 and the margin is 88, so the union's left edge clamps to 0 and
-///   its right is the track's; the band is 200px tall after the same clamp. That prices the pair at
-///   `(1048 + w/2) x 200`, which reaches [`crate::gfx::GLASS_REGION_BUDGET`] at **w = 904** — not at
-///   the 940 the track alone could afford.
-/// * **And the two must not TOUCH**, which binds tighter. The track is centred, so its left edge is
-///   `(SCR_W - w) / 2`; the capsule's right edge stops at [`CHIP_CAP_MAX_R`]. Solving for
-///   [`BAND_AIR`] between them is this expression — **856** — and it is written as the expression so
-///   that raising [`CHIP_NAME_MAX`] tightens the cap instead of silently letting the two meet.
+///   (`gfx::blur_region_union`), so the bar costs one snapshot — but that snapshot spans both. Its
+///   left edge is the capsule's ([`BAND_REGION_X0`]) and its right is the track's, over
+///   [`BAND_REGION_H`]; solving that for the width is [`GLASS_TRACK_BUDGET_MAX`].
+/// * **And the two must not TOUCH.** The track is centred, so its left edge is `(SCR_W - w) / 2`;
+///   the capsule's right edge stops at [`CHIP_CAP_MAX_R`]. Solving for [`BAND_AIR`] between them is
+///   [`GLASS_TRACK_TOUCH_MAX`] — **848** — written as the expression so that raising
+///   [`CHIP_NAME_MAX`] tightens the cap instead of silently letting the two meet.
+///
+/// **Which of the two BINDS moved on 2026-08-23, and this constant is now the `min` rather than the
+/// touch rule alone.** It was written as the touch expression with a comment saying the budget
+/// reached at 904 — true while the band's blurred region was 200px tall, i.e. while `TOP_BAR_Y` was
+/// 44. Dropping the bar 18px so its track clears the overscan frame (`consts::MARGIN_Y`) makes that
+/// region 218 tall, and 18 more rows of a ~1470-wide grab is 26k px², enough to put the touch width
+/// outside the budget. The two constraints were only ever ordered by coincidence; asserting one and
+/// documenting the other is what let that go unnoticed until the test caught it.
 ///
 /// Overlap is what had to be made impossible, rather than handled. There is ONE blur cache: a
 /// second surface over the first gets no second blur, only a second frost and a second rim
@@ -4211,10 +4251,54 @@ const CHIP_CAP_MAX_R: f32 = {
 /// source-pass note measures from the other direction. Nothing in the shader can undo that, so the
 /// geometry has to keep them apart, and the test below is what keeps them apart.
 ///
-/// What it costs is stated plainly: the pair fits ~84px less strip than the track alone did, which
-/// is under one pill's width and so changes the answer for at most one section table in the band
-/// where it lands. What it buys is that the band is never two materials and never a doubled one.
-const GLASS_TRACK_MAX: f32 = crate::ui::consts::SCR_W - 2.0 * (CHIP_CAP_MAX_R + BAND_AIR);
+/// What it costs is stated plainly: the product's own strip is 572px, so the material survives
+/// today's bar with room for one more library and not two. What it buys is that the band is never
+/// two materials and never a doubled one, and never over the budget a measurement set.
+const GLASS_TRACK_MAX: f32 = if GLASS_TRACK_TOUCH_MAX < GLASS_TRACK_BUDGET_MAX {
+    GLASS_TRACK_TOUCH_MAX
+} else {
+    GLASS_TRACK_BUDGET_MAX
+};
+
+/// The widest track that still leaves [`BAND_AIR`] between the unfurled chip and the centred strip.
+const GLASS_TRACK_TOUCH_MAX: f32 = crate::ui::consts::SCR_W - 2.0 * (CHIP_CAP_MAX_R + BAND_AIR);
+
+/// The band's blurred region HEIGHT, in authored px.
+///
+/// The top clamps to 0 — the track's own top edge (`TOP_BAR_Y - TAB_TRACK_PAD` = 54) is inside
+/// [`crate::gfx::BLUR_MARGIN`] 88 of the panel edge — so the whole region is
+/// `0 .. TOP_BAR_BOTTOM + BLUR_MARGIN`. If the bar ever drops far enough that the top stops
+/// clamping, this over-states the region and [`the_whole_bands_glass_fits_one_region_budget`] (which
+/// asks `gfx::blur_region` itself, not this) is what will say so.
+const BAND_REGION_H: f32 = TOP_BAR_BOTTOM + crate::gfx::BLUR_MARGIN;
+
+/// [`crate::gfx::GLASS_REGION_BUDGET`], restated here because that constant is `cfg(test)` on a
+/// deliberate argument — *"a number the shipping build never reads should not pretend to"* — and
+/// this one IS read by the shipping build, through [`GLASS_TRACK_MAX`]. The duplication is closed by
+/// an equality ([`tests::the_band_budget_restated_here_is_the_measured_one`]) rather than by a
+/// comment, which is the same trade `CHIP_CAP_MAX_R` makes against the rect `chip_cap` draws.
+const BAND_REGION_BUDGET: f32 = 300_000.0;
+
+/// The band's blurred region LEFT edge — the chip capsule's own left grown [`crate::gfx::BLUR_MARGIN`],
+/// clamped to the panel. It used to clamp to 0 and no longer does: the capsule starts at `MARGIN_X`
+/// 96 (it was 82 when the chip sat at a 90px margin with no [`TAB_TRACK_PAD`] inset), so the grab
+/// begins at 8. Written out because [`GLASS_TRACK_BUDGET_MAX`] is a closed form of what
+/// `gfx::blur_region_union` computes, and an assumed-0 left edge silently overcharges it by 16px of
+/// track — which is safe but wrong, and wrong in a constant the shipping build reads.
+const BAND_REGION_X0: f32 = {
+    let x = CHIP_FRAME.x - TAB_TRACK_PAD - crate::gfx::BLUR_MARGIN;
+    if x > 0.0 {
+        x
+    } else {
+        0.0
+    }
+};
+
+/// [`BAND_REGION_BUDGET`] solved for the track width, over the union
+/// `[BAND_REGION_X0, (SCR_W + w) / 2 + BLUR_MARGIN] x BAND_REGION_H`.
+const GLASS_TRACK_BUDGET_MAX: f32 = 2.0
+    * (BAND_REGION_BUDGET / BAND_REGION_H + BAND_REGION_X0
+        - (crate::ui::consts::SCR_W * 0.5 + crate::gfx::BLUR_MARGIN));
 
 /// Is the shared tab track wearing glass this frame?
 ///
@@ -5589,8 +5673,8 @@ mod tests {
         };
         let lib = area(crate::ui::library::GRID_TOP);
         let search = area(crate::ui::search::CONTENT_TOP);
-        assert_eq!(lib, 1920.0 * 302.0, "the Library band: 1920 wide, 0..214 grown 88 below");
-        assert_eq!(search, 1920.0 * 336.0, "Search's field sits 34px lower, and the band with it");
+        assert_eq!(lib, 1920.0 * 320.0, "the Library band: 1920 wide, 0..232 grown 88 below");
+        assert_eq!(search, 1920.0 * 354.0, "Search's field sits 34px lower, and the band with it");
         for (name, a) in [("library", lib), ("search", search)] {
             assert!(
                 a > 1.9 * crate::gfx::GLASS_REGION_BUDGET,
@@ -5681,6 +5765,19 @@ mod tests {
     /// exists to catch, so the counterexample moved with it: the old one was a 1050-wide track,
     /// which is far outside either limit, where 940 — the width the TRACK alone could afford — is
     /// inside its own budget and outside the band's. That is the boundary the second surface moved.
+    /// [`BAND_REGION_BUDGET`] is a restatement of a `cfg(test)` constant, so it can only be kept
+    /// honest by an equality. Both halves of [`GLASS_TRACK_MAX`] are also re-derived here through
+    /// `gfx::blur_region` itself, which is the check that `BAND_REGION_H`'s clamp assumption still
+    /// holds — the constant would silently over-state the region if the bar ever dropped past
+    /// `BLUR_MARGIN`.
+    #[test]
+    fn the_band_budget_restated_here_is_the_measured_one() {
+        assert_eq!(BAND_REGION_BUDGET, crate::gfx::GLASS_REGION_BUDGET);
+        let (h, y) = (TAB_PILL_H + 2.0 * TAB_TRACK_PAD, TOP_BAR_Y - TAB_TRACK_PAD);
+        let reg = crate::gfx::blur_region(0.0, y, crate::ui::consts::SCR_W, h);
+        assert_eq!(reg[3], BAND_REGION_H, "the band's real region height");
+    }
+
     #[test]
     fn the_whole_bands_glass_fits_one_region_budget() {
         assert!(
@@ -5732,12 +5829,40 @@ mod tests {
             track_x(GLASS_TRACK_MAX),
             BAND_AIR,
         );
+        // **The cap is TIGHT against whichever constraint binds** — a limit that gives away more
+        // strip than either rule needs is a cost nobody decided to pay. This used to be pinned
+        // within a pixel of `BAND_AIR`, which said the same thing while the touch rule was the one
+        // that bound; since the bar dropped to clear the overscan frame the BUDGET binds instead,
+        // so the clearance above is legitimately wider and the tightness claim has to be made
+        // against the widest track the budget admits.
+        //
+        // Both bounds are RE-DERIVED here rather than read back: the touch one off the rect
+        // `chip_cap` draws, the budget one by searching `band_region` — which asks
+        // `gfx::blur_region_union` itself. Comparing `GLASS_TRACK_MAX` against the two module
+        // constants it is literally the `min` of would be an identity that only NaN could fail, and
+        // it would have missed exactly the error this catches: `GLASS_TRACK_BUDGET_MAX`'s closed
+        // form assumed a union left edge of 0, which stopped being true when the chip moved to
+        // `MARGIN_X`.
+        let touch = crate::ui::consts::SCR_W - 2.0 * (cap.x + cap.w + BAND_AIR);
+        let budget = {
+            let (mut lo, mut hi) = (0.0f32, crate::ui::consts::SCR_W);
+            for _ in 0..40 {
+                let mid = 0.5 * (lo + hi);
+                if band_region(mid) <= crate::gfx::GLASS_REGION_BUDGET {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+            lo
+        };
+        let want = touch.min(budget);
         assert!(
-            cap.x + cap.w + 2.0 * BAND_AIR + 1.0 > track_x(GLASS_TRACK_MAX),
-            "the clearance is {:.0}px where {BAND_AIR} was asked for — a limit that gives away \
-             more strip than the band needs is a cost nobody decided to pay",
-            track_x(GLASS_TRACK_MAX) - (cap.x + cap.w),
+            (GLASS_TRACK_MAX - want).abs() <= 1.0,
+            "the cap is {GLASS_TRACK_MAX} where the binding constraint allows {want} \
+             (touch {touch}, budget {budget})",
         );
+        assert!(budget < touch, "the BUDGET is what binds today — if that flips, so does the note above");
         // the capsule only ever grows RIGHTWARD off a fixed edge, which is what lets one number
         // stand for the band at every point of the unfurl (see `band_region`).
         for e in [0.0, 0.25, 0.5, 0.75, 1.0] {


### PR DESCRIPTION
Unit **B9** — LG App Self Checklist **#2** (overscan frame), **#5** (display/resolution), **#7** (focus states).

## What was wrong

`docs/lg-self-checklist.md` marked #2 a pass on this sentence:

> UI authored at 1920×1080 with `MARGIN_X` 90 (4.7%), **inside** the 5% overscan frame.

That reads as clearance and is the opposite. A 4.7% margin puts content *nearer* the edge than a 5% one, so every screen in the app began six pixels inside the exclusion zone. Nobody had ever measured a screen — the number stood in for the measurement, exactly as the splash's "63% black" did until somebody looked at the panel.

**The vertical half was worse, because it did not exist.** There was no `MARGIN_Y` anywhere in the tree, so nothing bounded the top or bottom of anything.

## The audit — measured, at a real 1920×1080

Every screen was booted in the simulator at `SIM_W=1920 SIM_H=1080` and overlaid with the 5% frame (x 96…1823, y 54…1025). `SIM_W`/`SIM_H` are not optional here: left empty the window fits the display, which on a 1× screen is *half* the authored canvas and makes every margin measurement wrong.

| Screen / element | Where it was | Frame | Out by |
|---|---|---|---|
| **Top tab track** (Home, Library, Search) | y 36 | y ≥ 54 | **18 px** |
| Top tab pills / profile chip | y 44 | y ≥ 54 | 10 px |
| Profile chip, focused capsule | x 82 | x ≥ 96 | 14 px |
| **Library A–Z rail** | x 1834…**1878** | x ≤ 1824 | **32 px** ⚠ worst |
| **Detail pinned compact title** | y 40 band top; **y 22** for a square clearLogo | y ≥ 54 | 14 / **32 px** |
| Library grid last column, item count | x → 1830 | x ≤ 1824 | 6 px |
| Library toolbar chips, grid first column | x 90 | x ≥ 96 | 6 px |
| Home hero logo / meta / synopsis / action row | x 90 | x ≥ 96 | 6 px |
| Detail hero column + right-aligned people column | x 90 → 1830 | 96…1824 | 6 px |
| Person portrait + shelves; Onboard copy column | x 90 | x ≥ 96 | 6 px |
| Search field, headings, result shelves | x 90 | x ≥ 96 | 6 px |
| Chapters strip, every `card_row` shelf | x 90 | x ≥ 96 | 6 px |
| **Player HUD** scrubber / title / bottom tabs | x 90 | x ≥ 96 | 6 px |
| **Player HUD** control discs (`right: 80`) | x → 1840 | x ≤ 1824 | 16 px |
| Track menu + `…` overflow panels (`right: 80`) | x → 1840 | x ≤ 1824 | 16 px |
| Account menu panel | x 80 | x ≥ 96 | 16 px |
| Item menu / Also-available panels (edge clamp) | x 64 worst case | x ≥ 96 | 32 px |
| Stats read-out panel | x 60 | x ≥ 96 | 36 px |
| Home / Library / Person scroll reveal, focused card caption | 24 / 16 / 40 px above the edge | ≥ 54 | 30 / 38 / 14 px |
| **Library last row's caption** (scroll ceiling) | 20 px above the edge | ≥ 54 | 34 px |

Clean on both axes already, and unchanged: Login (QR + code, centred), the profiles picker, the exit alert, About / Track-information / Person-bio alerts (`EDGE_CLEAR` 68, centred), the failure read-out (centred).

**Measured confirmation** (ink extremes against the page ground, dev FPS counter masked — it is `devtools`, compiled out of `RELEASE`):

| Screen | before | after |
|---|---|---|
| Library | x 77…1877, y 36…1060 | x 83…**1823**, y **54**…1078 |
| Search | x 89…1460, y 36…1079 | x 95…1466, y **54**…1079 |

The residual `83` / `95` on the left is the focused card's own drop shadow and the field capsule's antialiased edge — the drawn rects are at exactly 96. The residual bottom is the scrolling shelf's peek, which is by design.

## What changed

**Tokens** (`ui/consts.rs`): `MARGIN_X` 90 → **96**, new `MARGIN_Y` **54**, plus `SAFE: Rect` and `inside_safe(r)` so nothing re-derives the frame and gets a sign wrong.

**Derived instead of respelled** — the shape that let 90 survive was the margin being spelled twice: `player_hud::SB_X`, `search::FIELD.x`, `CTRL_RIGHT`, both player panels' `right: 80`, `account_menu`'s `px`, `stats`' panel x and `CHIP_FRAME` now all read the token.

**Moved:**
- `widgets::TOP_BAR_Y` 44 → `MARGIN_Y + TAB_TRACK_PAD` (62), measured from the band's *outermost* ink so the whole control clears the frame, not just the part you press. `consts::GRID_TOP_Y`, `library::TOOL_Y`/`GRID_TOP` and `search::FIELD.y`/`CONTENT_TOP` follow it by 18px, keeping their stated clearances.
- `CHIP_FRAME.x` → `MARGIN_X + TAB_TRACK_PAD`: it is the **capsule** that lands on the margin, as the tab track's does.
- `detail::COMPACT_TITLE_BOT` is solved from the frame (`MARGIN_Y + COMPACT_H_MAX`), and `TOP_MARGIN` follows it — the tallest logo, not the reserved band, is what has to clear the top.
- Scroll reveals: Home/Library/Person/Search bottom keep-outs are `MARGIN_Y`. Library's scroll **ceiling** moved with its reveal bound — they are a pair, and moving only one left the last row 34px short.
- The two anchored popovers got a **per-axis** keep-out: `space::XL` 64 already cleared `MARGIN_Y` and missed `MARGIN_X` by 32.

**The A–Z rail could not be fixed by moving the rail.** With the grid filling `SCR_W − 2·MARGIN_X` exactly there is no room inside the frame for a 44px control to its right, so the grid now reserves `RAIL_BAND` unconditionally (`LGAP` 48 → 35.2). Unconditional because widening the grid when the rail is absent moves every column between two sections of one library, and a grid that reflows as you change tab is worse than one that is slightly narrower and never moves — the same argument `draw_rail` already makes for top-anchoring rather than centring.

## The test — the invariant, not the literal

`no_required_content_enters_the_safe_area_exclusion_zone` (in `ui/consts.rs`) grades the **composed rect** of every screen and panel — 30 rows, contributed by eight `#[cfg(test)] overscan_rects` probes plus the geometry already public there — against `consts::SAFE`. There is deliberately no `assert_eq!(MARGIN_X, 96.0)`: that passes today and forbids the very fix an audit needs. Each probe is asserted to contribute individually, because a table-wide row floor cannot see one of eight going silent.

**"Required" is doing real work.** A full-bleed backdrop, page ground, scrim, focus glow and a shelf peeking off the bottom edge are all *supposed* to reach the panel edge. Tiles are entered at REST for the same reason: the 1.09 focus pop magnifies ink already inside the frame, strictly contains its resting rect, and does not scale the caption. The compact logo *is* graded at its spill — there the spill is the logo.

Two more tests pin what the table cannot: the Library's last-row reveal (pure arithmetic over the `lo`/`max_y` pair) and the two anchored popovers at their clamp extremes.

## One design cost, stated as a trade

Dropping the top bar 18px grows the tab band's backdrop-blur region by 18 rows of a ~1470px-wide grab, which puts `widgets::GLASS_TRACK_MAX` outside `gfx::GLASS_REGION_BUDGET`. It is now the `min` of its two constraints rather than the "must not touch" rule alone, so the glass material comes off a strip wider than **~672px** instead of ~848. The product's own strip is **572px**, so today's bar is unaffected and one more library still keeps it; two more drop to the flat capsule, which is a designed, shipped alternative rather than a break. If that is judged too tight the lever is the measured budget (`docs/glass-hardware-budget.md` §11 already records the region term as ~4× conservative on the direct source path), not the frame.

While re-deriving it, `GLASS_TRACK_BUDGET_MAX`'s closed form was found to assume a union left edge of 0 — true when the capsule started at x=82, false now that it starts at 96. Fixed, and the test now re-derives both bounds through `gfx::blur_region_union` rather than comparing the constant against the two constants it is the `min` of (which only NaN could fail).

## #7 — focus / selected states

Audited screen by screen; **nothing needed changing**, and the checklist row now says what was looked at rather than what was believed. All three states are distinguishable, and on two surfaces they are visible simultaneously:

- **Tab strip:** idle = bare label, no capsule; focused = bright white capsule with dark ink; selected = subtle plated capsule with white bold ink. Captured with focus on *Movies* while *TV Shows* was selected.
- **`TableView` rows** (Sort menu): idle = plain label; selected = ✓ in the leading column; focused = white pill spanning the row. Captured with focus two rows below the checked one.
- **Cards:** idle vs focused separated by scale, drop shadow *and* the title/caption band only the focused tile draws.

## Two published LG numbers, and which one this is graded against

LG's developer *overscan* guide states a **20px** margin; the checklist item says "overscan frame", which by broadcast convention is **5%**. This is graded against 5%, because a layout that satisfies 5% satisfies 20px and not the other way round. Both are recorded in `MARGIN_X`'s doc and in the checklist note.

## #5 — display / resolution

No change needed and none made. The UI stays authored at logical 1920×1080; the drawable is read back by `surface.rs` (1920×1080 on every device so far, `scale()` = 1.0); the panel's 3840×2160 remains a diagnostic and is not a layout input anywhere in this diff.

## Files

`ui/consts.rs` (tokens + `SAFE`/`inside_safe` + the audit test) · `ui/theme.rs` (`logo::COMPACT_H_MAX` doc) · `ui/widgets.rs` (top bar, chip frame, glass cap) · `ui/library.rs` · `ui/detail.rs` · `ui/home.rs` · `ui/person.rs` · `ui/search/mod.rs` · `ui/search/results.rs` · `ui/player_hud.rs` · `ui/account_menu.rs` · `ui/track_menu.rs` · `ui/more_menu.rs` · `ui/item_menu.rs` · `ui/alt_sources.rs` · `ui/stats.rs` · `ui/onboard.rs` · `docs/lg-self-checklist.md`.

`ui/widgets.rs` is a shared component file rather than a screen: the edits there are `TOP_BAR_Y`, `CHIP_FRAME`, `TAB_SIDE_CLEAR`, the glass cap and one test probe. Naming it explicitly because other lanes are in UI files.

## Verification

- `make check` — **980 passed**, lint clean, both feature configurations type-check (the `RELEASE=1` hook ran on every `.rs` edit).
- Simulator at 1920×1080: Home, Home grid, Library, Detail, Search, account menu, item menu, Login, Onboarding, plus live-driven tab-row / toolbar / Sort-menu focus states.
- `/code-review high` run and its findings applied — including two real bugs it caught that the audit table could not: the Library scroll ceiling and `search::results::BOTTOM_PAD`.

**Not verified on a television.** This lane had no device access, so nothing here is a claim about frame rate or text rasterization. The one thing that wants a device pass is the tab bar's glass at the new region size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GovTtrsD9P7Ld7DnLCMK2G
