### PR TITLE
fix(plex): dial a custom access URL's advertised port, not the PMS de…

### DIFF
--- a/rust-modules/src/plex/origin.rs
+++ b/rust-modules/src/plex/origin.rs
@@ -161,6 +161,30 @@ impl Origin {
             .then(|| Origin::new(p.scheme, p.host, p.port.unwrap_or(DEFAULT_PORT)))
     }
 
+    /// Parse an advertised `Connection.uri`, but fall back to the connection's own advertised
+    /// `port` — not [`DEFAULT_PORT`] — when the URI wrote none.
+    ///
+    /// plex.tv's `plex.direct` URIs always spell their port (`…plex.direct:32400`). A **custom
+    /// server-access URL** does not: `https://plex.example.com` carries no port, and its owner is
+    /// serving it on 443 (a reverse proxy), which is exactly what the connection's `port` field
+    /// reports. Parsing such a URI through [`parse`] would apply the 32400 PMS default and dial a
+    /// closed port — the whole server then reads as unreachable, with no relay to fall back on
+    /// (observed live: a share whose only remote was `https://<custom>` at `port:443`, timing out
+    /// at every probe deadline while the official client reached it fine). A URI that DID write a
+    /// port keeps it; `advertised` is the fallback, and only a `port_bad` URI (a written-but-
+    /// garbage port) is still refused.
+    pub fn parse_connection(uri: &str, advertised: i64) -> Option<Origin> {
+        let p = Parts::of(uri);
+        if !p.scheme_known || p.host.is_empty() || p.port_bad {
+            return None;
+        }
+        let port = p
+            .port
+            .or_else(|| dial_port(advertised))
+            .unwrap_or(DEFAULT_PORT);
+        Some(Origin::new(p.scheme, p.host, port))
+    }
+
     pub fn scheme(&self) -> Scheme {
         self.scheme
     }
@@ -328,6 +352,32 @@ fn is_v6_literal(host: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `parse_connection` falls back to the connection's advertised port for a portless custom URL,
+    /// keeps a port the URL DID write, and still refuses a written-but-garbage one. This is the
+    /// contract that stops a custom `https://host` (served on 443) from being dialled on 32400.
+    #[test]
+    fn parse_connection_takes_the_advertised_port_only_when_the_uri_omits_one() {
+        // portless custom URL → the advertised 443, not the 32400 PMS default
+        let o = Origin::parse_connection("https://plex.example.com", 443).unwrap();
+        assert_eq!(
+            (o.scheme(), o.host(), o.port()),
+            (Scheme::Https, "plex.example.com", 443)
+        );
+        assert_eq!(o.base(), "https://plex.example.com:443");
+
+        // a plex.direct URL that spells its port keeps it, ignoring the advertised fallback
+        let o = Origin::parse_connection("https://1-2-3-4.hash.plex.direct:32400", 443).unwrap();
+        assert_eq!(o.port(), 32400);
+
+        // an empty advertised port is not a port — fall through to the PMS default rather than 0
+        let o = Origin::parse_connection("https://plex.example.com", 0).unwrap();
+        assert_eq!(o.port(), DEFAULT_PORT);
+
+        // a written-but-garbage port is still refused (the `port_bad` guard `parse` also honours)
+        assert!(Origin::parse_connection("https://plex.example.com:", 443).is_none());
+        assert!(Origin::parse_connection("ftp://plex.example.com", 443).is_none());
+    }
 
     /// **The bracket invariant, as a round trip.** `host()` is the resolver's node and is bare;
     /// `authority()` is URL serialization and is bracketed; `base()` reproduces the input exactly.

--- a/rust-modules/src/plex/probe.rs
+++ b/rust-modules/src/plex/probe.rs
@@ -304,9 +304,11 @@ fn is_numeric_address(a: &str) -> bool {
 
 /// Every address of `res` that policy allows, best first.
 ///
-/// Each surviving connection yields its advertised `uri` (verbatim — the `plex.direct` hostname's
-/// hash label is the *certificate's* UUID, so it cannot be rebuilt from the machine id, and https to
-/// the bare IP fails validation by design), plus a synthesized `http://{address}:{port}` twin unless
+/// Each surviving connection yields its advertised `uri` — kept as given except that a portless one
+/// takes the connection's advertised port (a custom access URL; see [`Origin::parse_connection`]),
+/// never rebuilt from the address, because the `plex.direct` hostname's hash label is the
+/// *certificate's* UUID and cannot be reconstructed from the machine id, and https to the bare IP
+/// fails validation by design — plus a synthesized `http://{address}:{port}` twin unless
 /// something refuses it: `httpsRequired` (rule 2), a relay connection, or an unmatched private-LAN
 /// connection advertised by somebody else's server. Rule 1 gates only that plaintext twin: the
 /// advertised TLS URI survives because certificate and `machineIdentifier` verification can reject
@@ -345,7 +347,13 @@ pub fn candidates(res: &Resource) -> Vec<Candidate> {
         if !c.uri.is_empty() {
             let scheme = scheme_of(&c.uri, &c.protocol);
             if !(unmatched_shared_lan && scheme == Scheme::Http) {
-                push(c.uri.trim_end_matches('/').to_string(), scheme);
+                // Not `c.uri` verbatim: a custom server-access URL (`https://host`, no port) must
+                // dial the connection's advertised `port` (443, a reverse proxy), not the 32400
+                // PMS default `Origin::parse` would apply — see `Origin::parse_connection`. A
+                // `plex.direct` URI already spells its port, so this is a no-op for it.
+                if let Some(o) = Origin::parse_connection(&c.uri, c.port) {
+                    push(o.base(), scheme);
+                }
             }
         }
         if !c.relay && !unmatched_shared_lan {
@@ -728,6 +736,53 @@ mod tests {
         assert!(
             cs.iter().any(|c| c.url == "http://[2001:db8::1]:32400"),
             "{cs:#?}"
+        );
+    }
+
+    /// A **custom server-access URL** advertises its `uri` WITHOUT a port (`https://<host>`) and its
+    /// real port only in the connection's `port` field (443, a reverse proxy). The candidate must
+    /// dial that 443, not the 32400 PMS default `Origin::parse` applies to a portless URL — the bug
+    /// that made a real share (only remote a custom `https://` at `port:443`, no relay) unreachable
+    /// while the official client reached it. A `plex.direct` URI that already spells its port is
+    /// unaffected.
+    #[test]
+    fn a_custom_access_urls_port_comes_from_the_connection_not_the_pms_default() {
+        // A reporter's shape: one unmatched-LAN plex.direct + one portless custom-access remote.
+        let res: Resource = parse(
+            r#"{"name":"nas-home","clientIdentifier":"cccc3333","provides":"server","owned":false,
+                "sourceTitle":"friend","ownerId":222,"publicAddressMatches":false,
+                "httpsRequired":false,"connections":[
+                  {"protocol":"https","address":"10.9.9.7","port":32400,
+                   "uri":"https://172-20-4-7.hash3.plex.direct:32400","local":true,"relay":false,"IPv6":false},
+                  {"protocol":"https","address":"plex.example.com","port":443,
+                   "uri":"https://plex.example.com","local":false,"relay":false,"IPv6":false}]}"#,
+        );
+        let cs = candidates(&res);
+        let remote: Vec<&Candidate> = cs
+            .iter()
+            .filter(|c| c.location == Location::Remote)
+            .collect();
+        assert!(
+            !remote.is_empty(),
+            "the custom remote must survive: {cs:#?}"
+        );
+        // the https candidate for the custom host dials 443, never 32400
+        let https = remote
+            .iter()
+            .find(|c| c.scheme == Scheme::Https)
+            .expect("a TLS candidate for the custom host");
+        assert_eq!(
+            https.url, "https://plex.example.com:443",
+            "portless custom uri must take the connection's advertised 443, not the 32400 default: {cs:#?}"
+        );
+        assert_eq!(
+            https.origin().expect("custom remote origin parses").port(),
+            443,
+            "{cs:#?}"
+        );
+        assert!(
+            !cs.iter().any(|c| c.url.contains("plex.example.com:32400")),
+            "nothing may dial the custom host on the PMS default port: {cs:#?}"
         );
     }
 


### PR DESCRIPTION
…fault

A shared server can advertise a custom server-access URL — `https://host` with no port — whose real port lives only in the connection's `port` field (443, a reverse proxy). `candidates()` pushed the `uri` verbatim, so `Origin::parse` applied its 32400 PMS default and the probe dialled a closed port: the whole server then read as unreachable, and a server with no relay connection had no fallback to mask it. `plex.direct` URIs are unaffected — they always spell their port.

Add `Origin::parse_connection(uri, advertised)`, which falls back to the connection's advertised port only when the URI omits one (a port the URI wrote still wins, and a written-but-garbage port is still refused), and use it when building the URI candidate. Regression-tested from the real `/api/v2/resources` shape, watched red on the verbatim-uri behaviour first.

---------------------

This PR was made with claude.

It fixes a small issue that excludes some remote servers from being loaded.

Awesome work btw, really like the client :) 