### PR TITLE
fix(sentry): the daemon's mapping-cache allocation flag resets per capture

### DIFF
--- a/vendor/sentry-native/webos-arm32.patch
+++ b/vendor/sentry-native/webos-arm32.patch
@@ -459,13 +459,14 @@ diff -ruN a/src/backends/native/sentry_crash_daemon.c b/src/backends/native/sent
              saved_fp = SENTRY__STRIP_PAC(saved_fp);
              return_addr = SENTRY__STRIP_PAC(return_addr);
  
-@@ -1711,9 +1987,13 @@
+@@ -1711,9 +1987,14 @@
  
      char line[1024];
      ctx->module_count = 0;
 +#    if defined(__arm__)
 +    g_vma_count = 0;
 +    g_vma_complete = false;
++    g_vma_alloc_failed = false;
 +    bool vma_ok = true;
 +#    endif
  


### PR DESCRIPTION
Mirrors the one-line fix from sentry[bot]'s comment on getsentry/sentry-native#2053 into `webos-arm32.patch`: `g_vma_alloc_failed` is reset at the top of `capture_modules_from_proc_maps`, so an allocation failure disables the ARM32 frame-pointer walk for that capture only. Patch re-applied and the handler cross-built; no behaviour change on a healthy capture, so no device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)