### PR TITLE
packaging: the launcher tile learns twelve languages, and the gate learns to see it (LG #41)

### DIFF
--- a/ci/check-package.py
+++ b/ci/check-package.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import flavor  # noqa: E402  — ci/flavor.py, the one descriptor transform
+import flavor  # noqa: E402  — ci/flavor.py, which DECIDES a flavour's id and title
 
 ROOT = Path(__file__).resolve().parent.parent
 FAILURES: list[str] = []

--- a/ci/check-package.py
+++ b/ci/check-package.py
@@ -31,6 +31,70 @@ def png_size(p: Path) -> tuple[int, int]:
     return struct.unpack(">II", p.read_bytes()[16:24])
 
 
+# ---- the localized descriptors ----------------------------------------------------------------
+#
+# `resources/<locale>/appinfo.json` gives the launcher tile and the store listing a title and
+# description per television language. LG documents exactly two properties in one — "In the
+# appinfo.json file for localization, you should fill appDescription and title properties. All
+# other properties are kept the same as the top-level appinfo.json file" — and requires UTF-8
+# WITHOUT BOM for non-Latin text. Both are gated below, and neither is cosmetic:
+#
+#   * a THIRD property in one of these files is `pkg/appinfo.json` duplicated. The version would
+#     then live in a file `ci/bump-version.py`, `release.yml`'s tag guard and every version
+#     assertion in THIS file have never heard of — the failure `ci/flavor.py`'s "PATCH, DO NOT
+#     DUPLICATE" exists to prevent, arrived at from the other direction.
+#   * a BOM makes the file unparseable to a strict JSON reader while looking identical in every
+#     editor and in `git diff`. LG asks for its absence by name, so this is their rule, not ours.
+#
+# This runs against the TRACKED tree in every invocation, including the one that has no package
+# staged — the tracked-only branch below is what `release.yml`'s `prepare` runs before a tag
+# exists, and a translation is exactly the kind of thing that gets edited by hand.
+LOCALE_RE = re.compile(r"^[a-z]{2,3}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$")
+LOCALIZED_KEYS = {"title", "appDescription"}
+
+
+def check_tracked_resources(expect_title: str) -> list:
+    """Grade `pkg/resources/`. `expect_title` is the title these must carry. Returns the locales."""
+    src = ROOT / "pkg" / "resources"
+    if not src.is_dir():
+        check(False, "pkg/resources/ exists — the localized appinfo tree (LG checklist #41)")
+        return []
+    locales = sorted(p.name for p in src.iterdir() if p.is_dir())
+    check(bool(locales), f"pkg/resources/ carries at least one locale (saw {len(locales)})")
+    english = json.loads((ROOT / "pkg/appinfo.json").read_text())["appDescription"]
+    for loc in locales:
+        f = src / loc / "appinfo.json"
+        check(LOCALE_RE.fullmatch(loc) is not None,
+              f"pkg/resources/{loc} is a locale tag (language[-Script][-REGION])")
+        if not f.is_file():
+            check(False, f"pkg/resources/{loc}/appinfo.json exists")
+            continue
+        raw = f.read_bytes()
+        check(not raw.startswith(b"\xef\xbb\xbf"),
+              f"{loc}/appinfo.json is UTF-8 without BOM (LG's stated requirement)")
+        try:
+            d = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            check(False, f"{loc}/appinfo.json is valid UTF-8 JSON ({e})")
+            continue
+        check(set(d) == LOCALIZED_KEYS,
+              f"{loc}/appinfo.json carries exactly {sorted(LOCALIZED_KEYS)} (saw {sorted(d)})")
+        # The title is the BRAND, not a string to translate: TRADEMARKS.md reserves it, and LG's
+        # own listing shows it verbatim. A translated one here would also silently un-badge a
+        # flavoured install's tile, which is why `mkipk.stage_resources` reapplies the suffix
+        # rather than trusting whatever is written in the tree.
+        check(d.get("title") == expect_title,
+              f"{loc}/appinfo.json title is the untranslated brand ({expect_title!r})")
+        desc = d.get("appDescription", "")
+        check(bool(desc.strip()) and desc != english,
+              f"{loc}/appinfo.json appDescription is present and actually translated")
+        # The English sentence is a trademark disclaimer. A translation that transliterated the
+        # mark ("플렉스") would both lose the disclaimer's force and misuse it, and no reader of
+        # this repository is placed to catch that by eye in twelve languages.
+        check("Plex" in desc, f"{loc}/appinfo.json names Plex verbatim (the disclaimer's subject)")
+    return locales
+
+
 def font_family(p: Path) -> str:
     """nameID 1 out of a TrueType `name` table, without fontTools."""
     b = p.read_bytes()
@@ -106,6 +170,10 @@ if len(staged) != 1 and not REQUIRE_PACKAGE:
           f'pkg/appinfo.json id is the stable id ({flavor.STABLE_ID})')
     check(tracked_control.get("Package") == flavor.STABLE_ID,
           f'control Package is the stable id ({flavor.STABLE_ID})')
+    # Tracked too, and editable by hand in twelve languages — so graded on the cheap path as well,
+    # not only after a cross-build has produced a package.
+    print("== localized appinfo (tracked) ==")
+    check_tracked_resources(tracked_appinfo["title"])
     for f in FAILURES:
         print(f"::error::{f}")
     print(f"\n{'all tracked-file assertions passed' if not FAILURES else 'FAILURES above'}")
@@ -198,8 +266,12 @@ for member in sorted(PAYLOAD.rglob("*")) if PAYLOAD.is_dir() else []:
     if not member.is_file():
         continue
     dirty = sorted({m for m in HOSTPATH.findall(member.read_bytes()) if not ALLOWED_PATH.search(m)})
+    # Labelled by PATH inside the payload, not basename: since the localized descriptors landed
+    # there are THIRTEEN files called `appinfo.json` in here (the top level plus one per locale),
+    # and a basename cannot say which one is dirty — nor which twelve of the thirteen identical
+    # `ok` lines to stop reading.
     check(not dirty,
-          f"{member.name} carries no build-machine path"
+          f"{member.relative_to(PAYLOAD)} carries no build-machine path"
           + (f" (saw {dirty[0].decode(errors='replace')})" if dirty else ""))
 
 # ---- the RELEASE is coherent, not just the package -------------------------------------------
@@ -487,6 +559,32 @@ for name, why in NEEDED_LICENCES.items():
     p = ROOT / "licenses" / name
     check(p.exists() and p.stat().st_size > 200, f"licenses/{name} — {why}")
 
+print("== localized appinfo (staged) ==")
+# The tracked half first, against the TRACKED title — `stage_resources` reapplies the flavour
+# suffix, so the file in the tree carries the bare brand name whatever is being packaged.
+tracked_locales = check_tracked_resources(json.loads((ROOT / "pkg/appinfo.json").read_text())["title"])
+staged_res = PAYLOAD / "resources"
+staged_locales = sorted(p.name for p in staged_res.iterdir() if p.is_dir()) if staged_res.is_dir() else []
+# A SET EQUALITY, not a subset. A locale added to the tree and never staged is the ipk-vs-deploy
+# divergence that shipped a fontless package for months, and a locale left in the stage after being
+# deleted from the tree is a translation nobody can find the source of.
+check(staged_locales == tracked_locales,
+      f"the staged locales are exactly the tracked ones ({len(tracked_locales)}: "
+      f"{' '.join(tracked_locales) or 'none'})")
+for loc in staged_locales:
+    staged_loc = json.loads((staged_res / loc / "appinfo.json").read_text(encoding="utf-8"))
+    check(set(staged_loc) == LOCALIZED_KEYS,
+          f"staged {loc}/appinfo.json carries exactly {sorted(LOCALIZED_KEYS)} (saw {sorted(staged_loc)})")
+    # THE flavour assertion, and the only one that can fail for the debug package alone: a localized
+    # descriptor overrides the top-level one, so a tile reading `PlxNative debug` in English and
+    # `PlxNative` in Korean is two installs that cannot be told apart on a Korean set.
+    check(staged_loc.get("title") == appinfo["title"],
+          f'staged {loc}/appinfo.json title == the staged top-level title ({appinfo["title"]!r})')
+    if loc in tracked_locales:
+        tracked_loc = json.loads((ROOT / "pkg/resources" / loc / "appinfo.json").read_text(encoding="utf-8"))
+        check(staged_loc.get("appDescription") == tracked_loc.get("appDescription"),
+              f"staged {loc}/appinfo.json appDescription is the tracked translation, unchanged")
+
 print("== ipk payload ==")
 expected = {
     "plxnative", "appinfo.json", "icon.png", "largeIcon.png", "splash.png",
@@ -513,6 +611,15 @@ if data_tar.exists():
     # TV already has registered. Without it `appinstalld` unpacks nothing.
     check(f'usr/palm/packages/{appinfo["id"]}/packageinfo.json' in paths,
           "payload carries usr/palm/packages/<id>/packageinfo.json")
+    # ...and the localized descriptors, asserted BY PATH. The `expected` set above is basenames, so
+    # it cannot see these at all: `resources/ko/appinfo.json` contributes the basename
+    # `appinfo.json`, which the top-level descriptor already supplies. A resources tree that never
+    # reached the archive would pass every other assertion in this file.
+    missing = [loc for loc in tracked_locales
+               if f'usr/palm/applications/{appinfo["id"]}/resources/{loc}/appinfo.json' not in paths]
+    check(not missing,
+          f"payload carries resources/<locale>/appinfo.json for all {len(tracked_locales)} locales"
+          + (f" (missing {' '.join(missing)})" if missing else ""))
 else:
     print("  SKIP — ipkroot/data.tar.gz absent (run `make ipk` first)")
 

--- a/ci/mkipk.py
+++ b/ci/mkipk.py
@@ -29,6 +29,13 @@ needed, both derived from `pkg/appinfo.json` so the version stays single-sourced
     not the member's, so the error reads like a corrupt archive.
   * `Installed-Size` in the control file — opkg checks it against free space before unpacking.
     Verifiers ignore the literal `1234`, the dummy `ares-package` emits, so it must be real.
+  * `resources/<locale>/appinfo.json` — the LOCALIZED descriptors, staged from the tracked
+    `pkg/resources/` tree. Same reason as the two above: the ipk is the only artifact that carries
+    them, `make deploy` has no use for them (the launcher tile of a developer install is not what
+    LG's QA looks at), and the Makefile's `APP_FILES` is a flat `cp … $(STAGE)/` that cannot
+    express a two-level tree. `stage_resources` is where the FLAVOUR suffix is reapplied — see its
+    docstring for why a flavoured package that skipped that step would lose its badge in every
+    non-English locale.
 
 WHY NOT `ares-package` (LG's own packager, which webosbrew's submission check asks for): it is NOT
 REPRODUCIBLE. Measured with ares-cli 2.4.0 on this payload — two runs of byte-identical input give
@@ -57,6 +64,7 @@ import gzip
 import io
 import json
 import os
+import shutil
 import sys
 import tarfile
 from pathlib import Path
@@ -128,6 +136,61 @@ def write_packageinfo(data: Path, app: dict) -> Path:
     return out
 
 
+def stage_resources(repo: Path, data: Path, app: dict) -> list:
+    """Stage `pkg/resources/<locale>/appinfo.json` into the app dir. Returns the locales staged.
+
+    webOS reads a locale's app title and description from `resources/<locale>/appinfo.json` inside
+    the application directory, merging it over the top-level descriptor when the television's
+    language changes (LG, *App Localization*; webOS OSE, *appinfo.json*). Only `title` and
+    `appDescription` belong in one — `ci/check-package.py` gates that, because a full copy would put
+    the version and the id in a file `ci/bump-version.py` has never heard of.
+
+    THE FLAVOUR SUFFIX IS REAPPLIED HERE, and it is the whole reason this is a transform rather than
+    a copy. `flavor.appinfo_for` renames a flavoured install's tile `PlxNative debug` precisely so
+    two tiles are not a coin flip; a localized descriptor carrying the bare tracked title would
+    override that back to `PlxNative` the moment the set was switched to Korean — restoring the
+    ambiguity in exactly the locale nobody developing this app is looking at.
+
+    The suffix is read off the transform's OUTPUT rather than re-derived from `flavor.FLAVORS`,
+    so there is still only one place that decides what a flavoured title looks like. If that rule
+    ever stops being a suffix, the assertion below fails loudly instead of silently mislabelling.
+    """
+    src = repo / "pkg" / "resources"
+    dest = data / "usr" / "palm" / "applications" / app["id"] / "resources"
+    if dest.exists():
+        # Idempotence: a locale deleted from the tree must not survive in a stale stage, and two
+        # runs of this script must produce the same archive.
+        shutil.rmtree(dest)
+    if not src.is_dir():
+        return []
+    base_title = json.loads((repo / "pkg" / "appinfo.json").read_text())["title"]
+    if not app["title"].startswith(base_title):
+        raise SystemExit(f"flavour title {app['title']!r} is not {base_title!r} plus a suffix — "
+                         "stage_resources can no longer reapply it; see ci/flavor.py")
+    suffix = app["title"][len(base_title):]
+    locales = []
+    for loc_dir in sorted(p for p in src.iterdir() if p.is_dir()):
+        f = loc_dir / "appinfo.json"
+        if not f.is_file():
+            continue
+        loc = json.loads(f.read_text(encoding="utf-8"))
+        if "title" not in loc:
+            # Packaging runs BEFORE ci/check-package.py, so say what is wrong rather than dying in
+            # a KeyError traceback that names neither the file nor the rule.
+            raise SystemExit(f"{f} has no `title` — a localized appinfo.json carries exactly "
+                             "`title` and `appDescription` (ci/check-package.py gates it)")
+        out_dir = dest / loc_dir.name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # Rewritten rather than copied, so the staged bytes are this script's output on every host:
+        # `ensure_ascii=False` keeps the translations readable in the archive, UTF-8 with no BOM is
+        # LG's stated requirement for non-Latin text, and the key order is the input file's.
+        body = json.dumps({**loc, "title": loc["title"] + suffix},
+                          ensure_ascii=False, indent=2) + "\n"
+        (out_dir / "appinfo.json").write_bytes(body.encode("utf-8"))
+        locales.append(loc_dir.name)
+    return locales
+
+
 def control_with_size(ctl: Path, data: Path, flav: str) -> tuple:
     """The control file's text with a real Installed-Size. Returns (text, size in KiB).
 
@@ -184,7 +247,22 @@ def main() -> int:
     # right default for anything that does not know about flavours (release.yml pins it anyway).
     flav = os.environ.get("FLAVOR", "stable")
     app = flavor.appinfo_for(flav)
+    # The staged application directory's NAME is a fourth witness of the id, and the one the
+    # installed app READS at runtime (`paths::app_id`). It is laid down by the Makefile rather than
+    # here, so this is the one place that can see both at once — and a package whose directory and
+    # descriptor disagree is one whose binary would identify as something its own appinfo denies.
+    #
+    # IT RUNS BEFORE ANYTHING IS WRITTEN, and that ordering is load-bearing rather than tidy:
+    # `stage_resources` mkdirs `applications/<id>/resources/…`, so it would CREATE the very
+    # directory this reads and turn "nothing was staged" into a package containing the localized
+    # descriptors and nothing else — exit 0, no binary, no top-level appinfo. Checked at the end,
+    # as it was until the resources tree existed, this guard could no longer see its own subject.
+    staged = sorted((root / "data/usr/palm/applications").glob("*"))
+    if [p.name for p in staged] != [app["id"]]:
+        sys.exit(f"staged applications/{[p.name for p in staged]} does not match appinfo id {app['id']}")
     write_packageinfo(root / "data", app)
+    # Before `control_with_size`, which sums the staged tree for `Installed-Size`.
+    locales = stage_resources(repo, root / "data", app)
     control, kib = control_with_size(root / "ctl" / "control", root / "data", flav)
     write_targz(root / "control.tar.gz", root / "ctl", "",
                 extra={"control": control.encode()})
@@ -195,14 +273,8 @@ def main() -> int:
     write_ar(ipk, [(n, (root / n).read_bytes())
                    for n in ("debian-binary", "control.tar.gz", "data.tar.gz")])
     print(f"wrote {ipk.name} ({ipk.stat().st_size} bytes) — packageinfo.json for {app['id']}, "
-          f"Installed-Size {kib} KiB")
-    # The staged application directory's NAME is a fourth witness of the id, and the one the
-    # installed app READS at runtime (`paths::app_id`). It is laid down by the Makefile rather than
-    # here, so this is the one place that can see both at once — and a package whose directory and
-    # descriptor disagree is one whose binary would identify as something its own appinfo denies.
-    staged = sorted((root / "data/usr/palm/applications").glob("*"))
-    if [p.name for p in staged] != [app["id"]]:
-        sys.exit(f"staged applications/{[p.name for p in staged]} does not match appinfo id {app['id']}")
+          f"Installed-Size {kib} KiB, {len(locales)} localized appinfo "
+          f"({' '.join(locales) or 'none'})")
     return 0
 
 

--- a/ci/mkipk.py
+++ b/ci/mkipk.py
@@ -17,8 +17,12 @@ television. Every id in the archive — the control `Package:`, `packageinfo.jso
 directory is additionally what the installed binary reads to learn which install it is
 (`paths::app_id`). They are asserted equal here and again in `ci/check-package.py`.
 
-This module also SYNTHESISES the two descriptors an ipk must carry and a scp-based dev loop never
-needed, both derived from `pkg/appinfo.json` so the version stays single-sourced:
+This module also writes THREE things the ipk carries and a scp-based dev loop never needed. The
+first two are SYNTHESISED from `pkg/appinfo.json`, so the version stays single-sourced; the third
+is a TRANSFORM of the tracked `pkg/resources/` tree, which carries no version and no id at all —
+and that is a gate rather than a convention (`ci/check-package.py` fails a localized descriptor
+with any third property). Only the first is load-bearing for installation; the third is metadata
+whose absence registers an app perfectly well and costs it its language.
 
   * `usr/palm/packages/<id>/packageinfo.json` — webOS's *package* descriptor, distinct from the
     *application* descriptor `appinfo.json`. `com.webos.appInstallService` reads it to learn which
@@ -70,7 +74,7 @@ import tarfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import flavor  # noqa: E402  — ci/flavor.py, the one descriptor transform
+import flavor  # noqa: E402  — ci/flavor.py, which DECIDES a flavour's id and title
 
 # Any fixed epoch works; 2010-01-01 is safely inside the range old opkg builds accept.
 EPOCH = 1262304000

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1438,8 +1438,11 @@ webosbrew: `github.com/webosbrew/apps-repo` (README, `repogen/`, `content/schema
 `github.com/webosbrew/dev-toolbox-cli`, `github.com/webosbrew/native-toolchain`,
 `github.com/webosbrew/webos-bridge-64to32`, `repo.webosbrew.org/api/apps.json`, `webosbrew.org/devmode`.
 LG: `webostv.developer.lge.com` (appinfo-json reference, app-approval-process, app-ecosystem,
-guides/flutter-for-webos, news 2026-06-30, web-api-and-web-engine), `forum.webostv.developer.lge.com`
+guides/flutter-for-webos, guides/app-localization, news 2026-06-30, web-api-and-web-engine),
+`forum.webostv.developer.lge.com`
 (threads 5262, 10290, 3365, 10880, 27101), `github.com/lg-flutter-webos/ndk`.
+webOS OSE: `webosose.org/docs/guides/development/configuration-files/appinfo-json/` (the
+localization tree, and `type: native` documented on the same page — §12.1).
 Other native webOS apps: `xbmc/xbmc` `docs/README.webOS.md`, `mariotaku/moonlight-tv`,
 `webosbrew/retroarch-cores`, `throwaway96/faultmanager-autoroot`.
 Licences: `gnu.org` LGPL-2.1 + GPL FAQ, `ffmpeg.org/legal.html`, `learn.microsoft.com` font-redistribution FAQ,
@@ -1481,3 +1484,179 @@ What remains is not a licensing question but a taste one: the tomato is a fruit,
 a percentage in a movie app still gestures at Rotten Tomatoes. That is the owner's call, made with
 the facts on the table, and the two shapes a rights holder would actually write about — the seal and
 the popcorn pair — are the ones that are gone.
+
+---
+
+## 12. Localized app metadata — `resources/<locale>/appinfo.json` (2026-08-23)
+
+**LG App Self Checklist #41 (*Change Language*).** Before this, the checklist recorded #41 as
+*"the app is English-only … LG supports locale-specific `appinfo.json` files carrying a translated
+`title` and `appDescription`, which localizes the store listing and launcher tile without touching
+the UI. That is the cheap half and it is not done."* It is done now. **The UI half is not, and
+this section is careful about which half is which**, because the difference is the difference
+between an honest Pass and the marking error LG's own preamble names as a rejection ground.
+
+### 12.1 What LG documents, and what tier that documentation is
+
+Two sources, neither of which is a television.
+
+**LG, *App Localization* — `webostv.developer.lge.com/develop/guides/app-localization`.**
+`develop/*`, so by this repo's own rule it is **web-runtime documentation: context, never proof for
+a native app**. It says:
+
+> To add app information in a specific locale, you need to first create a locale folder under the
+> resources folder and then write an *appinfo.json* file under the correct location.
+
+> In the *appinfo.json* file for localization, you should fill appDescription and title properties.
+
+> When the locale value is changed after adding an *appinfo.json* file corresponding to the locale
+> information, the top-level *appinfo.json* file is loaded into the system memory of webOS TV
+> first, and then other *appinfo.json* files are overridden depending on the locale setting.
+
+> The app ID and version in each localized *appinfo.json* file are the same as those in the
+> top-level *appinfo.json* file.
+
+> If you use non-Latin letters (non-ASCII) in the *appinfo.json* file, you should save the file in
+> UTF-8 without BOM format.
+
+**webOS OSE, *appinfo.json* — `webosose.org/docs/guides/development/configuration-files/appinfo-json/`.**
+The open-source platform's reference for the same descriptor read by the same SAM; still not this
+firmware, but not the web-runtime guide either:
+
+> To provide app information in a specific locale, you need to create locale folders under the
+> `resources` folder, then `appinfo.json` files for each locale under correct locations
+
+with the localized file carrying only `title` and `appDescription`.
+
+**The honest reading.** The mechanism is documented by LG for webOS TV apps and by webOS OSE for
+the descriptor in general — and the OSE page which documents the localization tree is the *same
+page* that documents `type: native` as a valid application type, so the one authority describing
+both does not carve native apps out of it. Neither page, however, says anything about native apps
+and localization *together*, and LG's is under `develop/*`. What reads the file is **SAM**, which
+is app-type agnostic in both descriptions: the descriptor is read to register and display an app,
+not to run its code, and nothing in either page ties the resource lookup to the web runtime. That
+is a good argument, not a measurement.
+
+**So: the path is documented, the native applicability is inferred, and it has NOT been seen on a
+television.** §12.4 is the recipe that would settle it. Until somebody runs it, #41's metadata half
+is *implemented and gated* rather than *verified*, and the checklist should say so.
+
+### 12.2 What ships
+
+`pkg/resources/<language>/appinfo.json`, twelve of them — `de es fr it ja ko nl pl pt ru sv tr` —
+each carrying exactly two properties, UTF-8 without BOM:
+
+```json
+{
+  "title": "PlxNative",
+  "appDescription": "비공식 네이티브 Plex 클라이언트 - Plex와 제휴 관계가 없습니다"
+}
+```
+
+Three decisions in that file are deliberate and each has a gate behind it in `ci/check-package.py`:
+
+* **The title is NOT translated.** `PlxNative` is the brand `TRADEMARKS.md` reserves, and LG's own
+  listing shows it verbatim. Every locale carries the same string.
+* **Exactly two properties.** A third would be `pkg/appinfo.json` duplicated — the version would
+  then live in a file `ci/bump-version.py`, the release tag guard and every version assertion in
+  `ci/check-package.py` have never heard of. This is `ci/flavor.py`'s "PATCH, DO NOT DUPLICATE"
+  arrived at from the other direction, and it is also what LG asks for.
+* **The description is a near-literal translation, not marketing copy per market.** The English
+  sentence is a **trademark disclaimer** (*"not affiliated with Plex"*), so it is graded against
+  the English rather than rewritten — and the mark itself stays Latin `Plex` in every locale, which
+  is asserted, because a transliteration would both weaken the disclaimer and misuse the mark.
+  Chinese is absent for a related reason: `zh` alone does not say Hans or Hant, and guessing a
+  script for a legal sentence is worse than shipping English.
+
+**Only plain language folders are used.** LG says a locale "consists of Language, Script, and
+Country/Region information (e.g., ko-KR, mn-Cy-MN)", and the example tree on that page is an image
+this repo cannot read; the OSE page's worked example is a bare `ko`. Region- and script-qualified
+folders are therefore a device-verification question, and the bare-language form is the one both
+sources agree on. `ci/check-package.py`'s `LOCALE_RE` already accepts the **hyphenated** shapes
+(`ko-KR`, `zh-Hans-CN`, `es-419`), so widening the set that way is adding directories and nothing
+else; a **nested** `resources/ko/KR/appinfo.json` is the one shape that would need a code change,
+and it fails loudly (`pkg/resources/ko/appinfo.json exists`) rather than shipping silently.
+
+### 12.3 How it is packaged and gated
+
+**`ci/mkipk.py::stage_resources` stages the tree; the Makefile does not.** `APP_FILES` is a flat
+`cp … $(STAGE)/` that preserves basenames — it cannot express a two-level tree, and `make deploy`
+has no use for these files anyway (a developer install's tile is not what LG's QA looks at). So
+this joins `packageinfo.json` and the real `Installed-Size` as a thing the ipk carries and a
+scp-based dev loop never needed. **Consequence worth stating: the localized descriptors are in the
+`.ipk` only.** `make deploy` does not put them on the television, so the device recipe below is an
+*install*, not a deploy.
+
+**The flavour suffix is reapplied when staging, and that is the non-obvious half.**
+`ci/flavor.py` renames a flavoured install's tile `PlxNative debug` precisely so two tiles on one
+set are not a coin flip. A localized descriptor carrying the bare tracked title would override that
+back to `PlxNative` the moment the set was switched to Korean — restoring the ambiguity in exactly
+the locale nobody developing this app is looking at. `stage_resources` reads the suffix off
+`flavor.appinfo_for`'s **output** rather than re-deriving it, so there is still one place that
+decides what a flavoured title looks like, and it raises rather than guesses if that rule ever
+stops being a suffix.
+
+**The gates, all in `ci/check-package.py`**, and all verified to FAIL on a planted defect rather
+than assumed to work (seven of them: a third property, a BOM, a non-locale directory name, a
+translated title, a translation that dropped the mark, a tracked locale that never reached the
+archive, and the tree deleted outright):
+
+* the tracked half runs on **both** paths — including the no-package-staged branch that
+  `release.yml`'s `prepare` takes before a tag exists — because a translation is exactly the kind
+  of thing edited by hand between builds;
+* the staged locale set is a **set equality** with the tracked one, so a locale added and never
+  shipped fails as loudly as a stale one left behind. That is the ipk-vs-deploy divergence which
+  shipped a fontless package for months, caught on the way in;
+* the payload is asserted **by path**, `usr/palm/applications/<id>/resources/<loc>/appinfo.json`.
+  The existing `expected` set is basenames and is structurally blind to this: `resources/ko/appinfo.json`
+  contributes the basename `appinfo.json`, which the top-level descriptor already supplies, so a
+  resources tree that never reached the archive would pass every other assertion in the file.
+
+**Reproducibility is unaffected and was re-measured, not assumed.** `stage_resources` writes its
+output through `json.dumps` and `add_tree` normalises identity, mode, mtime and order as before;
+two `mkipk.py` runs over one stage give one sha256 (checked for both flavours).
+
+### 12.4 What only a television can settle
+
+Nothing below is answerable from a desk, and the first item is the one that decides whether this
+section closed anything at all.
+
+1. **Does webOS read `resources/<locale>/appinfo.json` for a NATIVE app?** Install the ipk
+   (`make FLAVOR=debug install` — an *install*, not a deploy: the descriptors are packaged, not
+   scp'd), then switch the television to 한국어 in *Settings → General → Language → Menu Language*
+   and look at the launcher tile and the app's entry in the app list. The tile title should still
+   read `PlxNative debug` (the brand is not translated, and the flavour suffix must survive); the
+   *description*, wherever this firmware surfaces one, should be Korean.
+2. **Does SAM need a restart or a reinstall to notice?** webOS OSE's own documentation warns that
+   SAM may cache the contents of `appinfo.json` at boot. If the tile does not change on a live
+   language switch, re-check after a reboot before concluding the file is unread.
+3. **Bare language vs region-qualified.** If `resources/ko/` is not picked up, try `resources/ko-KR/`
+   and `resources/ko/KR/` before concluding the mechanism does not apply to native apps — the two
+   sources disagree about the folder shape and neither example is machine-readable here. `ko-KR` is
+   a rename of a directory and nothing else; **`ko/KR` needs a code change** — `stage_resources`
+   walks exactly one level — so try it by hand in the staged tree before writing that recursion.
+4. **Does anything on a webOS TV display `appDescription` at all** for a sideloaded app, or is it
+   Content-Store-listing metadata only? If the latter, this closes #41's listing half and nothing
+   visible on the set, which is still the right answer for a submission but is a different claim.
+5. **The app does not crash or misrender on a language change** — which it structurally cannot,
+   see §12.5, but the checklist item asks about behaviour and behaviour is measured.
+
+### 12.5 What is explicitly NOT closed
+
+**The UI is English-only and stays that way in this change.** There are ~203 display literals
+across 45 files, and `Label`/`Button` take a non-owning `*const c_char` — an owned `String` needs a
+lifetime story that a metadata change has no business inventing. The CJK fallback face landed
+separately and is a *precondition* for a translated UI, not the thing itself: glyph coverage means
+Korean renders, not that anything is written in Korean.
+
+**The app is locale-blind, and that is checkable rather than asserted:** `grep -rn
+"setlocale\|LC_ALL\|localeInfo\|X-Plex-Language" rust-modules/src src` finds nothing. It never
+reads the television's language, and it never sends `X-Plex-Language` — so PMS returns metadata in
+the server's default language whatever the set is set to. That last one is the cheapest remaining
+i18n win by a wide margin (one header, and `docs/pms-api.md` already documents it as *"selects the
+language of server-returned strings"*), and it is a `plex/` change rather than a packaging one.
+
+**So the honest mark for #41** is: the metadata half is implemented and gated; the UI half is
+English-only by design; and the whole thing is **unverified on a television** until §12.4 item 1 is
+run. A tester who changes the language and finds an English UI has found a documented decision, not
+a defect — but "Pass" cannot be written next to this row on the strength of this section alone.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1575,7 +1575,11 @@ folders are therefore a device-verification question, and the bare-language form
 sources agree on. `ci/check-package.py`'s `LOCALE_RE` already accepts the **hyphenated** shapes
 (`ko-KR`, `zh-Hans-CN`, `es-419`), so widening the set that way is adding directories and nothing
 else; a **nested** `resources/ko/KR/appinfo.json` is the one shape that would need a code change,
-and it fails loudly (`pkg/resources/ko/appinfo.json exists`) rather than shipping silently.
+and it fails loudly (`pkg/resources/ko/appinfo.json exists`) rather than shipping silently. One
+trap in that regex, since it will be met by whoever widens the set: **LG's own example `mn-Cy-MN`
+is rejected**, and correctly — ISO 15924 script subtags are four letters (`Cyrl`), so `Cy` is not a
+tag any BCP-47 reader would resolve. Copying LG's string verbatim fails the gate with a message
+naming the directory; the fix is `mn-Cyrl-MN`, not a looser regex.
 
 ### 12.3 How it is packaged and gated
 

--- a/pkg/resources/de/appinfo.json
+++ b/pkg/resources/de/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Inoffizieller nativer Plex-Client - steht in keiner Verbindung zu Plex"
+}

--- a/pkg/resources/es/appinfo.json
+++ b/pkg/resources/es/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Cliente Plex nativo no oficial - sin afiliación con Plex"
+}

--- a/pkg/resources/fr/appinfo.json
+++ b/pkg/resources/fr/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Client Plex natif non officiel - non affilié à Plex"
+}

--- a/pkg/resources/it/appinfo.json
+++ b/pkg/resources/it/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Client Plex nativo non ufficiale - non affiliato a Plex"
+}

--- a/pkg/resources/ja/appinfo.json
+++ b/pkg/resources/ja/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "非公式のネイティブ Plex クライアント - Plex とは提携していません"
+}

--- a/pkg/resources/ko/appinfo.json
+++ b/pkg/resources/ko/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "비공식 네이티브 Plex 클라이언트 - Plex와 제휴 관계가 없습니다"
+}

--- a/pkg/resources/nl/appinfo.json
+++ b/pkg/resources/nl/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Onofficiële native Plex-client - niet gelieerd aan Plex"
+}

--- a/pkg/resources/pl/appinfo.json
+++ b/pkg/resources/pl/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Nieoficjalny natywny klient Plex - niepowiązany z Plex"
+}

--- a/pkg/resources/pt/appinfo.json
+++ b/pkg/resources/pt/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Cliente Plex nativo não oficial - sem afiliação com a Plex"
+}

--- a/pkg/resources/ru/appinfo.json
+++ b/pkg/resources/ru/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Неофициальный нативный клиент Plex - не связан с Plex"
+}

--- a/pkg/resources/sv/appinfo.json
+++ b/pkg/resources/sv/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Inofficiell nativ Plex-klient - inte associerad med Plex"
+}

--- a/pkg/resources/tr/appinfo.json
+++ b/pkg/resources/tr/appinfo.json
@@ -1,0 +1,4 @@
+{
+  "title": "PlxNative",
+  "appDescription": "Resmi olmayan yerel Plex istemcisi - Plex ile bağlantısı yoktur"
+}


### PR DESCRIPTION
Closes the metadata half of **LG App Self Checklist #41 (*Change Language*)**: the app now ships
`resources/<locale>/appinfo.json` for twelve languages, staged into the `.ipk`, gated on both
packaging paths, and documented with its sources and its unverified edges.

`docs/distribution.md` §12 is the full account. This body is the short version plus the three
things a reviewer should not have to dig for: what LG actually documents, what this change does
*not* close, and the two claims in the plan that turned out not to match the tree.

## What LG documents, and its tier

Two sources, neither of which is a television.

**LG, *App Localization* — `webostv.developer.lge.com/develop/guides/app-localization`.** This is
`develop/*`, so by this repo's own rule it is **web-runtime documentation: context, never proof for
a native app**. It states:

> To add app information in a specific locale, you need to first create a locale folder under the
> resources folder and then write an *appinfo.json* file under the correct location.

> In the *appinfo.json* file for localization, you should fill appDescription and title properties.

> the top-level *appinfo.json* file is loaded into the system memory of webOS TV first, and then
> other *appinfo.json* files are overridden depending on the locale setting.

> The app ID and version in each localized *appinfo.json* file are the same as those in the
> top-level *appinfo.json* file.

> If you use non-Latin letters (non-ASCII) in the *appinfo.json* file, you should save the file in
> UTF-8 without BOM format.

**webOS OSE, *appinfo.json* — `webosose.org/docs/guides/development/configuration-files/appinfo-json/`.**
The open-source platform's reference for the same descriptor read by the same SAM — not LG's web
runtime guide, and still not this firmware:

> To provide app information in a specific locale, you need to create locale folders under the
> `resources` folder, then `appinfo.json` files for each locale under correct locations

**The honest reading, stated as such in the doc.** The mechanism is documented; the *native*
applicability is **inferred**, not sourced. The strongest thing that can be said for it is that the
OSE page documenting the localization tree is the same page documenting `type: native` as a valid
application type, and that what reads the descriptor is SAM — which registers and displays an app
rather than running its code, and which neither page ties to the web runtime. That is a good
argument, not a measurement. **#41's metadata half is therefore implemented and gated, not
verified**, and `docs/lg-self-checklist.md` should say exactly that (see the note at the bottom).

## What ships

`pkg/resources/{de,es,fr,it,ja,ko,nl,pl,pt,ru,sv,tr}/appinfo.json`, each exactly two properties,
UTF-8 without BOM:

```json
{
  "title": "PlxNative",
  "appDescription": "비공식 네이티브 Plex 클라이언트 - Plex와 제휴 관계가 없습니다"
}
```

Three deliberate decisions, each with a gate behind it:

* **The title is not translated.** `PlxNative` is the brand `TRADEMARKS.md` reserves.
* **Exactly two properties.** A third would duplicate `pkg/appinfo.json` and put the version in a
  file `ci/bump-version.py` and the release tag guard have never heard of — `ci/flavor.py`'s
  "PATCH, DO NOT DUPLICATE" reached from the other side, and also what LG asks for.
* **Near-literal translations.** The English sentence is a **trademark disclaimer**; it is graded
  against the English rather than rewritten per market, and the mark stays Latin `Plex` in every
  locale (asserted — a transliteration would both weaken the disclaimer and misuse the mark).
  Chinese is deliberately absent: `zh` alone says neither Hans nor Hant, and guessing a script for
  a legal sentence is worse than shipping English.

## Packaging

**`ci/mkipk.py::stage_resources` stages the tree, not the Makefile** — `APP_FILES` is a flat
`cp … $(STAGE)/` that cannot express a two-level tree, and `make deploy` has no use for these
(a developer install's tile is not what QA looks at). This joins `packageinfo.json` and the real
`Installed-Size` as something the ipk carries and a scp dev loop never needed. **Consequence: the
localized descriptors are in the `.ipk` only**, so the device recipe below is an *install*.

**The flavour suffix is reapplied when staging** — the non-obvious half. A localized descriptor
carrying the bare tracked title would override `PlxNative debug` back to `PlxNative` the moment the
set was switched to Korean, restoring exactly the two-identical-tiles ambiguity `ci/flavor.py`
exists to prevent, in the locale nobody developing this app is looking at. The suffix is read off
`flavor.appinfo_for`'s **output** rather than re-derived, so one place still decides what a
flavoured title looks like; it raises rather than guesses if that rule stops being a suffix.

**Reproducibility re-measured, not assumed.** Two `mkipk.py` runs over one stage give one sha256,
checked for both flavours (`stage_resources` writes through `json.dumps`; `add_tree` normalises
identity, mode, mtime and order as before).

## Gates, proven to fail

Seven defects were planted and `ci/check-package.py` caught every one: a third property, a BOM, a
non-locale directory name, a translated title, a translation that dropped the mark, a tracked
locale that never reached the archive, and the tree deleted outright.

Three shapes worth calling out:

* the tracked half runs on **both** paths, including the no-package-staged branch `release.yml`'s
  `prepare` takes before a tag exists;
* the staged locale set is a **set equality** with the tracked one — a locale added and never
  shipped fails as loudly as a stale one left behind (the ipk-vs-deploy divergence that shipped a
  fontless package for months, caught on the way in);
* the payload is asserted **by path**. This is the load-bearing one — see the corrections below.

## Two claims in the plan that do not match the tree

Reported per the fleet rule rather than worked around silently.

1. **"`ci/check-package.py` pins the payload file set, so a new `resources/` tree fails the check
   until it is widened" — FALSE.** The assertion is `check(expected <= names, …)` where
   `names = {Path(m.name).name for m in members}` — a **subset** check over **basenames**. A
   `resources/ko/appinfo.json` contributes the basename `appinfo.json`, which the top-level
   descriptor already supplies, so the tree neither fails the check nor is seen by it. Nothing had
   to be widened; something had to be **added**, and it is a full-path assertion, because the
   existing one is structurally blind here — a resources tree that never reached the archive would
   have passed every other assertion in the file.
2. **"it asserts the staged file equals the tracked one byte for byte" — imprecise.** It is
   `appinfo == json.loads((ROOT / "pkg/appinfo.json").read_text())`, a parsed-dict equality, and
   only under `IS_STABLE`. Nothing about it constrains a `resources/` subtree, in either direction.

Neither changes the design; both changed which gate had to be written, which is why they are here.

## Two things the review pass caught, both fixed here

* **`mkipk.py`'s id guard was being defeated by the new staging.** The "staged `applications/<dir>`
  name is a fourth witness of the id" check ran at the *end* of `main()`, and `stage_resources`
  mkdirs `applications/<id>/resources/…` — so it created the very directory the guard reads.
  Reproduced against a wiped stage: the new code wrote a 1808-byte `.ipk` containing
  `packageinfo.json` and twelve locale files, **no binary, no top-level `appinfo.json`**, and
  exited 0, where the pre-change script exited 1. The guard now runs **before anything is
  written**, which is strictly better than where it was (a bad stage no longer produces an ipk at
  all) and is commented as load-bearing ordering rather than tidiness.
* **The build-machine-path scan labelled failures by basename.** There are now *thirteen* files
  called `appinfo.json` in the payload, so a real hit would have named a file nobody could
  identify. It labels by path within the payload now.

## Explicitly NOT closed

**Full UI i18n is out of scope.** ~203 display literals across 45 files, and `Label`/`Button` take
a non-owning `*const c_char` — an owned `String` needs a lifetime story a metadata change has no
business inventing. The CJK fallback face that landed separately is a *precondition* for a
translated UI, not the thing itself: glyph coverage means Korean renders, not that anything is
written in Korean.

**The app is locale-blind, and that is checkable rather than asserted:**
`grep -rn "setlocale\|LC_ALL\|localeInfo\|X-Plex-Language" rust-modules/src src` finds nothing. It
never reads the television's language and never sends `X-Plex-Language`, so PMS returns metadata in
the server's default language whatever the set is set to. That header is the cheapest remaining
i18n win by a wide margin and is a `plex/` change, not a packaging one — out of this unit's files.

## Device recipe that would settle #41

No television was touched by this lane, so none of this is verified. §12.4 has the full list; the
first item is the one that decides whether anything was closed:

1. `make FLAVOR=debug install` — an **install**, not a deploy: the descriptors are packaged, not
   scp'd. Then switch the set to 한국어 in *Settings → General → Language → Menu Language* and look
   at the launcher tile and the app-list entry. The tile should still read `PlxNative debug` (brand
   untranslated, flavour suffix survived); the description, wherever this firmware surfaces one,
   should be Korean.
2. If nothing changes, **reboot before concluding the file is unread** — webOS OSE's own docs warn
   SAM may cache `appinfo.json` at boot.
3. If `resources/ko/` is still not picked up, try `resources/ko/KR/` and `resources/ko-KR/` before
   concluding the mechanism does not apply to native apps. The two sources disagree about the
   folder shape and LG's example tree is an image.
4. Establish whether a webOS TV displays `appDescription` **at all** for a sideloaded app, or
   whether it is Content-Store-listing metadata only. If the latter, this closes #41's listing half
   and nothing visible on the set — still the right answer for a submission, but a different claim.

## One file this unit does not own

`docs/lg-self-checklist.md` §5 still reads *"That is the cheap half and it is not done."* — which
this change makes stale. It is not in this unit's file set (several lanes are closing checklist
rows into it), so it is left alone. Suggested replacement for whoever owns it:

> **#41 — the app is English-only, and the metadata half is now done.** N/A on the item's own
> precondition (no in-app language setting). The launcher tile and store listing carry a translated
> `appDescription` in twelve languages via `resources/<locale>/appinfo.json`, staged into the .ipk
> and gated in `ci/check-package.py` — `docs/distribution.md` §12, including the citation tier and
> the device recipe that would let this row be marked at all. **Unverified on a television**: no
> source in this repo proves webOS reads that path for a *native* app, so it is not markable yet.

## Verification

* `python3 ci/check-package.py` — green on the tracked path and, against a synthetic stage, on the
  packaged path (both flavours). *(No `make ipk`: it cross-compiles FFmpeg, and this lane's rules
  forbid it. The staged path was exercised by hand-staging a payload and running `ci/mkipk.py`
  directly — which is also what made the id-guard defect above reproducible.)*
* Seven planted defects, all caught (above).
* Reproducibility: two `mkipk.py` runs over one stage → identical sha256, per flavour.
* `make check` — 1062 host tests, lint, `ci/flavor.py --selftest`, `tests/test_harness.py`: all
  green.
* **No television.** No ssh, no deploy, no `tests/run.py`.
