### PR TITLE
fix(ui): draw the tab's libraries at the head of the Library (#68)

### DIFF
--- a/docs/shared-servers.md
+++ b/docs/shared-servers.md
@@ -316,7 +316,12 @@ machine name (`nas-home`) only in the Sources list and the failure read-out.
 - **D — a dead source is absent from Home** (no shelf, no spinner) and its borrowed items leave
   Continue Watching. Its library section draws the shared failure read-out: `Can't reach nas-home`,
   reason `Shared by friend · your own server is fine.`, one action `Try again`, anchored in the
-  content region with only the Source chip beside it — no sort/filter chips, no count, no A–Z rail.
+  content region with only the head of the document beside it — no sort/filter chips, no count, no
+  A–Z rail. **The head is whichever form it would take on a healthy page**, which since issue #68
+  (2026-09-06) is not always the chip: `Layout::failed` takes `head_on()` and `draw_document` asks
+  `lib_row_on()` first, so a dead library that shares its type with another favourite draws the
+  library ROW beside the read-out. That is the useful answer anyway — the row is how you leave the
+  library that cannot be reached — but "only the Source chip" is no longer what you will see.
 - **E — `Shared by friend`** as the last run on the detail hero's date/runtime line, plus an **Also
   available** button in the actions row when a second pinned source holds the film. **OK navigates**
   to that server's page rather than swapping the copy in place, which is also what settles the

--- a/rust-modules/src/browse/mod.rs
+++ b/rust-modules/src/browse/mod.rs
@@ -1589,6 +1589,57 @@ pub(crate) fn source_rows() -> Vec<SrcRow> {
     rows_where(|s| s.kind == kind && s.pinned)
 }
 
+/// **Where library `i` sits among the ones its own tab pill can reach, and how many there are** —
+/// the library chip's `1 of 2`.
+///
+/// It answers the question the chip could not: the chip's PRESENCE already means "there is
+/// somewhere else to go" ([`crate::ui::library`]'s `lib_chip_on`), but that is knowledge the user
+/// has no way to have. Issue #68 is what it costs — two TV libraries behind one *TV Shows* pill,
+/// the second one read as missing rather than as one press away.
+///
+/// **The same predicate and the same order as [`source_rows`]**, deliberately: the number the chip
+/// prints is a promise about the list the chip OPENS, so a position derived any other way could
+/// disagree with the menu it names. Scoped to the type of `i` rather than to `cur()`, because the
+/// chip relabels on the press frame from `view_section()` while the store still holds the old one.
+///
+/// `None` when there is nothing to count — one library of this type, or a section that is not a
+/// favourite of its own type and so draws no row in that list at all. Absence, not `1 of 1`.
+///
+/// Allocation-free, unlike `source_rows`, because the chip's cache KEY is rebuilt every frame on
+/// this screen's hot path and cloning every row's title to count them is not what that key is for.
+pub(crate) fn kind_position(i: usize) -> Option<(usize, usize)> {
+    let kind = section_kind(i)?;
+    if !sections().get(i)?.pinned {
+        return None;
+    }
+    let (mut pos, mut n) = (0usize, 0usize);
+    for (j, s) in sections().iter().enumerate() {
+        if s.kind != kind || !s.pinned {
+            continue;
+        }
+        if j == i {
+            pos = n;
+        }
+        n += 1;
+    }
+    (n > 1).then_some((pos + 1, n))
+}
+
+/// The Sources rows for the type of **section `i`**, rather than of `cur()`.
+///
+/// It exists because [`source_rows`] reads `cur_kind()`, and the Library's head relabels on the
+/// PRESS frame from `view_section()` — so between a tab press and the fade floor the two name
+/// different types. Building the head's row from the current one drew the MOVIE libraries under a
+/// *TV Shows* tab and then never corrected itself: the row's cache is keyed on the viewed section,
+/// which does not move again at the commit, so the stale answer was cached for the life of the
+/// page. Same predicate, same order, same projection — only the scope's source differs.
+pub(crate) fn source_rows_for(i: usize) -> Vec<SrcRow> {
+    let Some(kind) = section_kind(i) else {
+        return Vec::new();
+    };
+    rows_where(|s| s.kind == kind && s.pinned)
+}
+
 /// **Every library, unscoped** — the first-run route's list (`Shared Sources.dc.html` §F).
 ///
 /// The panel's [`source_rows`] is scoped to the browsed TYPE (and to the FAVOURITES of it) because
@@ -3998,6 +4049,179 @@ mod tests {
     /// asserting against whatever `home_pins` the developer happens to have recorded — green here
     /// and red on a clean checkout, the shape `[[make-check-hides-host-assumptions]]` describes.
     /// That hazard is older than this test and is not this landing's to fix; stating the intent is.
+    /// **Issue #68, at the layer that can answer it.** Two TV libraries on one server sit behind
+    /// ONE *TV Shows* pill — `tab_section` opens exactly one of them — so the head of the Library
+    /// is the only place that can say the other exists. This is the fact it says it from.
+    ///
+    /// The three assertions are the three ways the head can be wrong: silence where there is a
+    /// choice, a `1 of 1` where there is not, and a position that disagrees with the panel the
+    /// same head opens.
+    #[test]
+    fn two_libraries_behind_one_pill_have_a_position_and_a_lone_one_has_none() {
+        let _g = crate::testlock::serial();
+        let _t = TempPins::new("kind-position");
+        seed_sources(vec![a_source("mac-mini", "", true)]);
+        append_sections(
+            0,
+            vec![
+                (1, "Movies".into(), SecKind::Movie),
+                (2, "TV Shows".into(), SecKind::Show),
+                (3, "Animes".into(), SecKind::Show),
+            ],
+        );
+        assert_eq!(
+            tab_count(),
+            2,
+            "still two pills — the second TV library folds onto the one it shares a type with, \
+             which is the whole shape of the report"
+        );
+        assert_eq!(
+            kind_position(1),
+            Some((1, 2)),
+            "the TV library the pill opens on is the FIRST of two"
+        );
+        assert_eq!(kind_position(2), Some((2, 2)), "…and the reported one the second");
+        assert_eq!(
+            kind_position(0),
+            None,
+            "the lone film library has no position: `1 of 1` would advertise a choice that does \
+             not exist"
+        );
+
+        // …and the count is a promise about the list the head OPENS, so it follows the same
+        // favourite filter that list does rather than the grant.
+        set_pinned_for_test(2, false);
+        assert_eq!(
+            kind_position(1),
+            None,
+            "with its sibling switched off there is nowhere else to go, and nothing to count"
+        );
+        assert_eq!(
+            source_rows().len(),
+            1,
+            "the panel agrees — one row, so a `1 of 2` beside it would have been a lie"
+        );
+    }
+
+    /// **The scope both the head's row and the panel it opens now share.** Two surfaces read this:
+    /// `ui::library`'s library row, and `build_source_menu` behind the row's `+N`. Neither may use
+    /// [`source_rows`], which is scoped through `cur_kind()` and therefore lags a tab press by the
+    /// length of the page fade — the row drew the MOVIE libraries under a *TV Shows* tab and kept
+    /// them (its cache key is the viewed section, which does not move again at the commit), and the
+    /// popover listed the other type's libraries under a row naming this one.
+    ///
+    /// It is graded here rather than at either call site because both of those go through text
+    /// measurement — `crate::text` is SDL2_ttf, which the host test build does not link — so this
+    /// is the layer at which the shared decision is reachable at all.
+    #[test]
+    fn the_rows_a_head_offers_follow_the_viewed_librarys_type_not_the_current_one() {
+        let _g = crate::testlock::serial();
+        let _t = TempPins::new("rows-for-section");
+        seed_sources(vec![a_source("mac-mini", "", true)]);
+        append_sections(
+            0,
+            vec![
+                (1, "Movies".into(), SecKind::Movie),
+                (2, "Films".into(), SecKind::Movie),
+                (3, "TV Shows".into(), SecKind::Show),
+                (4, "Animes".into(), SecKind::Show),
+            ],
+        );
+        // browsing a FILM library, asking about a SHOW one — the mid-fade shape exactly
+        set_cur(0);
+        let rows = source_rows_for(3);
+        let shows: Vec<&str> = rows.iter().map(|r| r.title.as_str()).collect();
+        assert_eq!(
+            shows,
+            vec!["TV Shows", "Animes"],
+            "the rows must follow the section asked about, not `cur()`"
+        );
+        assert_eq!(
+            source_rows().len(),
+            2,
+            "…while `source_rows` answers for the films, which is what made it the wrong call"
+        );
+
+        // …and it is the FAVOURITE filter too, so the count on a head can never promise a row the
+        // panel behind it will not draw.
+        set_pinned_for_test(3, false); // "Animes"
+        assert_eq!(
+            source_rows_for(3).len(),
+            1,
+            "a switched-off library draws no row here either"
+        );
+        assert_eq!(kind_position(3), None, "…and so there is nothing left to count");
+    }
+
+    /// The position is read of the VIEWED library, which during a page fade is not `cur()` — so it
+    /// may not be derived from the current section's kind the way [`source_rows`] is.
+    #[test]
+    fn a_position_is_scoped_to_the_type_of_the_library_it_is_asked_about() {
+        let _g = crate::testlock::serial();
+        let _t = TempPins::new("kind-position-scope");
+        seed_sources(vec![a_source("mac-mini", "", true)]);
+        append_sections(
+            0,
+            vec![
+                (1, "Movies".into(), SecKind::Movie),
+                (2, "Films".into(), SecKind::Movie),
+                (3, "TV Shows".into(), SecKind::Show),
+            ],
+        );
+        set_cur(2); // browsing the SHOW library…
+        assert_eq!(
+            kind_position(0),
+            Some((1, 2)),
+            "…and a film library still counts against the films, not against what is on screen"
+        );
+        assert_eq!(kind_position(2), None, "the lone show library, from the same call");
+    }
+
+    /// **Issue #68's second half, reported by the person who hit it.** Two TV libraries on one
+    /// server, the pill opening the one they did not want — so they did the obviously right thing
+    /// and switched the other OFF in *Favorite libraries*. Nothing changed: "even if I disable my
+    /// Anime library in the settings, only my Animes library is populated under TV Shows".
+    ///
+    /// They were not wrong about the control. In the shipped build the favourite switch governed
+    /// HOME alone and `tab_section` filtered on `s.kind` and nothing else, so a pill resolved to
+    /// the first library of its type whether or not the user had just told the app to stop showing
+    /// it. That is worse than the missing switcher beside it: the one workaround the UI offered was
+    /// correct, and the app ignored it.
+    #[test]
+    fn switching_a_librarys_favourite_off_repoints_its_tab_at_the_one_that_is_left() {
+        let _g = crate::testlock::serial();
+        let _t = TempPins::new("tab-follows-favourite");
+        seed_sources(vec![a_source("mac-mini", "", true)]);
+        // The reporter's shape, in their order: the pill lands on the library they were trying to
+        // get away from, because table order is the server's and nothing else.
+        append_sections(
+            0,
+            vec![
+                (1, "Animes".into(), SecKind::Show),
+                (2, "TV Shows".into(), SecKind::Show),
+            ],
+        );
+        let shows = tab_of_kind(SecKind::Show).expect("the type has a pill");
+        assert_eq!(
+            tab_section(shows),
+            Some(0),
+            "the pill opens the first of the two — which is the complaint, not the bug"
+        );
+
+        // …and now the switch they actually reached for.
+        set_pinned_for_test(0, false);
+
+        assert_eq!(
+            tab_section(shows),
+            Some(1),
+            "with Animes switched off the TV Shows pill must open the library that is left"
+        );
+        assert!(
+            tab_has_favorite(SecKind::Show),
+            "…and it keeps its pill: one of the two is still on"
+        );
+    }
+
     #[test]
     fn switching_off_a_types_last_favourite_takes_its_pill_and_renumbers_the_rest() {
         let _g = crate::testlock::serial();

--- a/rust-modules/src/browse/mod.rs
+++ b/rust-modules/src/browse/mod.rs
@@ -492,6 +492,10 @@ pub(crate) fn reset() {
         // on the switch. Carrying it would let the previous person's answer govern the next
         // person's Home for the frames before their own record is read (see [`RECORDED`]).
         *addr_of_mut!(RECORDED) = None;
+        // …and the remembered libraries with it, for the same reason and one more: the next
+        // profile's own record is read by `resolve_pins` a moment later, and between the two a
+        // stale entry would resolve a tab to a library this person may not even be granted.
+        *addr_of_mut!(REMEMBERED) = Vec::new();
         // …and the strip's measured shape with it: the next read must count as a move, or a cache
         // keyed on `tabs_gen` would serve the previous account's pills.
         TAB_SHAPE = u32::MAX;
@@ -771,6 +775,16 @@ impl SecKind {
             "movie" => Some(SecKind::Movie),
             "show" => Some(SecKind::Show),
             _ => None,
+        }
+    }
+    /// The wire code this type was parsed FROM — the inverse of [`from_wire`](Self::from_wire), and
+    /// the key `plex::session::TypedLib` records a remembered library under. A `&'static str` from
+    /// this table rather than an enum discriminant, so a reordered `SecKind` cannot silently
+    /// repoint a record an older build wrote.
+    pub(crate) fn wire(self) -> &'static str {
+        match self {
+            SecKind::Movie => "movie",
+            SecKind::Show => "show",
         }
     }
     /// The Sources row's count noun ("187 films") — plural, and the singular-less form the row
@@ -1070,12 +1084,122 @@ pub(crate) fn tab_section(t: usize) -> Option<usize> {
 /// because the last-favourite fallback ([`repoint_cur`]) asks the same question of a kind it did
 /// not get from a strip position.
 fn section_of_kind(kind: SecKind) -> Option<usize> {
+    // **What you were last browsing of this type wins**, when it is still granted and still a
+    // favourite. Without it a tab resolves the same way on every launch — owned first, then TABLE
+    // order, which is the server's order and is not a preference anybody expressed — so a
+    // household with two libraries of one type opens whichever their server happens to list first,
+    // forever. That is the second half of what issue #68 costs: with the switcher drawn it is one
+    // press, but it is one press EVERY launch.
+    //
+    // The fallback below is unchanged and still does all the work on a fresh install, on a profile
+    // that has never browsed this type, and whenever the remembered library has been switched off
+    // or has gone away with its server.
+    if let Some(i) = remembered_section(kind) {
+        return Some(i);
+    }
     sections()
         .iter()
         .enumerate()
         .filter(|(_, s)| s.kind == kind && s.pinned)
         .min_by_key(|(_, s)| !sources().get(s.src).map(|x| x.owned).unwrap_or(false))
         .map(|(i, _)| i)
+}
+
+/// This profile's remembered library for `kind`, resolved against the table as it is NOW.
+///
+/// Every term is a re-check rather than a lookup, because a record outlives the world it was
+/// written in: the server may be gone from the roster, the library may have been deleted, and the
+/// profile may since have switched it off. Any of those falls through to the ordinary resolution
+/// instead of pointing a tab at something that is not there — which is the failure the whole
+/// `section_of_kind` guard exists to prevent, arriving by a new route.
+fn remembered_section(kind: SecKind) -> Option<usize> {
+    let want = unsafe { &*addr_of!(REMEMBERED) }
+        .iter()
+        .find(|(k, _, _)| *k == kind)?;
+    sections().iter().position(|s| {
+        s.kind == kind
+            && s.pinned
+            && s.key == want.2
+            && sources().get(s.src).map(|x| x.machine_id.as_str()) == Some(want.1.as_str())
+    })
+}
+
+/// This profile's remembered libraries, as `(kind, machine id, section key)` — the session record
+/// (`plex::session::LastLibrary`) held in memory so [`section_of_kind`] can consult it without
+/// touching the disk.
+///
+/// **It must not read the session file**, which is why this exists at all rather than a `peek()` at
+/// the point of use: `section_of_kind` runs from `tab_section`, i.e. off the tab strip's own draw
+/// and from `repoint_cur`, and `session::peek` takes the session lock and reads files. That is the
+/// same deadlock `diag::scrub` documents — identities are PUSHED to it for exactly this reason —
+/// and the same per-frame file read. Loaded by [`load_remembered`] on the paths that already hold
+/// the session, and cleared by [`reset`] so it can never outlive the profile that chose it.
+static mut REMEMBERED: Vec<(SecKind, String, i64)> = Vec::new();
+
+/// Take this profile's remembered libraries out of the session and into [`REMEMBERED`].
+///
+/// Called from [`resolve_pins`], which already holds the session for the pins and runs on exactly
+/// the events that can change the answer: a table landing, a profile switch, a favourite flip.
+fn load_remembered(sess: &crate::plex::session::Session, user: &str) {
+    let libs = sess
+        .last_library
+        .iter()
+        .find(|l| l.user == user)
+        .map(|l| {
+            l.libs
+                .iter()
+                .filter_map(|t| {
+                    SecKind::from_wire(&t.kind).map(|k| (k, t.machine_id.clone(), t.key))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    unsafe { *addr_of_mut!(REMEMBERED) = libs };
+}
+
+/// **Remember the library the viewer is now browsing, for its type.**
+///
+/// Called from the COMMIT of a user-driven page change (`ui::library`'s `apply_section`), never
+/// from [`set_cur`] itself. The distinction is the whole correctness of the record: `set_cur` also
+/// runs from [`repoint_cur`], which MOVES the cursor when the library under it stops being a
+/// favourite, and from the boot path before discovery has settled. Recording either would write
+/// down a library the user never chose and then open there next launch — a preference invented by
+/// the app, which is worse than having none.
+pub(crate) fn note_library_choice(i: usize) {
+    let (Some(kind), Some(sec)) = (section_kind(i), sections().get(i)) else {
+        return;
+    };
+    let Some(machine) = sources().get(sec.src).map(|s| s.machine_id.clone()) else {
+        return;
+    };
+    let key = sec.key;
+    // in memory first, so the next `section_of_kind` in this run agrees with what was just chosen
+    // even if the write below is refused (no session on disk yet, a read-only runtime root)
+    unsafe {
+        let mem = &mut *addr_of_mut!(REMEMBERED);
+        mem.retain(|(k, _, _)| *k != kind);
+        if !machine.is_empty() {
+            mem.push((kind, machine.clone(), key));
+        }
+    }
+    let user = crate::plex::session::current_profile_key();
+    let wire = kind.wire();
+    crate::plex::session::update(|cur| {
+        let mut next = cur.clone();
+        let slot = match next.last_library.iter_mut().find(|l| l.user == user) {
+            Some(l) => l,
+            None => {
+                next.last_library
+                    .push(crate::plex::session::LastLibrary {
+                        user: user.clone(),
+                        libs: Vec::new(),
+                    });
+                next.last_library.last_mut()?
+            }
+        };
+        slot.set(wire, &machine, key);
+        Some(next)
+    });
 }
 /// The pill that represents section `s`: the pill of its own TYPE — so browsing a friend's film
 /// library keeps the *Movies* pill lit, which is what "a pill is a type" means for the selection
@@ -1193,7 +1317,12 @@ fn lib_refs() -> Vec<crate::plex::pins::LibRef<'static>> {
 fn resolve_pins() {
     let libs = lib_refs();
     let sess = crate::plex::session::peek();
-    let rec = sess.pins_for(&crate::plex::session::current_profile_key());
+    let user = crate::plex::session::current_profile_key();
+    // The remembered libraries ride along with the pins: this is already the one place holding the
+    // session on exactly the events that can change what a tab should open — a table landing, a
+    // profile switch, a favourite flip — and reading it here keeps `section_of_kind` off the disk.
+    load_remembered(&sess, &user);
+    let rec = sess.pins_for(&user);
     let want = crate::plex::pins::resolve(&libs, rec);
     unsafe {
         // …and keep the record itself, because [`library_pins`] needs it for the sources this

--- a/rust-modules/src/diag/schema.rs
+++ b/rust-modules/src/diag/schema.rs
@@ -147,6 +147,16 @@ pub(crate) enum Feature {
     SubtitleTrack,
     SkipIntro,
     SkipCredits,
+    /// **The viewer moved to another library of the tab they were on** — a pill in the Library's
+    /// head row, or a row of the Sources panel behind it.
+    ///
+    /// It exists because issue #68 could not be answered from this channel at all. A user with two
+    /// TV libraries reported the second one as missing; the switcher was drawn and was never found,
+    /// and nothing here could say whether that was one account or every account with the shape.
+    /// This is the numerator for that question — "does anybody ever leave the library a tab opens
+    /// on" — and it is deliberately the whole of it: the denominator is a topology fact about an
+    /// account, which this channel does not carry and is not the place to start carrying.
+    LibrarySwitch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,6 +187,7 @@ impl Feature {
             Self::SubtitleTrack => "subtitle_track",
             Self::SkipIntro => "skip_intro",
             Self::SkipCredits => "skip_credits",
+            Self::LibrarySwitch => "library_switch",
         }
     }
 }

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -233,6 +233,26 @@ pub struct Session {
     /// search term would sign the device out on every boot.
     #[serde(default, deserialize_with = "de_soft_vec")]
     pub recent_searches: Vec<RecentSearches>,
+    /// **The library each top tab was last browsed in**, per profile — so a household with two TV
+    /// libraries opens the one it actually watches instead of whichever the server happens to list
+    /// first.
+    ///
+    /// Without it the tab resolves through `browse::section_of_kind` every launch: owned first,
+    /// then table order, which is the server's order and is not a preference anybody expressed.
+    /// Issue #68 is what that costs when the two are not the same library — the reporter's own
+    /// libraries opened in the order their server listed them, every time.
+    ///
+    /// **Per TYPE, not one entry per profile.** The Movies tab and the TV Shows tab are two
+    /// choices; one slot would make picking a film library forget which shows you browse.
+    ///
+    /// Keyed by profile like [`RecentSearches`] and [`HomePins`], and by (machine id, section key)
+    /// like [`PinnedLib`] — never a section INDEX, which the table renumbers on every
+    /// `browse::reset` and on a re-discovery that appends.
+    ///
+    /// Soft-parsed for the reason every list in this struct is: one hand-edited entry costs that
+    /// entry, never the credentials.
+    #[serde(default, deserialize_with = "de_soft_vec")]
+    pub last_library: Vec<LastLibrary>,
     /// The install's playback-quality preference. `None` is deliberately distinct from an
     /// explicit value: every session written before this field existed lands there and must keep
     /// the old **Original** behaviour rather than being migrated onto automatic playback.
@@ -533,6 +553,56 @@ impl SourceRef {
 pub struct PinnedLib {
     pub machine_id: String,
     pub key: i64,
+}
+
+/// One profile's last-browsed library per content type. See [`Session::last_library`].
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(default)]
+pub struct LastLibrary {
+    /// The Plex Home user's `uuid`, or **empty for the account owner** with no Home selection —
+    /// the same convention [`HomePins`] and [`RecentSearches`] use, and for the same reason.
+    pub user: String,
+    pub libs: Vec<TypedLib>,
+}
+
+/// One remembered library, tagged with the TYPE whose tab it answers for.
+///
+/// `kind` is the wire's own `Directory.type` string (`movie` / `show`) rather than an enum
+/// discriminant, so a reordered `SecKind` cannot silently repoint an entry written by an older
+/// build — the same reason [`PinnedLib`] keys on a machine id rather than a roster position.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(default)]
+pub struct TypedLib {
+    pub kind: String,
+    pub machine_id: String,
+    pub key: i64,
+}
+
+impl LastLibrary {
+    /// This profile's remembered library for `kind`, as `(machine_id, key)`.
+    pub fn get(&self, kind: &str) -> Option<(&str, i64)> {
+        self.libs
+            .iter()
+            .find(|l| l.kind == kind)
+            .map(|l| (l.machine_id.as_str(), l.key))
+    }
+    /// Record a choice, replacing this type's entry rather than appending beside it.
+    ///
+    /// **A library with no machine id is not recorded and CLEARS the entry**, rather than being
+    /// written with an empty one: `""` would match every nameless library on every server nobody
+    /// has identified yet, which is the trap [`HomePins::answer`] carries its own guard for — and
+    /// here it would point a tab at an arbitrary one of them on the next boot.
+    pub fn set(&mut self, kind: &str, machine_id: &str, key: i64) {
+        self.libs.retain(|l| l.kind != kind);
+        if machine_id.is_empty() {
+            return;
+        }
+        self.libs.push(TypedLib {
+            kind: kind.to_string(),
+            machine_id: machine_id.to_string(),
+            key,
+        });
+    }
 }
 
 /// **One profile's FAVOURITE libraries** — the first-run route's record (`Shared Sources.dc.html`

--- a/rust-modules/src/ui/CLAUDE.md
+++ b/rust-modules/src/ui/CLAUDE.md
@@ -312,7 +312,7 @@ the last item was parked on. `tabs_layout` is CACHED per season set for that: it
 three times a frame (scroll target, capsule spans, draw) and this row has no FPS scene to catch the
 cost — `fps:detail-transition` is a movie and returns before reaching it.
 `library.rs` is the Library, and since 2026-09-05 it is **ONE VERTICAL DOCUMENT** rather than a
-poster wall under a fixed bar: the library chip at the head of the scroll, then the library's own
+poster wall under a fixed bar: the LIBRARY ROW at the head of the scroll, then the library's own
 server-published shelves (`browse::section_hubs`, one `card_row::CardRow` each), then the grid's
 heading with its Sort/Filter row under it, then the 6-across A–Z grid — all in one scroll, with the
 shared tab track the only chrome standing over content. `widgets::nav_scrim` is GONE — Search
@@ -324,10 +324,24 @@ controls in two reachable states. **BACK from anywhere below the head returns to
 document** (a deep shelf is as far from the top as a deep grid row), and a second BACK leaves for
 Home. Every grid coordinate goes through `Layout` — `doc_to_grid`, `row_y`, `visible_rows` — and the
 review rule is that none is derived from `SCROLL` outside it.
-Its chips are a **typed list** (`Chip`) that is now TWO zones sharing one array: the **Source chip**
-— `Library · <name> <handle> ▾`, the handle a `MICRO` run at 62% of the label's own ink — heads the
-DOCUMENT as `Area::LibChip` when the roster or the type holds more than one library, and Sort and
-Filter are the control row under the grid's heading. `control_lo`/`control_n` give that row its own
+**The head of the document is the LIBRARY ROW** (`Area::LibChip`), and it has two forms. With more
+than one favourite library of the type being browsed it draws them all — a pill each, the one you
+are in filled and the rest bare dim text, `+N` into the Sources panel when they outgrow the band —
+which is the tab track's own language one level down, and deliberately so: the hierarchy is *type
+above, libraries nested inside*, and issue #68 is what it costs to leave the nested level undrawn (a
+second TV library reported as MISSING from the app, confirmed present in Settings). One press
+switches; the row publishes what it drew (`LIB_PILLS`) because the cursor, the walk and the
+activation may not measure text — `crate::text` is SDL2_ttf, which the host test build does not
+link. Otherwise it is the older single **Source chip** — `Library · <name> <handle> ▾`, the handle a
+`MICRO` run at 62% of the label's own ink — which stays for the states where this type holds ONE
+favourite library and there is still something to say: a second server on the roster, and a BORROWED
+library, whose owner nothing else on the screen would name. That last clause is only true while the
+borrowed library is ALONE under its pill: `draw_document` asks the row first, so a borrowed library
+with a same-type sibling favourite draws in the row like any other, carrying its owner's handle as
+its own dim run. `Chip` is a **typed list** either way, TWO zones
+sharing one array: `Chip::Source` is the head's identity (and the popover's anchor, so it exists
+even on the frames the row is what is drawn), and Sort and Filter are the control row under the
+grid's heading. `control_lo`/`control_n` give that row its own
 bounds, because a toolbar cursor seated at index 0 stands on a chip the control row does not draw —
 a zone you could walk into with nothing focused. A chip's index is never its identity and every
 activation matches on the enum (a `_` catch-all there is what once made inserting Source at 0 open

--- a/rust-modules/src/ui/detail.rs
+++ b/rust-modules/src/ui/detail.rs
@@ -398,15 +398,10 @@ const HERO_ART: (c_int, c_int) = (1920, 1080);
 
 // Season tabs (header for the episode row)
 const TAB_ROW_H: f32 = CD; // tab pills stand as tall as the hero buttons (one control height)
-/// Season-tab pill padding either side of its label (`Details Screen.dc.html`'s `padding: 0 26px`,
-/// up from 18). A 60px-tall pill wrapped on 18 read as a tall thin lozenge; at 26 the pill is the
-/// capsule the mock draws, and it matches the Play pill's own label inset beside it.
-const TAB_PAD: f32 = 26.0;
-/// Air BETWEEN two tab pills.
-const TAB_GAP: f32 = theme::space::SM;
-/// Per-tab horizontal advance past the label width — derived from the two above rather than spelled,
-/// so a change to the padding can't silently change the gap (which is what 52 vs 18 used to hide).
-const TAB_ADVANCE: f32 = 2.0 * TAB_PAD + TAB_GAP;
+// The pill padding, gap and advance moved to `widgets` when the Library grew a strip of its own —
+// `TabStrip` and `TabPill` were already shared and the numbers that place their pills were not. The
+// aliases keep this file's prose (and its dozen call sites) reading in its own terms.
+use crate::ui::widgets::STRIP_ADVANCE as TAB_ADVANCE;
 const SEASON_SETTLE: f32 = 0.2; // hold a season tab this long (s) before its episodes are fetched
                                 // Episodes: landscape stills + under-card metadata
 const EP_ANIM_MAX: usize = 40; // per-episode pop-spring count (episodes past this don't animate the pop)
@@ -762,7 +757,7 @@ fn hero_btn_rect_at(set: HeroSet, i: c_int, y: f32, cw: HeroWidths) -> Rect {
 /// screen y for the hit-test; the horizontal scroll is applied by the caller, which is why this
 /// takes the layout entry rather than reaching for one.
 fn tab_pill_rect(lay: &TabLay, top: f32) -> Rect {
-    Rect::new(lay.x - TAB_PAD, top, lay.w + 2.0 * TAB_PAD, TAB_ROW_H)
+    crate::ui::widgets::strip_pill_rect(lay, top, TAB_ROW_H)
 }
 
 /// The content-space left edge of strip index `i` at horizontal pitch `pitch` — the ONE x formula
@@ -1747,12 +1742,7 @@ pub(crate) fn move_focus(sym: c_int) {
 
 /// ONE season tab's resolved layout: its index, content-space label x, the tab's CONTENT width
 /// (label plus whatever trailing note it carries) and the label CString.
-struct TabLay {
-    i: usize,
-    x: f32,
-    w: f32,
-    label: CString,
-}
+use crate::ui::widgets::StripLay as TabLay;
 
 /// ONE source of truth for the season-tab strip's layout — the draw pass and the focus/scroll
 /// geometry both walk this, so their x-advance can't drift. A label that can't be a CString
@@ -1826,10 +1816,7 @@ fn tabs_layout(d: &crate::metadata::Detail) -> &'static [TabLay] {
 /// label inside it. The one span function [`TabStrip`] is placed from, so a capsule can only ever
 /// come to rest exactly on a pill.
 fn tab_span(lays: &[TabLay], i: usize) -> Option<(f32, f32)> {
-    lays.get(i).map(|l| {
-        let r = tab_pill_rect(l, 0.0);
-        (r.x, r.w)
-    })
+    crate::ui::widgets::strip_span(lays, i, TAB_ROW_H)
 }
 
 /// content-space geometry (label x, label width) of the focused season tab.

--- a/rust-modules/src/ui/filmography.rs
+++ b/rust-modules/src/ui/filmography.rs
@@ -119,7 +119,10 @@ const PV_SETTLE: f32 = 0.180;
 /// the pill's.
 const STRIP_INSET: f32 = 20.0;
 const TAB_PAD: f32 = 26.0;
-const TAB_GAP: f32 = theme::space::SM;
+/// Air between two department pills — the WIDE rung, shared with the Library's library row (owner
+/// call, and see [`widgets::STRIP_GAP_WIDE`] for why the two rows want it and the season strip does
+/// not).
+const TAB_GAP: f32 = widgets::STRIP_GAP_WIDE;
 
 /// The slide-in. Shares `K_SCROLL` with the page's own scroll for the reason the design system
 /// gives for the tab capsules: two things answering one press at two rates read as two objects.

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -68,7 +68,7 @@ use crate::ui::popover::{Opener, Popover};
 use crate::ui::source_list::{self, Level, SrcAction, Tail};
 use crate::ui::table::{Row, Section, TableView};
 use crate::ui::theme;
-use crate::ui::widgets::{Art, PageGround, Pill, Spinner, StatusKind};
+use crate::ui::widgets::{Art, PageGround, Pill, Spinner, StatusKind, StripLay};
 use crate::ui::xfade::Xfade;
 use crate::ui::{on_axis, Env, Painter, Rect, Spring, View};
 use std::ffi::CString;
@@ -154,7 +154,7 @@ pub(crate) const CONTENT_TOP: f32 = crate::ui::consts::GRID_TOP_Y;
 /// via the nearest `theme::space` rung (`XL` 64). On the panel it reads as a hole: the chip is a
 /// control row like any other, and every other control row in this document is followed by 26px.
 /// The canvas authored this block before the grid's own heading row existed to be consistent with.
-const HEADER_H: f32 = TOOL_H + crate::ui::consts::CARD_DY + crate::ui::consts::TITLE_DY;
+const HEADER_H: f32 = HEAD_H + crate::ui::consts::CARD_DY + crate::ui::consts::TITLE_DY;
 
 /// The grid block's heading band: its title, air, the Sort/Filter control row, air. Everything
 /// above the first grid row and below the last shelf.
@@ -1277,7 +1277,31 @@ fn lib_chip_on() -> bool {
 /// a page transition between two types can have one true and the other false for 70 ms. The head
 /// must be drawn whenever either wants it, or the row appears out of nothing at the fade floor.
 fn head_on() -> bool {
-    lib_chip_on() || lib_row_on()
+    lib_row_on() || lone_borrowed_library() || dead_source_escape()
+}
+
+/// The failure read-out's ESCAPE HATCH. A listing that failed draws no grid, no Sort, no Filter and
+/// no count, and on a multi-source roster the Sources panel is how you leave the source that is not
+/// answering — which is exactly why the read-out itself spends no line telling you the way out
+/// (`Shared Sources.dc.html` D).
+///
+/// It is the one place a count of SERVERS still decides this, and the one place it is the right
+/// question: the head is not offering a choice between libraries here, it is offering a way off a
+/// dead one, and the table this page would have counted libraries in is empty by construction.
+/// With a single source there is nothing to escape TO and the tab strip above is the way out.
+fn dead_source_escape() -> bool {
+    readout() == Readout::Failed && crate::browse::sources().len() > 1
+}
+
+/// The one case a head is still owed when there is NOWHERE ELSE TO GO: the library you are in is
+/// somebody else's, and this is the only surface in the app that says whose.
+///
+/// **It replaced `lib_chip_on()` here, whose first term was a count of SERVERS.** A second server
+/// drew a chip even when the browsed type held one library — a control with a chevron, opening a
+/// panel with a single row, on a page with nothing to switch to. Owner call: hide it when one
+/// library is enabled. Absence, not a control that leads back to itself.
+fn lone_borrowed_library() -> bool {
+    crate::browse::section_sid_is_borrowed(view_section())
 }
 /// The old name, kept while the fixed toolbar's own callers are migrated onto the scroll.
 ///
@@ -1789,18 +1813,42 @@ enum LibPill {
 /// bound exists so the array is fixed, not because eight is a design limit.
 const MAX_LIB_PILLS: usize = 8;
 
-/// One pill's cached strings, measured once per row shape. Same rationale as [`ChipStrs`]: building
-/// `CString`s and re-measuring text every frame on this screen's hot path was a review-confirmed
-/// waste, and this row is drawn on every frame of every library.
+/// The row's height. **[`StatusOverlay::CTRL_H`], the same rung the detail page's season strip
+/// stands at** — these are one control family and the whole point of moving onto the shared strip
+/// is that they are indistinguishable. It is 8px taller than the [`TOOL_H`] chip it replaced, which
+/// the head block absorbs through [`HEADER_H`].
+const HEAD_H: f32 = crate::ui::widgets::StatusOverlay::CTRL_H;
+
+/// The row's label size — **`BODY`, the size the app's other plated strip sets its pills at** (the
+/// Filmography route's department filter). Named once because [`build_lib_row`] MEASURES with it
+/// and `draw_lib_row` DRAWS with it: a disagreement between those two puts a capsule at rest off a
+/// pill, which is the failure `widgets::strip_span`'s own doc exists to prevent.
+const LIB_PILL_SZ: c_int = theme::size::BODY;
+
+/// One pill's cached layout — **[`StripLay`], the shared strip's own**, so the x-advance, the pill
+/// frame and the capsule spans all come from one place. Same caching rationale as [`ChipStrs`]:
+/// building `CString`s and re-measuring text every frame on this screen's hot path was a
+/// review-confirmed waste, and this row draws on every frame of every library.
 struct LibStrs {
     pill: LibPill,
-    label: CString,
-    /// The owner's handle, for a BORROWED library — the one annotation that survived the chip, and
-    /// for the same reason it existed there: nothing else on this screen says whose library this
-    /// is. `None` on your own, and `None` means no run at all.
-    note: Option<CString>,
-    w: f32,
+    lay: StripLay,
 }
+
+/// **The row's two capsules** — the subtle plate marking the library you are IN and the bright one
+/// following the remote — held here exactly as `detail::View::tabs` holds the season strip's.
+///
+/// This row was hand-drawn from the toolbar chip's own primitives until the owner tested it on the
+/// television and named both halves of what was missing: "deselected pill has no background, no
+/// animations like on season". Both are properties of the shared component, not of a colour choice
+/// — a plated pill lays its own ground, and the capsules TRAVEL between pills on the strip's own
+/// springs. Re-forking that motion is what `ui/CLAUDE.md`'s directive above `widgets::TAB_PILL_H`
+/// forbids, and this is what forking it cost.
+static mut LIB_TABS: crate::ui::widgets::TabStrip = crate::ui::widgets::TabStrip::new();
+/// The focused pill's POP and press dip, folded into the capsule that IS that pill's face
+/// ([`TabGround::Plated`]). One `CtlPop<1>` because the strip has ONE focused pill and its capsule
+/// travels between them — there is no second control here to keep animating after focus left it,
+/// which is why the hero row next door needs a spring per control and this does not.
+static mut LIB_POP: crate::ui::widgets::CtlPop<1> = crate::ui::widgets::CtlPop::new();
 
 /// (cache key, pills). The key is the section table's shape plus the library being VIEWED, because
 /// the selected pill is drawn differently and the row relabels on the press frame like every other
@@ -1882,7 +1930,7 @@ fn lib_row() -> &'static [LibStrs] {
 /// is built from and now scoped the same way — off the VIEWED section, see below — so the row and
 /// the panel behind `+N` can never disagree about which libraries exist or what order they are in.
 fn build_lib_row(sel: usize) -> Vec<LibStrs> {
-    let sz = theme::size::LABEL;
+    let sz = LIB_PILL_SZ;
     // **The VIEWED section's type, not the current one.** `source_rows` reads `cur_kind()`, which
     // lags the head by the length of a page fade — and this row's cache key is the viewed section,
     // which does not move again at the commit, so a row built from the old type stays cached for
@@ -1890,67 +1938,67 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
     // drawing them: caught in the simulator, invisible to every host test, because the defect is
     // the ORDER two statics settle in rather than anything either of them says.
     let rows = crate::browse::source_rows_for(sel);
-    let measured: Vec<(usize, CString, Option<CString>, f32)> = rows
+    // A BORROWED library says whose it is in its own label. The chip carried the handle as a dim
+    // MICRO run on its own rung; a shared strip pill has one label and one weight (`TabNote` is a
+    // tick, not text), so the fact moves into the label rather than being dropped — losing the
+    // annotation entirely would take away the only surface in the app that names an owner.
+    let labels: Vec<String> = rows
         .iter()
         .map(|r| {
-            let label = CString::new(r.title.as_str()).unwrap_or_default();
             let handle = crate::browse::handle_of(r.section);
-            let note = (!handle.is_empty())
-                .then(|| CString::new(format!("  {handle}")).unwrap_or_default());
-            let mut w = CHIP_PAD + crate::text::text_width(label.as_ptr(), sz, 1) + CHIP_PAD;
-            if let Some(h) = &note {
-                w += crate::text::text_width(h.as_ptr(), NOTE_SZ, 0);
+            if handle.is_empty() {
+                r.title.clone()
+            } else {
+                format!("{} {handle}", r.title)
             }
-            (r.section, label, note, w)
         })
         .collect();
-    let widths: Vec<f32> = measured.iter().map(|m| m.3).collect();
-    let sel_i = measured.iter().position(|m| m.0 == sel).unwrap_or(0);
+    // Measured through the SHARED layout, so the pill frames, the x-advance and the capsule spans
+    // can never disagree — the contract `TabStrip::update` states for its span function.
+    let all = crate::ui::widgets::strip_layout(labels.iter().cloned(), MARGIN_X, sz);
+    let widths: Vec<f32> = all
+        .iter()
+        .map(|l| crate::ui::widgets::strip_pill_rect(l, 0.0, HEAD_H).w)
+        .collect();
+    let sel_i = rows.iter().position(|r| r.section == sel).unwrap_or(0);
     // The `+N` pill is measured for the worst case it can carry — every library but one — so the
-    // window solve below never has to be re-run against a narrower tail than it reserved for.
-    let more = CString::new(format!("+{}", widths.len().saturating_sub(1))).unwrap_or_default();
-    let more_w = CHIP_PAD + crate::text::text_width(more.as_ptr(), sz, 1) + CHIP_PAD;
-    // **[`MAX_LIB_PILLS`] goes IN, rather than being applied to the answer.** A truncate after the
-    // solve cannot be told apart from a fit: `hidden` is computed from the window, so a row that
-    // the array cut short reported nothing hidden and grew no `+N`, and the libraries past slot 8
-    // were simply gone — including, when the viewer was standing in one of them, the SELECTED one,
-    // which then had no pill, no overflow to reach it through and no chip either. Passing the bound
-    // in is what lets the solve reserve the overflow slot it needs.
+    // window solve never has to be re-run against a narrower tail than it reserved for.
+    let more_label = format!("+{}", widths.len().saturating_sub(1));
+    let more_w = crate::ui::widgets::strip_layout(std::iter::once(more_label), 0.0, sz)
+        .first()
+        .map(|l| crate::ui::widgets::strip_pill_rect(l, 0.0, HEAD_H).w)
+        .unwrap_or(0.0);
     let (start, len) = lib_window(
         &widths,
         sel_i,
         lib_band_w(),
-        theme::space::XS,
+        crate::ui::widgets::STRIP_GAP,
         more_w,
         MAX_LIB_PILLS,
     );
-    let mut out: Vec<LibStrs> = measured
-        .into_iter()
+    // Re-laid from the WINDOW, so the drawn run starts at the margin whatever it starts with —
+    // `strip_layout` is the one place an x-advance is computed, here as at the season strip.
+    let hidden = widths.len() - len;
+    let mut shown: Vec<String> = labels.iter().skip(start).take(len).cloned().collect();
+    let mut pills: Vec<LibPill> = rows
+        .iter()
         .skip(start)
         .take(len)
-        .map(|(section, label, note, w)| LibStrs {
-            pill: LibPill::Library(section),
-            label,
-            note,
-            w,
-        })
+        .map(|r| LibPill::Library(r.section))
         .collect();
-    let hidden = widths.len() - len;
     if hidden > 0 {
-        let label = CString::new(format!("+{hidden}")).unwrap_or_default();
-        let w = CHIP_PAD + crate::text::text_width(label.as_ptr(), sz, 1) + CHIP_PAD;
-        out.push(LibStrs {
-            pill: LibPill::More,
-            label,
-            note: None,
-            w,
-        });
+        shown.push(format!("+{hidden}"));
+        pills.push(LibPill::More);
     }
-    // A BACKSTOP now, not a policy: `lib_window` was given the same bound and reserved the `+N`
-    // slot against it, so there is nothing left here to discard. It stays because the array this
-    // feeds is fixed-length and the draw indexes it — a bound the type system does not carry is
-    // better restated than assumed.
-    debug_assert!(out.len() <= MAX_LIB_PILLS, "the window solve overran the rect array");
+    let lays = crate::ui::widgets::strip_layout(shown.into_iter(), MARGIN_X, sz);
+    let mut out: Vec<LibStrs> = pills
+        .into_iter()
+        .zip(lays)
+        .map(|(pill, lay)| LibStrs { pill, lay })
+        .collect();
+    // A backstop, not the bound: [`lib_window`] is given `MAX_LIB_PILLS` and reserves the `+N`
+    // slot against it, so this can only fire if the two ever disagree.
+    debug_assert!(out.len() <= MAX_LIB_PILLS, "lib_window must bound the row");
     out.truncate(MAX_LIB_PILLS);
     out
 }
@@ -2168,62 +2216,92 @@ fn draw_lib_row(p: Painter, y: f32) -> [Rect; MAX_LIB_PILLS] {
     publish_lib_row(pills, row.len().min(MAX_LIB_PILLS), sel);
     let focused_row = area() == Area::LibChip && !menu_open();
     let cur = lib_f();
+    // **The capsules go down FIRST — they are the pills' ground**, and a label drawn under an
+    // opaque focus capsule is a label nobody can read. `TabStrip::draw`'s own rule.
+    let tabs = unsafe { addr_of!(LIB_TABS).read() };
+    tabs.draw(
+        p,
+        y,
+        HEAD_H,
+        crate::ui::widgets::TabGround::Plated {
+            pop: unsafe { (*addr_of!(LIB_POP)).scale(0) },
+        },
+    );
+    let e = Env::inert();
     let mut rects = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_LIB_PILLS];
-    let mut x = MARGIN_X;
     for (i, cs) in row.iter().enumerate().take(MAX_LIB_PILLS) {
-        rects[i] = lib_pill_at(
-            p,
-            x,
-            y,
-            cs,
-            cs.pill == LibPill::Library(sel),
-            focused_row && i == cur,
-        );
-        x += cs.w + theme::space::XS;
+        let pill = crate::ui::widgets::strip_pill_rect(&cs.lay, y, HEAD_H);
+        rects[i] = pill;
+        // Each pill takes its ink from HOW COVERED it is by the two capsules, which is what makes
+        // the travel read as one control moving rather than two labels swapping colour. `plated()`
+        // is the season strip's own face: **every pill lays its own ground**, so a deselected one
+        // is a plate with dim ink and not bare text on the page — the half the owner named first.
+        let (fm, sm) = tabs.mixes((pill.x, pill.w));
+        let (fm, sm) = if focused_row { (fm, sm) } else { (0.0, sm) };
+        let _ = i;
+        crate::ui::widgets::TabPill::new(cs.lay.label.as_ptr(), LIB_PILL_SZ, pill)
+            .plated()
+            .mix(fm, sm)
+            .draw(&e, p);
     }
+    let _ = cur;
     rects
 }
 
-/// One library pill. **Three faces, and they are the tab bar's own language one level down**:
-/// focused wears the app's Accent like every other control, the library you are IN wears the
-/// filled idle capsule, and the rest are bare dim text with no capsule at all.
-///
-/// That last one is what makes the row read as a row rather than as several buttons — the same
-/// distinction the tab track above draws between the selected type and its neighbours, which is
-/// the point: a user who reads *Movies · TV Shows* up there reads *Films · Animation* down here
-/// the same way, and the nesting explains itself.
-fn lib_pill_at(p: Painter, x: f32, y: f32, cs: &LibStrs, selected: bool, focused: bool) -> Rect {
-    let sz = theme::size::LABEL;
-    let r = Rect::new(x, y, cs.w, TOOL_H);
-    let ink = match (focused, selected) {
-        (true, _) => {
-            p.rrect(r, TOOL_H * 0.5, TOOL_H * 0.5, crate::ui::ACCENT);
-            crate::ui::ACCENT_INK
-        }
-        (false, true) => {
-            p.rrect(r, TOOL_H * 0.5, TOOL_H * 0.5, theme::CONTROL_IDLE_FILL);
-            theme::CONTROL_IDLE_INK
-        }
-        (false, false) => theme::TEXT_SECONDARY,
-    };
-    let ty = crate::text::text_vcenter_y(sz, 1, r.y + r.h * 0.5);
-    let mut tx = r.x + CHIP_PAD;
-    tx += p.text(cs.label.as_ptr(), tx, ty, sz, ink, 0, 1);
-    // the owner annotation, on the VALUE's baseline — the same treatment and the same reason as the
-    // chip's, which this row replaces on accounts that have one
-    if let Some(h) = &cs.note {
-        let hy = crate::text::baseline_y(NOTE_SZ, 0, sz, 1, ty);
-        p.text(
-            h.as_ptr(),
-            tx,
-            hy,
-            NOTE_SZ,
-            theme::with_a(ink, NOTE_INK_A),
-            0,
-            0,
+/// Step the row's capsules and its focus pop. Called from [`update`] every frame, like every other
+/// spring on this screen — the capsules ARE springs, so `gfx`'s integrator reports their motion to
+/// `ui::idle` itself and the present gate cannot freeze a travel mid-flight.
+fn update_lib_row(dt: f32) {
+    // The strip is placed from the SAME span function it was laid out with, which is what stops a
+    // capsule ever coming to rest off a pill (`TabStrip::update`'s contract).
+    let (sel_i, foc_i) = lib_row_marks();
+    let lays: Vec<&StripLay> = lib_row().iter().map(|c| &c.lay).collect();
+    unsafe {
+        (*addr_of_mut!(LIB_TABS)).update(
+            sel_i,
+            foc_i,
+            |i| {
+                lays.get(i)
+                    .map(|l| crate::ui::widgets::strip_pill_rect(l, 0.0, HEAD_H))
+                    .map(|r| (r.x, r.w))
+            },
+            // **`SelMark::Travels`, as the Filmography route's department strip does** — and
+            // NOT the season strip's `Lands`. The season plate lands because selection there only
+            // ever changes with the focus capsule already sitting on the destination, so its
+            // travel would be hidden under a brighter capsule that has already answered. Neither
+            // is true here: the library also changes from the Sources panel (the `+N` pill, with
+            // focus on the overflow rather than on the destination) and from a pointer click, and
+            // in both the plate's path from the old library to the new one is the whole statement
+            // — a filter re-pointing itself, which is the case `Travels` is for.
+            crate::ui::widgets::SelMark::Travels,
+            dt,
+        );
+        // the pop belongs to the focused pill and nothing else; `None` eases it back to rest
+        (*addr_of_mut!(LIB_POP)).step(
+            (foc_i >= 0).then_some(0),
+            dt,
         );
     }
-    r
+}
+
+/// `(selected, focused)` as strip indices — `-1` for "nothing to mark", which is what fades a
+/// capsule out in place rather than leaving it on a stale pill.
+///
+/// The SELECTED pill is the library being viewed; the FOCUSED one exists only while the head holds
+/// focus and no menu is open, so walking away from the row takes the bright capsule with it.
+fn lib_row_marks() -> (c_int, c_int) {
+    let sel = view_section();
+    let selected = lib_pills()
+        .iter()
+        .position(|&p| p == LibPill::Library(sel))
+        .map(|i| i as c_int)
+        .unwrap_or(-1);
+    let focused = if area() == Area::LibChip && !menu_open() && lib_row_on() {
+        lib_f() as c_int
+    } else {
+        -1
+    };
+    (selected, focused)
 }
 
 /// Is the pointer on a library pill? The drawn rects, so an undrawn slot is not hittable.
@@ -2850,6 +2928,12 @@ fn apply_section(i: usize) {
         return;
     }
     crate::browse::set_cur(i);
+    // **Remember it, HERE and not in `set_cur`.** This is the commit of a page change the viewer
+    // asked for — a tab press or a library pill — so it is the only seam that can tell a choice
+    // from `repoint_cur` moving the cursor off a library that stopped being a favourite, or from
+    // the boot path settling before discovery has finished. Recording either would invent a
+    // preference and then open there next launch.
+    crate::browse::note_library_choice(i);
     crate::browse::kick_letters();
     restore_view();
 }
@@ -3045,6 +3129,8 @@ fn rail_jump(i: usize) {
 
 pub(crate) fn update(dt: f32) {
     unsafe { PHASE_MS += dt * 1000.0 };
+    // the head's strip: two capsules and a focus pop, stepped like every other spring here
+    update_lib_row(dt);
 
     // ---- content cross-fade. FIRST, because the commit frame teleports SCROLL/GR/GC and the
     // wanted window below must be computed from the POST-swap scroll (the same reason that window
@@ -4685,7 +4771,7 @@ fn draw_document(pg: Painter, ph: Painter, lay: &Layout, sc: f32) {
         // gap between them by the whole lift, which is what "the pills stay where they were,
         // leaving an awkward amount of spacing" describes. Moving with it holds the gap constant.
         let y = doc_y(lay, 0.0, sc) - head_lift(lay);
-        if on_axis(y, TOOL_H, SCR_H, 0.0) {
+        if on_axis(y, HEAD_H, SCR_H, 0.0) {
             // **Two forms, one block.** The row when this tab holds more than one library, the
             // single chip when it does not — and the head is [`TOOL_H`] tall either way, so
             // nothing in [`Layout`] has to know which one ran.
@@ -5824,12 +5910,15 @@ mod tests {
             "there is nothing to sort, to filter or to count"
         );
 
-        // TWO sources: the Source chip leads the row, and it OUTLIVES the failure
+        // TWO sources, healthy and with no library of this type between them: **no head at all**.
+        // A second SERVER used to be enough to draw one, which put a chevron over a panel with one
+        // row on a page with nowhere to go (owner call: hide it when one library is enabled). The
+        // head is a choice between libraries now, and there is no choice here.
         crate::browse::seed_sources_for_test(2, true);
         assert_eq!(
             chips(),
-            &CHIPS_MANY[..],
-            "two sources put Source at the head of the row"
+            &CHIPS_ONE[..],
+            "a second server is not by itself somewhere else to go"
         );
         crate::browse::seed_sources_for_test(2, false);
         assert_eq!(readout(), Readout::Failed);
@@ -6246,7 +6335,13 @@ mod tests {
         // so a row that lost its grid chips drew no focused chip at all while OK still fired the
         // clamped last one — and RIGHT was dead, because it too measured a stale index against the
         // shorter row. Both now read [`tool_f`], which is why this asserts through it.
-        crate::browse::seed_sources_for_test(2, true);
+        // The long row needs a real HEAD, which since the head became a choice between libraries
+        // means more than one FAVOURITE of the browsed type — not merely a second server, and not
+        // a friend's library of a type we own, which defaults off. Two switched-on libraries on
+        // one source is the smallest fixture that draws one; the grid under them is what makes the
+        // control row drawn at all.
+        crate::browse::seed_pins_for_test(&[true, true]);
+        crate::browse::seed_items_for_test(4);
         assert_eq!(chips(), &CHIPS_MANY[..]);
         unsafe { TOOL_F = 2 };
         assert_eq!(tool_f(), 2, "the user walked to the end of the long row");
@@ -6275,8 +6370,12 @@ mod tests {
         );
 
         // the source answers again: the row grows back and focus returns to the chip the user
-        // actually walked to, rather than having been dumped at 0 while it was away
-        crate::browse::seed_sources_for_test(2, true);
+        // actually walked to, rather than having been dumped at 0 while it was away. The regrown
+        // row has to be the LONG one, so this restores the same two-favourite fixture rather than a
+        // bare pair of sources — which since the head became a choice between libraries draws no
+        // head at all.
+        crate::browse::seed_pins_for_test(&[true, true]);
+        crate::browse::seed_items_for_test(4);
         assert_eq!((tool_f(), focused_chip()), (2, Some(Chip::Filter)));
 
         crate::browse::reset();

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -1819,6 +1819,23 @@ const MAX_LIB_PILLS: usize = 8;
 /// the head block absorbs through [`HEADER_H`].
 const HEAD_H: f32 = crate::ui::widgets::StatusOverlay::CTRL_H;
 
+/// **The row's content origin, placed so the first PILL'S EDGE lands on the safe-area margin.**
+///
+/// `strip_layout` takes the content x and [`widgets::strip_pill_rect`] pads [`STRIP_PAD`] either
+/// side of it, so laying out from `MARGIN_X` puts the pill's LEFT EDGE 26px outside the margin —
+/// which is what the owner caught on the panel: the row hung left of everything under it.
+///
+/// Every other block in this document aligns its BOX to the margin — the shelf headings, the
+/// Sort/Filter chips, the grid's first column — so the pill does too. The season strip on the
+/// detail page keeps the other convention deliberately and is not touched: its neighbours are the
+/// hero buttons, and there the LABELS are what line up.
+const LIB_ROW_X0: f32 = MARGIN_X + crate::ui::widgets::STRIP_PAD;
+
+/// Air BETWEEN two library pills — the WIDE rung, shared with the Filmography route's department
+/// filter. See [`crate::ui::widgets::STRIP_GAP_WIDE`] for why those two rows want it and the season
+/// strip does not.
+const LIB_PILL_GAP: f32 = crate::ui::widgets::STRIP_GAP_WIDE;
+
 /// The row's label size — **`BODY`, the size the app's other plated strip sets its pills at** (the
 /// Filmography route's department filter). Named once because [`build_lib_row`] MEASURES with it
 /// and `draw_lib_row` DRAWS with it: a disagreement between those two puts a capsule at rest off a
@@ -1955,7 +1972,7 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
         .collect();
     // Measured through the SHARED layout, so the pill frames, the x-advance and the capsule spans
     // can never disagree — the contract `TabStrip::update` states for its span function.
-    let all = crate::ui::widgets::strip_layout(labels.iter().cloned(), MARGIN_X, sz);
+    let all = crate::ui::widgets::strip_layout(labels.iter().cloned(), LIB_ROW_X0, sz, LIB_PILL_GAP);
     let widths: Vec<f32> = all
         .iter()
         .map(|l| crate::ui::widgets::strip_pill_rect(l, 0.0, HEAD_H).w)
@@ -1964,7 +1981,7 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
     // The `+N` pill is measured for the worst case it can carry — every library but one — so the
     // window solve never has to be re-run against a narrower tail than it reserved for.
     let more_label = format!("+{}", widths.len().saturating_sub(1));
-    let more_w = crate::ui::widgets::strip_layout(std::iter::once(more_label), 0.0, sz)
+    let more_w = crate::ui::widgets::strip_layout(std::iter::once(more_label), 0.0, sz, LIB_PILL_GAP)
         .first()
         .map(|l| crate::ui::widgets::strip_pill_rect(l, 0.0, HEAD_H).w)
         .unwrap_or(0.0);
@@ -1972,7 +1989,7 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
         &widths,
         sel_i,
         lib_band_w(),
-        crate::ui::widgets::STRIP_GAP,
+        LIB_PILL_GAP,
         more_w,
         MAX_LIB_PILLS,
     );
@@ -1990,7 +2007,7 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
         shown.push(format!("+{hidden}"));
         pills.push(LibPill::More);
     }
-    let lays = crate::ui::widgets::strip_layout(shown.into_iter(), MARGIN_X, sz);
+    let lays = crate::ui::widgets::strip_layout(shown.into_iter(), LIB_ROW_X0, sz, LIB_PILL_GAP);
     let mut out: Vec<LibStrs> = pills
         .into_iter()
         .zip(lays)
@@ -2006,6 +2023,8 @@ fn build_lib_row(sel: usize) -> Vec<LibStrs> {
 /// The band the row is laid out in: the document's own width, stopping where the grid does so the
 /// row cannot run under the A–Z rail's reserved band.
 fn lib_band_w() -> f32 {
+    // In PILL-BOX terms, which is what [`lib_window`] compares against: the run starts at the
+    // margin (see [`LIB_ROW_X0`]) and may not cross the grid's own right edge.
     GRID_R - MARGIN_X
 }
 

--- a/rust-modules/src/ui/library.rs
+++ b/rust-modules/src/ui/library.rs
@@ -4,7 +4,9 @@
 //! Layout, top to bottom (`Library Screens.dc.html` D, since 2026-09-05): the shared top bar
 //! (profile chip leading at the margin + CENTERED tab pills — [`draw_tab_row`] is shared with Home
 //! and Search) is the ONLY chrome standing over content; everything else scrolls. The document is
-//! the library chip at its head, then this library's own server-published shelves
+//! the LIBRARY ROW at its head — every library this tab pill can reach, drawn rather than hidden
+//! behind one chip (issue #68; see the section above [`LibPill`]) — then this library's own
+//! server-published shelves
 //! ([`crate::browse::section_hubs`], one [`card_row::CardRow`] each, in the owner's *Manage →
 //! Libraries* order), then the grid's heading with its Sort/Filter row a rung under it, then the
 //! 6-across grid of [`card_row`] leaf tiles fed by the `browse` paged store. There is no fixed
@@ -178,7 +180,8 @@ const GRID_HEAD: f32 =
 /// reason: `want`, row culling, `cell_at`, `rail_jump`, `page`, `save_view`/`restore_view`.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) struct Layout {
-    /// Is the library chip drawn at the head?
+    /// Is the head drawn at all — either form? [`head_on`]; the block is [`TOOL_H`] tall whichever
+    /// one runs, which is why this stays one bool.
     chip: bool,
     /// How many shelves the COMMITTED set holds. A staged landing is not in here — that is the
     /// whole point of `section_hubs`' publication axis.
@@ -441,9 +444,11 @@ enum Area {
     /// the geometry admits; DOWN leaves the band exactly as it does from [`Area::Tabs`].
     Chip,
     Tabs,
-    /// The **library chip** at the head of the scroll — `Library · <name> <handle> ▾`. It is the
-    /// first thing in the document now rather than a fixed toolbar entry, so it scrolls away with
-    /// everything else and is reachable by walking UP to the top of the page.
+    /// The **head of the document** — the library ROW when this tab holds more than one library
+    /// ([`lib_row_on`], a run walked with LEFT/RIGHT), the single `Library · <name> <handle> ▾`
+    /// chip when it does not. It is the first thing in the document now rather than a fixed
+    /// toolbar entry, so it scrolls away with everything else and is reachable by walking UP to the
+    /// top of the page. The name predates the row and is kept: it is still one zone.
     LibChip,
     /// A tile on one of the library's own published shelves. `SHELF_F` is which shelf, `SHELF_C`
     /// the column inside it.
@@ -1266,9 +1271,22 @@ fn lib_chip_on() -> bool {
     // it is.
     crate::browse::section_sid_is_borrowed(crate::browse::cur())
 }
+/// Is the head of the document drawn at all — either form? **The row's own predicate is asked
+/// separately**, because the two are not the same question mid-fade: [`lib_chip_on`]'s first terms
+/// are about the ROSTER and its last reads `cur()`, while [`lib_row_on`] reads the VIEW section, so
+/// a page transition between two types can have one true and the other false for 70 ms. The head
+/// must be drawn whenever either wants it, or the row appears out of nothing at the fade floor.
+fn head_on() -> bool {
+    lib_chip_on() || lib_row_on()
+}
 /// The old name, kept while the fixed toolbar's own callers are migrated onto the scroll.
+///
+/// **[`head_on`], not [`lib_chip_on`]**: this decides whether `Chip::Source` is in [`chips`] at
+/// all, and that identity is what the Sources popover is ANCHORED to. The row form opens the same
+/// panel through `+N` and through an empty overflow, so the chip has to exist as an identity even
+/// on the frames where it is not the thing drawn.
 fn source_chip_on() -> bool {
-    lib_chip_on()
+    head_on()
 }
 
 /// **The ordered list of zones that are actually DRAWN this frame**, top to bottom — the
@@ -1370,6 +1388,9 @@ fn enter_zone(lay: &Layout, to: Area, dir: i32) {
             Area::Tabs => set_tab_p(own_pill_id()),
             // the control row's FIRST stop, which is not index 0 when the head chip shares the array
             Area::Toolbar => TOOL_F = control_lo(chips()),
+            // the head's row seats on the library you are IN, never at 0 — walking into it should
+            // land where you already are, the same rule `set_tab_p(own_pill_id())` follows above
+            Area::LibChip => seat_lib_cursor(),
             Area::Shelf => {
                 // walking DOWN into the run of shelves lands on the first, walking UP on the last
                 SHELF_F = if dir > 0 {
@@ -1529,13 +1550,13 @@ fn layout_with(band: impl Fn(usize) -> f32) -> Layout {
     if read == Readout::Failed {
         return Layout {
             pitch,
-            ..Layout::failed(lib_chip_on(), shelves)
+            ..Layout::failed(head_on(), shelves)
         };
     }
     Layout {
         pitch,
         ..Layout::new(
-        lib_chip_on(),
+        head_on(),
         shelves,
         n_rows(),
         // the grid's heading and its Sort/Filter row draw over a grid that has items — the
@@ -1700,6 +1721,12 @@ fn chip_menu(c: Chip) -> Menu {
 }
 
 /// A chip's two runs: the dim static NAME and the bright VALUE that carries the information.
+///
+/// **The library chip's `Library` prefix stays a bare word**, and a `Library 1 of 2` was tried and
+/// dropped rather than never considered. It cannot fire: the chip form is only drawn when
+/// [`crate::browse::kind_position`] is `None`, i.e. exactly when there is no count to print — the
+/// row above has taken every case where there was one. A prefix that says "1 of 1" or a branch that
+/// can only take its `else` is worse than the plain word.
 fn chip_value(c: Chip) -> (&'static str, String) {
     match c {
         // the chip names the LIBRARY (the owner rides beside it as a dim micro run — see
@@ -1712,6 +1739,498 @@ fn chip_value(c: Chip) -> (&'static str, String) {
         Chip::Sort => ("Sort", view_sort_label().to_string()),
         Chip::Filter => ("Filter", view_filter_value()),
     }
+}
+
+// ---- the library ROW: the tab's libraries drawn, rather than hidden behind one chip -----------
+//
+// **The head of the document draws every library the current tab pill can reach**, the one you are
+// in filled and the rest plain, in the same order the Sources panel lists them. It replaces the
+// single `Library · <name> ▾` chip whenever there is more than one to show.
+//
+// This is issue #68, and the report is worth keeping in front of whoever changes it next: two TV
+// libraries on one server, one *TV Shows* pill, and the second library read as **missing from the
+// application** — confirmed present in Settings, which is exactly the surface that proves the
+// switcher was never found. Nothing was broken. `browse::tab_section` resolves a pill to ONE
+// library and the chip was drawn, correctly, right where it is now.
+//
+// So the fix is not a louder chip. **A control that names one thing cannot say that a set exists**
+// — a chevron is an affordance for somebody who already suspects there is something behind it, and
+// a dim `1 of 2` beside the name is a footnote at ten feet. The hierarchy the app already has is
+// *type above, libraries nested inside* (the owner's own words on the issue); drawing the nested
+// level makes it a hierarchy the user can SEE instead of one they have to be told about. The
+// second library's NAME on screen is the whole fix, and no amount of decorating the chip is a
+// substitute for it.
+//
+// **The chip is not gone**, and it keeps every state where this type holds ONE favourite library
+// and there is still something to say: a second server on the roster, or a BORROWED library, whose
+// owner nothing else on the screen would name. The row is not the narrower case of that — it wins
+// whenever the type has a second favourite, borrowed or not (`draw_document` asks [`lib_row_on`]
+// first), and it carries the handle itself, as a dim run on the pill it belongs to. So the chip is
+// the only owner-naming surface exactly while a borrowed library is ALONE under its pill.
+//
+// The bound the owner raised on the issue — "some users can have quite a few of them" — is why the
+// row overflows into `+N` rather than growing: this level is scoped to ONE type, so the realistic
+// count is two or three, and the panel behind `+N` is the same list that was behind the chip.
+
+/// One pill in the head's library row.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LibPill {
+    /// A library of the browsed type, by its ABSOLUTE section index — never a row position. The
+    /// row is rebuilt whenever discovery lands or a favourite is switched, and a stored position
+    /// would name a different library across either.
+    Library(usize),
+    /// The overflow, which opens the same Sources panel the single chip does. It carries no count:
+    /// the label already says the number and the panel it opens lists every row regardless.
+    More,
+}
+
+/// The most pills the row can hold, INCLUDING the `+N` — the rect array's length, so a pointer can
+/// never be tested against a slot the draw does not own. Realistic counts are two or three; the
+/// bound exists so the array is fixed, not because eight is a design limit.
+const MAX_LIB_PILLS: usize = 8;
+
+/// One pill's cached strings, measured once per row shape. Same rationale as [`ChipStrs`]: building
+/// `CString`s and re-measuring text every frame on this screen's hot path was a review-confirmed
+/// waste, and this row is drawn on every frame of every library.
+struct LibStrs {
+    pill: LibPill,
+    label: CString,
+    /// The owner's handle, for a BORROWED library — the one annotation that survived the chip, and
+    /// for the same reason it existed there: nothing else on this screen says whose library this
+    /// is. `None` on your own, and `None` means no run at all.
+    note: Option<CString>,
+    w: f32,
+}
+
+/// (cache key, pills). The key is the section table's shape plus the library being VIEWED, because
+/// the selected pill is drawn differently and the row relabels on the press frame like every other
+/// chrome reader here.
+static mut LIB_CACHE: Option<(String, Vec<LibStrs>)> = None;
+/// Where each pill was DRAWN this frame, for the pointer. Parked (`w = 0`) for every slot the row
+/// does not use, so the scan's geometry is the authority on what is hittable — the same contract
+/// `TOOL_RECTS` keeps.
+///
+/// **That contract is "reset EVERY frame, fill only when the row draws", and it has to be the whole
+/// of it.** [`draw_document`] builds these into a zeroed local and writes them back unconditionally
+/// on its way out, exactly as it does `tool_rects` — because the head is INSIDE the scroll, and a
+/// rect only zeroed on the frames the head chose the chip form is not zeroed on the frames the head
+/// is off screen at all. Left to go stale it is a GHOST: scroll one header's height past the head
+/// and the grid moves up into the band the pills were drawn in, where [`lib_pill_hit`] — tested
+/// ahead of the shelves and the grid in both [`pointer_focus`] and [`click`] — still answers for
+/// them. A tap on a poster there switched library instead of opening the item.
+static mut LIB_RECTS: [Rect; MAX_LIB_PILLS] = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_LIB_PILLS];
+/// **What the row DREW this frame, as plain data** — recorded beside the rects and read by the
+/// cursor, the walk and the activation.
+///
+/// It exists because those three may not MEASURE TEXT. Which libraries fit is a question about
+/// glyph widths, so the answer can only come from the draw — but `crate::text` is SDL2_ttf, which
+/// the host test build does not link at all: it is dead-stripped there today precisely because no
+/// test reaches it, and a focus walk that measured a string would drag the whole font stack into
+/// `cargo test --lib` and fail to link. So the draw publishes its answer and everything else reads
+/// it, which is also the `TOOL_RECTS` contract one level up.
+///
+/// Empty before the first draw of a row — `lib_row_activate` opens the panel there, which is the
+/// right fallback and the chip's own behaviour.
+///
+/// **Deliberately NOT parked per frame the way [`LIB_RECTS`] is**, and the asymmetry is the point:
+/// a rect is a claim about WHERE something is on the screen this frame, which stops being true the
+/// moment the head scrolls away, while these are the row's CONTENT, which does not. [`enter_zone`]
+/// seats the cursor from them on the frame focus arrives — before any draw has put the head back on
+/// screen — so zeroing them with the geometry would seat every walk into the zone at index 0 and
+/// light the wrong pill. Everything that reads them either guards on [`lib_row_on`] (the walk, OK)
+/// or on a live rect (the pointer), so a row that is off screen is inert rather than wrong.
+static mut LIB_PILLS: [LibPill; MAX_LIB_PILLS] = [LibPill::More; MAX_LIB_PILLS];
+static mut LIB_N: usize = 0;
+/// The library the cursor was last seated against — `usize::MAX` before any row is published, which
+/// is not a section index, so the first row seats.
+///
+/// It exists because **a switch the row did not make still moves the row**: picking a library from
+/// the Sources panel behind `+N` (or from the panel the chip opens) changes `view_section()` while
+/// focus never leaves [`Area::LibChip`], so [`enter_zone`] — the only other place the cursor is
+/// derived from the selection — never runs. The row is rebuilt under a cursor that was left on the
+/// `+N` pill, and the accent then sits on a pill that has nothing to do with the library the user
+/// just picked. Pressing OK there acts on that stranger. The same thing happens one step smaller
+/// when the row OVERFLOWS and a press slides the window: the newly selected library is drawn, at a
+/// different index than the one it was pressed at.
+static mut LIB_SEEN: usize = usize::MAX;
+/// The row's cursor, as a DRAWN index. Clamped at every read by [`lib_f`], exactly as `TOOL_F` is
+/// by [`tool_f`] and for the same reason: the row's length moves with no input at all when a
+/// library lands or a favourite is switched off.
+static mut LIB_C: usize = 0;
+
+/// **Does the head draw the ROW rather than the single chip?** More than one favourite library of
+/// the type being VIEWED — the same question [`crate::browse::kind_position`] answers, asked of the
+/// view section so the head cannot change form halfway through a page fade.
+fn lib_row_on() -> bool {
+    crate::browse::kind_position(view_section()).is_some()
+}
+
+/// The row, measured. Rebuilt only when the table's shape or the viewed library changes.
+fn lib_row() -> &'static [LibStrs] {
+    let sel = view_section();
+    let key = format!("{}\u{1}{}", crate::browse::source_list_gen(), sel);
+    let cache = unsafe { &mut *addr_of_mut!(LIB_CACHE) };
+    if cache.as_ref().map(|(k, _)| *k != key).unwrap_or(true) {
+        *cache = Some((key, build_lib_row(sel)));
+    }
+    &cache.as_ref().unwrap().1
+}
+
+/// Measure every library of the viewed type, then fit as many as the band holds.
+///
+/// **The rows come from [`crate::browse::source_rows_for`]**, the same projection the Sources panel
+/// is built from and now scoped the same way — off the VIEWED section, see below — so the row and
+/// the panel behind `+N` can never disagree about which libraries exist or what order they are in.
+fn build_lib_row(sel: usize) -> Vec<LibStrs> {
+    let sz = theme::size::LABEL;
+    // **The VIEWED section's type, not the current one.** `source_rows` reads `cur_kind()`, which
+    // lags the head by the length of a page fade — and this row's cache key is the viewed section,
+    // which does not move again at the commit, so a row built from the old type stays cached for
+    // the life of the page. It drew the two MOVIE libraries under a *TV Shows* tab, and went on
+    // drawing them: caught in the simulator, invisible to every host test, because the defect is
+    // the ORDER two statics settle in rather than anything either of them says.
+    let rows = crate::browse::source_rows_for(sel);
+    let measured: Vec<(usize, CString, Option<CString>, f32)> = rows
+        .iter()
+        .map(|r| {
+            let label = CString::new(r.title.as_str()).unwrap_or_default();
+            let handle = crate::browse::handle_of(r.section);
+            let note = (!handle.is_empty())
+                .then(|| CString::new(format!("  {handle}")).unwrap_or_default());
+            let mut w = CHIP_PAD + crate::text::text_width(label.as_ptr(), sz, 1) + CHIP_PAD;
+            if let Some(h) = &note {
+                w += crate::text::text_width(h.as_ptr(), NOTE_SZ, 0);
+            }
+            (r.section, label, note, w)
+        })
+        .collect();
+    let widths: Vec<f32> = measured.iter().map(|m| m.3).collect();
+    let sel_i = measured.iter().position(|m| m.0 == sel).unwrap_or(0);
+    // The `+N` pill is measured for the worst case it can carry — every library but one — so the
+    // window solve below never has to be re-run against a narrower tail than it reserved for.
+    let more = CString::new(format!("+{}", widths.len().saturating_sub(1))).unwrap_or_default();
+    let more_w = CHIP_PAD + crate::text::text_width(more.as_ptr(), sz, 1) + CHIP_PAD;
+    // **[`MAX_LIB_PILLS`] goes IN, rather than being applied to the answer.** A truncate after the
+    // solve cannot be told apart from a fit: `hidden` is computed from the window, so a row that
+    // the array cut short reported nothing hidden and grew no `+N`, and the libraries past slot 8
+    // were simply gone — including, when the viewer was standing in one of them, the SELECTED one,
+    // which then had no pill, no overflow to reach it through and no chip either. Passing the bound
+    // in is what lets the solve reserve the overflow slot it needs.
+    let (start, len) = lib_window(
+        &widths,
+        sel_i,
+        lib_band_w(),
+        theme::space::XS,
+        more_w,
+        MAX_LIB_PILLS,
+    );
+    let mut out: Vec<LibStrs> = measured
+        .into_iter()
+        .skip(start)
+        .take(len)
+        .map(|(section, label, note, w)| LibStrs {
+            pill: LibPill::Library(section),
+            label,
+            note,
+            w,
+        })
+        .collect();
+    let hidden = widths.len() - len;
+    if hidden > 0 {
+        let label = CString::new(format!("+{hidden}")).unwrap_or_default();
+        let w = CHIP_PAD + crate::text::text_width(label.as_ptr(), sz, 1) + CHIP_PAD;
+        out.push(LibStrs {
+            pill: LibPill::More,
+            label,
+            note: None,
+            w,
+        });
+    }
+    // A BACKSTOP now, not a policy: `lib_window` was given the same bound and reserved the `+N`
+    // slot against it, so there is nothing left here to discard. It stays because the array this
+    // feeds is fixed-length and the draw indexes it — a bound the type system does not carry is
+    // better restated than assumed.
+    debug_assert!(out.len() <= MAX_LIB_PILLS, "the window solve overran the rect array");
+    out.truncate(MAX_LIB_PILLS);
+    out
+}
+
+/// The band the row is laid out in: the document's own width, stopping where the grid does so the
+/// row cannot run under the A–Z rail's reserved band.
+fn lib_band_w() -> f32 {
+    GRID_R - MARGIN_X
+}
+
+/// **Which run of libraries to draw**, given each one's measured width — `(start, len)`.
+///
+/// `start + len < widths.len()` means the row ends in a `+N` pill and `more_w` has already been
+/// taken off the budget here.
+///
+/// Two rules, and the second is the one that is easy to get wrong: draw everything when everything
+/// fits (the ordinary case — one type's libraries, so two or three), and **never leave the SELECTED
+/// library out of the window**. A row that omits the library you are standing in is worse than the
+/// chip it replaced: it would name several libraries, none of them the one on screen.
+///
+/// **`cap` is the SECOND budget, and it binds exactly like the first.** It is the length of the
+/// rect array the draw owns ([`MAX_LIB_PILLS`]), and a run of short names overflows it long before
+/// it overflows the band — nine libraries called *TV*, *Kids*, *Anime* fit the width three times
+/// over. So a solve that answered on width alone handed back a window the draw then had to cut,
+/// and cutting after the fact loses the `+N` with it: the caller computes what is hidden FROM this
+/// window, so it was told nothing was. When there are more libraries than `cap` holds, one slot is
+/// reserved here for the overflow pill and the guarantee above — the selected library is in the
+/// window — is kept against the smaller room.
+///
+/// Pure, so the fitting can be graded without a section table or a text rasterizer.
+fn lib_window(
+    widths: &[f32],
+    sel: usize,
+    avail: f32,
+    gap: f32,
+    more_w: f32,
+    cap: usize,
+) -> (usize, usize) {
+    if widths.is_empty() || cap == 0 {
+        return (0, 0);
+    }
+    // the LIBRARY pills the row may hold: every slot when they all fit the array, one fewer when
+    // they do not, because the last slot is then the `+N` that reaches the rest
+    let room = if widths.len() > cap {
+        cap.saturating_sub(1).max(1)
+    } else {
+        cap
+    };
+    let total: f32 =
+        widths.iter().sum::<f32>() + gap * widths.len().saturating_sub(1) as f32;
+    if widths.len() <= room && total <= avail {
+        return (0, widths.len());
+    }
+    let budget = avail - more_w - gap;
+    let mut start = 0;
+    loop {
+        let mut w = 0.0;
+        let mut len = 0;
+        for &pw in widths.iter().skip(start) {
+            if len == room {
+                break;
+            }
+            let step = pw + if len == 0 { 0.0 } else { gap };
+            if w + step > budget {
+                break;
+            }
+            w += step;
+            len += 1;
+        }
+        // A single pill wider than the whole band: draw it anyway rather than an empty row. It is
+        // clipped by the band, which is a legible failure; nothing at all is not.
+        if len == 0 {
+            return (start.min(widths.len() - 1), 1);
+        }
+        if sel < start + len || start + len >= widths.len() {
+            return (start, len);
+        }
+        start += 1;
+    }
+}
+
+/// The row's cursor, clamped to what is actually DRAWN. **Nothing else may read `LIB_C`** — the
+/// same single-authority rule [`tool_f`] documents, and for the same failure: a draw and an
+/// activation that clamp differently give a row where OK acts on a pill nothing is lit on.
+fn lib_f() -> usize {
+    unsafe { addr_of!(LIB_C).read().min(addr_of!(LIB_N).read().saturating_sub(1)) }
+}
+/// The pills the row drew, as plain data. See [`LIB_PILLS`].
+fn lib_pills() -> &'static [LibPill] {
+    unsafe {
+        let n = addr_of!(LIB_N).read();
+        let all: &[LibPill; MAX_LIB_PILLS] = &*addr_of!(LIB_PILLS);
+        &all[..n]
+    }
+}
+
+/// Seat the row's cursor on the library being viewed — what ENTERING the zone should do, so a walk
+/// into the head lands where the viewer already is. A switch is the other half and is not this:
+/// [`publish_lib_row`] owns it, because the pills this reads are the last draw's and a switch has to
+/// seat against the row that is about to replace them.
+fn seat_lib_cursor() {
+    unsafe { LIB_C = seat_on(lib_pills(), view_section()) };
+}
+
+/// Where the cursor belongs in `pills` when `sel` is the library on screen. Falls back to 0 for a
+/// selection the window does not hold, which is the overflow row's own answer: the first pill is
+/// drawn, so the accent is on something.
+fn seat_on(pills: &[LibPill], sel: usize) -> usize {
+    pills
+        .iter()
+        .position(|&p| p == LibPill::Library(sel))
+        .unwrap_or(0)
+}
+
+/// **Publish what the row drew, and re-seat the cursor when the library under it has changed.**
+///
+/// The seat is here rather than beside the switch for a reason that cost the first version of this
+/// row its focus: the pill array a switch could seat against is the one the LAST draw published,
+/// which was built for the library being left. The index of the newly picked library only exists
+/// once the row has been rebuilt for it — the window may have slid, and the pill pressed at index 1
+/// can land at index 0 — so the one place that can answer is the frame that draws the new row.
+///
+/// [`LIB_SEEN`] is what makes it a re-seat rather than a leash: while the selection holds still the
+/// cursor is the user's, so LEFT/RIGHT walk the row and stay where they are put.
+///
+/// Split from [`draw_lib_row`] so the rule can be graded on the host — the draw itself measures
+/// text and a host test may not (see [`LIB_PILLS`]).
+fn publish_lib_row(pills: [LibPill; MAX_LIB_PILLS], n: usize, sel: usize) {
+    unsafe {
+        *addr_of_mut!(LIB_PILLS) = pills;
+        LIB_N = n;
+        if addr_of!(LIB_SEEN).read() != sel {
+            LIB_SEEN = sel;
+            LIB_C = seat_on(&pills[..n], sel);
+        }
+    }
+}
+
+/// Activate the pill at drawn index `i` — the ONE place a library pill becomes an action, so the
+/// remote and the pointer cannot disagree about what one does.
+fn lib_row_activate(i: usize) {
+    match lib_pills().get(i).copied() {
+        Some(LibPill::Library(s)) => switch_library(s),
+        // `None` cannot happen against a clamped cursor and is the overflow's action anyway: the
+        // panel is what both a missing pill and a `+N` should open.
+        Some(LibPill::More) | None => open_source_menu(),
+    }
+}
+
+/// Switch to a library the user PICKED — from a pill in the row, or from a row of the Sources
+/// panel. The one seam that reports the switch, because the two paths are the same intent and a
+/// count that saw only one of them would answer the wrong question.
+///
+/// **Reported against the COMMITTED library, not the one on screen**, and the difference is a whole
+/// event. `switch_to_section` refuses a request for the library the chrome already names — which
+/// during a page fade is the QUEUED one — so a viewer who picks A and then, inside the 70 ms,
+/// changes their mind and picks B (the library they are actually still in) passes that guard: the
+/// request supersedes A, `apply_section` finds `cur()` already at B and does nothing, and the
+/// library never moved. Reported off `view_section` that was TWO events for zero switches, in the
+/// one number that exists to answer whether anybody finds the switcher at all.
+///
+/// What is counted is therefore a press that would leave the library the store is on. A request the
+/// viewer supersedes before its floor still counts once — the press is the evidence the switcher
+/// was found, which is the question — but a press that lands back where the store already is counts
+/// nothing, because nothing about it is a switch.
+fn switch_library(s: usize) {
+    if !switch_is_real(s, view_section(), crate::browse::section_count()) {
+        return;
+    }
+    if switch_is_reportable(s, crate::browse::cur()) {
+        crate::diag::event(crate::diag::schema::DiagEvent::FeatureUsed {
+            feature: crate::diag::schema::Feature::LibrarySwitch,
+        });
+    }
+    switch_to_section(s);
+}
+
+/// Is `s` a switch at all — a real library, and not the one already being viewed?
+///
+/// Pure, which is the only way either predicate is reachable from the host suite at all: their
+/// consumer calls `diag::event`, which is consent-gated with no test sink. The arithmetic is what
+/// can be pinned; the send is not.
+fn switch_is_real(s: usize, view: usize, count: usize) -> bool {
+    s != view && s < count
+}
+
+/// …and does that switch deserve a `LibrarySwitch` report?
+///
+/// **Against `cur()`, not `view_section()`.** The two differ for the length of a page fade, and the
+/// caller has already established `s != view`. Reporting on the view alone counted a press that
+/// merely SUPERSEDED a switch still in flight as a second use of the control — two events for a
+/// viewer who pressed twice inside 70 ms and landed in one library. Comparing against the
+/// COMMITTED section makes the count "arrivals somewhere new", which is the question the event was
+/// added to answer: does anybody ever leave the library a tab opens on.
+fn switch_is_reportable(s: usize, cur: usize) -> bool {
+    s != cur
+}
+
+/// Draw the row at `y`, returning each pill's rect for [`draw_document`] to publish. It hands them
+/// back rather than writing [`LIB_RECTS`] itself so that the park and the fill are ONE statement in
+/// the caller — see that static for the ghost pill an unparked frame leaves behind. Nothing else is
+/// returned: the head block's height is [`TOOL_H`] whichever form it takes, so the document's
+/// layout does not depend on this.
+fn draw_lib_row(p: Painter, y: f32) -> [Rect; MAX_LIB_PILLS] {
+    let sel = view_section();
+    let row = lib_row();
+    let mut pills = [LibPill::More; MAX_LIB_PILLS];
+    for (i, cs) in row.iter().enumerate().take(MAX_LIB_PILLS) {
+        pills[i] = cs.pill;
+    }
+    // **Published BEFORE the cursor is read**, both halves of it: `lib_f` clamps against `LIB_N`,
+    // so reading it first clamps this frame's cursor against the LAST frame's length, and the
+    // re-seat that follows a switch has to land before the accent is drawn or the wrong pill is lit
+    // for a frame.
+    publish_lib_row(pills, row.len().min(MAX_LIB_PILLS), sel);
+    let focused_row = area() == Area::LibChip && !menu_open();
+    let cur = lib_f();
+    let mut rects = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_LIB_PILLS];
+    let mut x = MARGIN_X;
+    for (i, cs) in row.iter().enumerate().take(MAX_LIB_PILLS) {
+        rects[i] = lib_pill_at(
+            p,
+            x,
+            y,
+            cs,
+            cs.pill == LibPill::Library(sel),
+            focused_row && i == cur,
+        );
+        x += cs.w + theme::space::XS;
+    }
+    rects
+}
+
+/// One library pill. **Three faces, and they are the tab bar's own language one level down**:
+/// focused wears the app's Accent like every other control, the library you are IN wears the
+/// filled idle capsule, and the rest are bare dim text with no capsule at all.
+///
+/// That last one is what makes the row read as a row rather than as several buttons — the same
+/// distinction the tab track above draws between the selected type and its neighbours, which is
+/// the point: a user who reads *Movies · TV Shows* up there reads *Films · Animation* down here
+/// the same way, and the nesting explains itself.
+fn lib_pill_at(p: Painter, x: f32, y: f32, cs: &LibStrs, selected: bool, focused: bool) -> Rect {
+    let sz = theme::size::LABEL;
+    let r = Rect::new(x, y, cs.w, TOOL_H);
+    let ink = match (focused, selected) {
+        (true, _) => {
+            p.rrect(r, TOOL_H * 0.5, TOOL_H * 0.5, crate::ui::ACCENT);
+            crate::ui::ACCENT_INK
+        }
+        (false, true) => {
+            p.rrect(r, TOOL_H * 0.5, TOOL_H * 0.5, theme::CONTROL_IDLE_FILL);
+            theme::CONTROL_IDLE_INK
+        }
+        (false, false) => theme::TEXT_SECONDARY,
+    };
+    let ty = crate::text::text_vcenter_y(sz, 1, r.y + r.h * 0.5);
+    let mut tx = r.x + CHIP_PAD;
+    tx += p.text(cs.label.as_ptr(), tx, ty, sz, ink, 0, 1);
+    // the owner annotation, on the VALUE's baseline — the same treatment and the same reason as the
+    // chip's, which this row replaces on accounts that have one
+    if let Some(h) = &cs.note {
+        let hy = crate::text::baseline_y(NOTE_SZ, 0, sz, 1, ty);
+        p.text(
+            h.as_ptr(),
+            tx,
+            hy,
+            NOTE_SZ,
+            theme::with_a(ink, NOTE_INK_A),
+            0,
+            0,
+        );
+    }
+    r
+}
+
+/// Is the pointer on a library pill? The drawn rects, so an undrawn slot is not hittable.
+fn lib_pill_hit(mx: f32, my: f32) -> Option<usize> {
+    unsafe { addr_of!(LIB_RECTS).read() }
+        .iter()
+        .position(|r| r.w > 0.5 && r.contains(mx, my))
 }
 
 // ---- per-frame draw caches (rebuilt only when their source state changes; building CStrings
@@ -2809,14 +3328,22 @@ pub(crate) fn move_focus(sym: c_uint) {
                 }
             }
             Area::LibChip => {
-                // ONE control at the head of the document: nothing sideways, and the vertical walk
-                // is the projection's — which is what makes an empty library (no grid, no controls)
-                // land DOWN on nothing rather than on an undrawn Sort chip.
+                // The head is ONE control when it is the chip and a RUN when it is the library row
+                // — so LEFT/RIGHT walk the row and do nothing at all in the chip form, which is
+                // what `n` being 1 says without a second branch. The vertical walk is the
+                // projection's either way, which is what makes an empty library (no grid, no
+                // controls) land DOWN on nothing rather than on an undrawn Sort chip.
+                let n = if lib_row_on() { lib_pills().len().max(1) } else { 1 };
+                let i = lib_f();
                 if sym == SDLK_UP {
                     AREA = Area::Tabs;
                     set_tab_p(own_pill_id());
                 } else if sym == SDLK_DOWN {
                     step_down(&lay);
+                } else if sym == SDLK_LEFT && i > 0 {
+                    LIB_C = i - 1;
+                } else if sym == SDLK_RIGHT && i + 1 < n {
+                    LIB_C = i + 1;
                 }
             }
             Area::Shelf => {
@@ -3047,10 +3574,16 @@ pub(crate) fn on_ok() -> Action {
             Action::None
         }
         Area::Grid => Action::Card,
-        // ONE control at the head of the document: OK opens the Sources picker, which is the only
-        // thing the chip does.
+        // The chip form opens the Sources picker, which is the only thing it does. The ROW form
+        // switches to the library under the cursor directly — one press instead of two, which is
+        // the other half of the change: a switcher you can see and cannot use in one press is
+        // still a menu.
         Area::LibChip => {
-            open_chip_menu(Chip::Source);
+            if lib_row_on() {
+                lib_row_activate(lib_f());
+            } else {
+                open_chip_menu(Chip::Source);
+            }
             Action::None
         }
         Area::Shelf => Action::ShelfCard {
@@ -3273,7 +3806,14 @@ fn build_source_menu(keep: bool) {
     // rather than one too many.
     let table_gen = crate::browse::source_list_gen();
     let groups = crate::browse::source_groups();
-    let rows = crate::browse::source_rows();
+    // **Scoped to the VIEWED library's type, not `cur()`'s** — the same correction the head's row
+    // needed, at the surface the head OPENS. `source_rows` reads `cur_kind()`, which lags a tab
+    // press by the length of the page fade, while the row and the chip above this panel have
+    // already relabelled from `view_section()`. Pressing `+N` inside that window listed the OTHER
+    // type's libraries under a row naming this one — and it does not heal, because [`menu_stale`]
+    // rebuilds this panel on the section table's GENERATION and the commit does not move it: the
+    // wrong list stays up for as long as the panel does.
+    let rows = crate::browse::source_rows_for(view_section());
     let (secs, acts) = source_list::sections(Level::Browse, &groups, &rows, Tail::Recheck);
     let sel = source_list::sel(&rows, keep.then(|| table().sel));
     // the panel IS its key: the generation these rows were projected from and one action per row,
@@ -3431,7 +3971,7 @@ fn menu_commit(sel: i32) {
     match menu() {
         Menu::Source { .. } => match src_action(sel) {
             SrcAction::Library(s) => {
-                switch_to_section(s);
+                switch_library(s);
                 close_menu();
             }
             SrcAction::Recheck => {
@@ -3521,6 +4061,13 @@ pub(crate) fn pointer_focus(mx: f32, my: f32) -> bool {
         if let Some(i) = crate::ui::widgets::tab_pill_at(mx, my) {
             AREA = Area::Tabs;
             set_tab_p(crate::ui::widgets::pill_at(i));
+            return moved(before);
+        }
+        // the head's library row FIRST: its pills are their own zone and their own cursor, and
+        // the chip form parks these rects so the two can never both answer
+        if let Some(i) = lib_pill_hit(mx, my) {
+            AREA = Area::LibChip;
+            LIB_C = i;
             return moved(before);
         }
         let tools = addr_of!(TOOL_RECTS).read();
@@ -3650,6 +4197,13 @@ pub(crate) fn click(mx: f32, my: f32) -> Action {
     pointer_focus(mx, my);
     if let Some(i) = crate::ui::widgets::tab_pill_at(mx, my) {
         return tab_pill_action(i);
+    }
+    // resolved through the PILL the click landed on, exactly as the key path does — `pointer_focus`
+    // above has already seated the cursor there, but agreeing by side effect is what the toolbar
+    // arm below was fixed for.
+    if let Some(i) = lib_pill_hit(mx, my) {
+        lib_row_activate(i);
+        return Action::None;
     }
     let tools = unsafe { addr_of!(TOOL_RECTS).read() };
     if let Some(i) = tools.iter().position(|r| r.w > 0.5 && r.contains(mx, my)) {
@@ -4120,6 +4674,10 @@ fn doc_y(_lay: &Layout, y: f32, scroll: f32) -> f32 {
 fn draw_document(pg: Painter, ph: Painter, lay: &Layout, sc: f32) {
     // ---- the library chip, at the head ----
     let mut tool_rects = [Rect::new(0.0, 0.0, 0.0, 0.0); 3];
+    // **Zeroed here and written back at the bottom whatever ran**, exactly as `tool_rects` is: the
+    // head is inside the scroll, so the frames with no pills to record are not only the chip form's
+    // — they are every frame the head is off screen. See [`LIB_RECTS`].
+    let mut lib_rects = [Rect::new(0.0, 0.0, 0.0, 0.0); MAX_LIB_PILLS];
     if lay.chip {
         // **The chip rides the lift of the block BELOW it**, which is the same rule Home's headings
         // have always followed and the reason `card_row` owns it. A magnified tile in the first
@@ -4128,16 +4686,27 @@ fn draw_document(pg: Painter, ph: Painter, lay: &Layout, sc: f32) {
         // leaving an awkward amount of spacing" describes. Moving with it holds the gap constant.
         let y = doc_y(lay, 0.0, sc) - head_lift(lay);
         if on_axis(y, TOOL_H, SCR_H, 0.0) {
-            let strs = chip_strs();
-            if let Some(cs) = strs.iter().find(|c| c.kind == Chip::Source) {
-                toolbar_chip_at(
-                    ph,
-                    MARGIN_X,
-                    y,
-                    cs,
-                    Icon::ChevronDown,
-                    area() == Area::LibChip && !menu_open(),
-                );
+            // **Two forms, one block.** The row when this tab holds more than one library, the
+            // single chip when it does not — and the head is [`TOOL_H`] tall either way, so
+            // nothing in [`Layout`] has to know which one ran.
+            if lib_row_on() {
+                lib_rects = draw_lib_row(ph, y);
+            } else {
+                // the chip form owns no pills, so the row's CONTENT is retired here too — the
+                // geometry is already parked by the local above, on this frame and on every frame
+                // this block does not run at all
+                unsafe { LIB_N = 0 };
+                let strs = chip_strs();
+                if let Some(cs) = strs.iter().find(|c| c.kind == Chip::Source) {
+                    toolbar_chip_at(
+                        ph,
+                        MARGIN_X,
+                        y,
+                        cs,
+                        Icon::ChevronDown,
+                        area() == Area::LibChip && !menu_open(),
+                    );
+                }
             }
         }
     }
@@ -4264,7 +4833,10 @@ fn draw_document(pg: Painter, ph: Painter, lay: &Layout, sc: f32) {
             }
         }
     }
-    unsafe { *addr_of_mut!(TOOL_RECTS) = tool_rects };
+    unsafe {
+        *addr_of_mut!(TOOL_RECTS) = tool_rects;
+        *addr_of_mut!(LIB_RECTS) = lib_rects;
+    }
 }
 
 /// The grid block's own heading — `All films · 185 films · A–Z`, the design's line. One string, so
@@ -5301,6 +5873,147 @@ mod tests {
             current,
         }
     }
+    // ---- the head's library row (issue #68) --------------------------------------------------
+
+    /// The event counts ARRIVALS SOMEWHERE NEW, and the two predicates say so separately: a press
+    /// on the library already being viewed is not a switch, and a press that supersedes a switch
+    /// still in flight is a switch but not a second USE of the control.
+    #[test]
+    fn a_superseding_press_switches_without_being_counted_twice() {
+        // the ordinary switch: away from what is viewed and from what is committed alike
+        assert!(switch_is_real(1, 0, 3) && switch_is_reportable(1, 0));
+        // pressing the library already on screen is not a switch at all
+        assert!(!switch_is_real(0, 0, 3));
+        // a section index the table does not hold — which a row published before a `browse::reset`
+        // renumbered it can still name
+        assert!(!switch_is_real(7, 0, 3));
+        // A → B queued, then B → A pressed inside the fade: `view` is B, so this IS a switch…
+        assert!(
+            switch_is_real(0, 1, 3),
+            "back to A while A is still committed is a real switch"
+        );
+        // …and `cur` is still A, so the viewer never left, and it is not a second event
+        assert!(!switch_is_reportable(0, 0));
+    }
+
+    /// The ordinary case, and the one the report is about: one type, two or three libraries, all
+    /// of them drawn. **No `+N`** — an overflow pill on a row that fits would put a menu back in
+    /// front of the thing this row exists to show.
+    #[test]
+    fn a_row_that_fits_draws_every_library_and_no_overflow() {
+        let (start, len) = lib_window(&[300.0, 260.0, 240.0], 0, 1500.0, 8.0, 90.0, MAX_LIB_PILLS);
+        assert_eq!((start, len), (0, 3));
+    }
+
+    /// **The selected library is never the one left out.** A row that names three libraries and
+    /// omits the one on screen is worse than the single chip it replaced: it would answer "which
+    /// library is this" with a library that is not this one.
+    #[test]
+    fn an_overflowing_row_always_keeps_the_selected_library() {
+        let w = [400.0, 400.0, 400.0, 400.0, 400.0];
+        // Wide enough for two pills plus the `+N`, so three of the five cannot be drawn.
+        let (start, len) = lib_window(&w, 4, 1000.0, 8.0, 90.0, MAX_LIB_PILLS);
+        assert!(len < w.len(), "the fixture must actually overflow, or this grades nothing");
+        assert!(
+            (start..start + len).contains(&4),
+            "the window {start}..{} does not hold the selected library",
+            start + len
+        );
+    }
+
+    /// …and it anchors as EARLY as it can, so a row does not scroll away from the front for a
+    /// selection that is already visible. Same widths, selection at the head.
+    #[test]
+    fn an_overflowing_row_starts_at_the_front_when_the_selection_is_there() {
+        let w = [400.0, 400.0, 400.0, 400.0, 400.0];
+        let (start, len) = lib_window(&w, 0, 1000.0, 8.0, 90.0, MAX_LIB_PILLS);
+        assert_eq!(start, 0);
+        assert!(len < w.len());
+    }
+
+    /// A single library whose name is wider than the whole band. Drawing it clipped is a legible
+    /// failure; an empty row is not, and an empty row is what a naive "fit or nothing" loop gives.
+    #[test]
+    fn a_pill_wider_than_the_band_is_still_drawn() {
+        let (start, len) = lib_window(&[4000.0, 300.0], 0, 1000.0, 8.0, 90.0, MAX_LIB_PILLS);
+        assert_eq!((start, len), (0, 1));
+    }
+
+    /// **The rect array is a budget too, and it binds before the band does.** Nine libraries called
+    /// *TV*, *Kids*, *Anime* fit a 1500px band three times over, so a solve that answered on width
+    /// alone handed back all nine — and [`build_lib_row`] then read "nothing hidden" off that
+    /// window, grew no `+N`, and let the fixed array drop everything past slot 8. With the viewer
+    /// standing in one of the dropped libraries the row had no pill for the library on screen, no
+    /// overflow to reach it through, and no chip either: the switcher silently lost the very
+    /// library it was showing.
+    #[test]
+    fn more_libraries_than_the_array_holds_overflow_rather_than_being_truncated_away() {
+        let w = [120.0; 9];
+        let (start, len) = lib_window(&w, 8, 1500.0, 8.0, 90.0, MAX_LIB_PILLS);
+        assert!(
+            len < w.len(),
+            "all {} were returned, so `hidden` is 0 and no `+N` is built — the tail is dropped by \
+             the array instead",
+            w.len()
+        );
+        assert!(
+            len + 1 <= MAX_LIB_PILLS,
+            "the `+N` has to fit the array beside the {len} libraries, or it is the pill that gets \
+             truncated away"
+        );
+        assert!(
+            (start..start + len).contains(&8),
+            "the window {start}..{} does not hold the selected library",
+            start + len
+        );
+    }
+
+    /// **A switch the row did not make still moves the row.** Picking a library out of the Sources
+    /// panel behind `+N` never leaves [`Area::LibChip`], so [`enter_zone`] — the only other place
+    /// the cursor is derived from the selection — does not run: the cursor is left wherever it was
+    /// when the panel opened, which is the `+N` pill it was opened from. The row is then rebuilt for
+    /// the new library under a cursor pointing at a stranger, and OK acts on that stranger.
+    ///
+    /// Graded at [`publish_lib_row`] because the draw around it measures text, which a host test
+    /// may not (see [`LIB_PILLS`]).
+    #[test]
+    fn the_cursor_follows_a_library_the_row_itself_did_not_pick() {
+        let _g = crate::testlock::serial();
+        let published = |a: &[LibPill]| {
+            let mut p = [LibPill::More; MAX_LIB_PILLS];
+            p[..a.len()].copy_from_slice(a);
+            (p, a.len())
+        };
+        let (p, n) = published(&[LibPill::Library(4), LibPill::Library(5), LibPill::More]);
+        publish_lib_row(p, n, 4);
+        assert_eq!(lib_f(), 0, "a row opens seated on the library it is showing");
+
+        // …RIGHT, RIGHT onto the overflow, OK, and library 5 picked out of the panel. Nothing but
+        // the rebuild can move the cursor, and it must move it onto the library that was picked —
+        // not to 0, which a fallback would make this test pass without seating anything.
+        unsafe { LIB_C = 2 };
+        let (p, n) = published(&[LibPill::Library(4), LibPill::Library(5), LibPill::More]);
+        publish_lib_row(p, n, 5);
+        assert_eq!(
+            lib_f(),
+            1,
+            "the accent is on a pill that is not the library the viewer just picked"
+        );
+
+        // …and it is a re-seat, not a leash: while the selection holds still the cursor is the
+        // user's, so a rebuild (a count landing, a probe finishing) does not undo a walk.
+        unsafe { LIB_C = 2 };
+        let (p, n) = published(&[LibPill::Library(4), LibPill::Library(5), LibPill::More]);
+        publish_lib_row(p, n, 5);
+        assert_eq!(lib_f(), 2, "a rebuild with the same library dragged the cursor back");
+
+        unsafe {
+            LIB_SEEN = usize::MAX;
+            LIB_N = 0;
+            LIB_C = 0;
+        }
+    }
+
     /// Our own server with two libraries and a friend's with one — the canvas's own shape.
     fn two_sources() -> (Vec<crate::browse::SrcGroup>, Vec<crate::browse::SrcRow>) {
         (

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -4411,8 +4411,16 @@ impl Capsule {
 /// up from 18). A 60px-tall pill wrapped on 18 read as a tall thin lozenge; at 26 the pill is the
 /// capsule the mock draws, and it matches the Play pill's own label inset beside it.
 pub(crate) const STRIP_PAD: f32 = 26.0;
-/// Air BETWEEN two pills of a strip.
+/// Air BETWEEN two pills of a strip — the tight rung, for a strip of SHORT labels.
 pub(crate) const STRIP_GAP: f32 = theme::space::SM;
+/// …and the wide rung, for a strip whose pills carry PHRASES rather than words.
+///
+/// Owner call from the panel, on the Library's library row and the Filmography route's department
+/// filter together. The padding is a property of the pill and never changes; the air between two
+/// of them is a property of the ROW, and at `SM` two adjacent plates carrying several words each
+/// read as one long run with a seam in it rather than as two controls. The season strip keeps
+/// [`STRIP_GAP`]: "Season 3" is a word and a number, and it separates cleanly at the tight rung.
+pub(crate) const STRIP_GAP_WIDE: f32 = theme::space::MD;
 /// Per-pill horizontal advance past the CONTENT width — derived from the two above rather than
 /// spelled, so a change to the padding cannot silently change the gap (which is what 52 vs 18 used
 /// to hide).
@@ -4446,7 +4454,13 @@ pub(crate) fn strip_span(lays: &[StripLay], i: usize, h: f32) -> Option<(f32, f3
 }
 
 /// Lay a strip out from its labels: content x from `x0`, advancing by each pill's measured width
-/// plus [`STRIP_ADVANCE`]. Bold, because every strip in this app draws its pills bold.
+/// plus twice [`STRIP_PAD`] and `gap`. Bold, because every strip in this app draws its pills bold.
+///
+/// **`gap` is a parameter and [`STRIP_GAP`] is its default**, not its only value. The padding is a
+/// property of the PILL and is shared unconditionally; the air between two of them is a property of
+/// the ROW, and the two strips want different amounts of it — a strip of two or three long library
+/// names reads as one run at the season strip's 16px, where a row of short department names does
+/// not. Pass [`STRIP_GAP`] to keep the shared rhythm.
 ///
 /// A label that cannot be a `CString` (an interior NUL — never in practice) is skipped entirely:
 /// not drawn, and no advance, so the gap it would have left cannot desynchronise the span function
@@ -4455,6 +4469,7 @@ pub(crate) fn strip_layout(
     labels: impl Iterator<Item = String>,
     x0: f32,
     sz: c_int,
+    gap: f32,
 ) -> Vec<StripLay> {
     let mut x = x0;
     let mut out = Vec::new();
@@ -4462,7 +4477,7 @@ pub(crate) fn strip_layout(
         let Ok(lc) = CString::new(label) else { continue };
         let w = crate::text::text_width(lc.as_ptr(), sz, 1);
         out.push(StripLay { i, x, w, label: lc });
-        x += w + STRIP_ADVANCE;
+        x += w + 2.0 * STRIP_PAD + gap;
     }
     out
 }

--- a/rust-modules/src/ui/widgets.rs
+++ b/rust-modules/src/ui/widgets.rs
@@ -4395,6 +4395,78 @@ impl Capsule {
     }
 }
 
+// ---- a strip's PILL GEOMETRY, shared by every strip a [`TabStrip`] drives ---------------------
+//
+// **These lived in `ui/detail.rs`, private to the season strip, until the Library grew a strip of
+// its own.** `TabStrip` and `TabPill` were already shared; the numbers that PLACE their pills were
+// not, so a second consumer's only options were to import private constants or to hand-author a
+// copy — and a copy is the fork the directive above [`TAB_PILL_H`] forbids, arrived at from
+// underneath. One padding, one gap, one advance, one pill rect, one span function.
+//
+// The row HEIGHT stays the caller's, because the two strips genuinely differ there: the season
+// strip stands as tall as the hero buttons beside it, and the Library's head as tall as the
+// control row it heads.
+
+/// A strip pill's padding either side of its CONTENT (`Details Screen.dc.html`'s `padding: 0 26px`,
+/// up from 18). A 60px-tall pill wrapped on 18 read as a tall thin lozenge; at 26 the pill is the
+/// capsule the mock draws, and it matches the Play pill's own label inset beside it.
+pub(crate) const STRIP_PAD: f32 = 26.0;
+/// Air BETWEEN two pills of a strip.
+pub(crate) const STRIP_GAP: f32 = theme::space::SM;
+/// Per-pill horizontal advance past the CONTENT width — derived from the two above rather than
+/// spelled, so a change to the padding cannot silently change the gap (which is what 52 vs 18 used
+/// to hide).
+pub(crate) const STRIP_ADVANCE: f32 = 2.0 * STRIP_PAD + STRIP_GAP;
+
+/// ONE strip pill's resolved layout: its index, content-space label x, the pill's CONTENT width
+/// (the label plus whatever trailing note it carries) and the label CString.
+pub(crate) struct StripLay {
+    pub(crate) i: usize,
+    pub(crate) x: f32,
+    pub(crate) w: f32,
+    pub(crate) label: CString,
+}
+
+/// A strip pill's frame: padded [`STRIP_PAD`] either side of its content, standing the full row
+/// height so the pills read as one control family with whatever sits beside them. `top` is the
+/// row's local y for the draw and its screen y for the hit-test; any horizontal scroll is applied
+/// by the caller, which is why this takes the layout entry rather than reaching for one.
+pub(crate) fn strip_pill_rect(lay: &StripLay, top: f32, h: f32) -> Rect {
+    Rect::new(lay.x - STRIP_PAD, top, lay.w + 2.0 * STRIP_PAD, h)
+}
+
+/// Content-space `(x, w)` of pill `i` — **the frame, not the label inside it.** The one span
+/// function a [`TabStrip`] is placed from, so a capsule can only ever come to rest exactly on a
+/// pill; `TabStrip::update`'s contract is that this IS the function the caller laid out with.
+pub(crate) fn strip_span(lays: &[StripLay], i: usize, h: f32) -> Option<(f32, f32)> {
+    lays.get(i).map(|l| {
+        let r = strip_pill_rect(l, 0.0, h);
+        (r.x, r.w)
+    })
+}
+
+/// Lay a strip out from its labels: content x from `x0`, advancing by each pill's measured width
+/// plus [`STRIP_ADVANCE`]. Bold, because every strip in this app draws its pills bold.
+///
+/// A label that cannot be a `CString` (an interior NUL — never in practice) is skipped entirely:
+/// not drawn, and no advance, so the gap it would have left cannot desynchronise the span function
+/// from the draw.
+pub(crate) fn strip_layout(
+    labels: impl Iterator<Item = String>,
+    x0: f32,
+    sz: c_int,
+) -> Vec<StripLay> {
+    let mut x = x0;
+    let mut out = Vec::new();
+    for (i, label) in labels.enumerate() {
+        let Ok(lc) = CString::new(label) else { continue };
+        let w = crate::text::text_width(lc.as_ptr(), sz, 1);
+        out.push(StripLay { i, x, w, label: lc });
+        x += w + STRIP_ADVANCE;
+    }
+    out
+}
+
 /// The motion state of ONE tab strip: the subtle capsule marking the SELECTED tab and the bright one
 /// marking the FOCUSED tab, both travelling. Two, not one, because they are independently placed —
 /// on the Library screen the selected tab is the section you are browsing while focus walks the row


### PR DESCRIPTION
Fixes #68.

## What the reporter hit

Two TV Shows libraries on one server; the *TV Shows* tab showed only one of them, and the other read as missing from the application. Two separate things were true at once, and the second is the one that stings:

1. **The switcher was not on screen.** In v0.6.0 it was gated on `sources().len() > 1` — a count of **servers**, not libraries — so a single-server account got no Library chip at all and the second library was genuinely unreachable, not merely hard to find. (Widened on `main` before this PR.)
2. **The one workaround the UI offered did nothing.** They switched the unwanted library off under *Settings → Home screen*, and the tab still opened it: the favourite switch governed Home alone, and `tab_section` filtered on `s.kind` and nothing else. Their instinct was right and the app ignored it. (Also fixed on `main`; this PR adds the regression test, watched red against the shipped predicate first.)

Which of the two a pill opens was never chosen either — it is whichever the server lists first.

## What this PR changes

The head of the Library document now draws **every favourite library of the browsed type** — a pill each, the current one filled and the rest bare dim text, overflowing into `+N` when they outgrow the band.

A control that names one thing cannot say that a set exists. A chevron is an affordance for somebody who already suspects there is something behind it, and a dim `1 of 2` beside the name is a footnote at ten feet. The hierarchy the app already had is *type above, libraries nested inside*; this draws the nested level instead of leaving it to be inferred, in the tab track's own visual language one level down. One press switches, where the chip cost two.

**The chip is not gone.** It stays for the two states it is still the only answer for: one library of this type reached from a second server, and a borrowed library, which nothing else on the screen names an owner for.

Supporting changes:

- **`browse::kind_position`** — where a library sits among the ones its own pill can reach. Shares `source_rows`' predicate and order, so a head can never promise a row the panel behind it will not draw.
- **`browse::source_rows_for`** — the rows projection scoped to the type of a *given* section rather than of `cur()`. `source_rows` reads `cur_kind()`, which lags a tab press by the length of the page fade while the head has already relabelled from `view_section()`. Both the row and the popover behind `+N` read this now.
- **`Area::LibChip` is a horizontal run.** The draw publishes what it drew (`LIB_PILLS`/`LIB_N`), because the cursor, the walk and the activation may not measure text — `crate::text` is SDL2_ttf, which the host test build does not link.
- **`lib_window`** bounds the drawn run by the band *and* by `MAX_LIB_PILLS`, always keeping the selected library inside it.
- **`Feature::LibrarySwitch`**, reported on arrival somewhere new. This channel could not answer the report at all: `feature.used` had three values in the wild and nothing carries library topology. It is the numerator for "does anybody ever leave the library a tab opens on".

## Bugs found and fixed during review

Three of these were mine, introduced in the first draft of the row and caught before this PR existed:

- **Stale row.** The cache key was the viewed section but the rows came from `cur_kind()`, so the row drew the Movie libraries under a TV Shows tab — and kept them, since the key does not move again at the fade floor. Caught in the simulator; no host test could have seen it.
- **Ghost pills.** `LIB_RECTS` was written only inside the head's on-screen guard, so scrolling the head away froze real rects at its old screen band — and the row's hit test runs *ahead* of the shelves and the grid in both input paths, so a click low on the page activated a library. Park and fill are one statement in `draw_document` now.
- **Silent truncation.** `lib_window` ignored `MAX_LIB_PILLS`, so more libraries than the array holds with names short enough to fit took the fast-fit path: `hidden` computed to zero, no `+N` was built, and the tail was dropped — including the library being browsed.
- **Stranded cursor** after a switch the row itself did not make (picked from the `+N` popover), and the popover itself still scoped to `cur_kind()`.

## Verification

- `make check` — **2190** (default) / **2211** (`hostsim`), lint and the Python suites green
- `cargo +nightly check --lib --no-default-features` — clean (the shipping feature set)
- `make` — ARM cross-build links
- Simulator, against a server with two Movies and two TV Shows libraries — the reporter's shape. The TV Shows tab draws both show libraries at the head; one press switches, the accent follows the picked pill, and the other library's content loads.

Twelve host tests, including both of the reporter's shapes. The regression test for (2) was watched red against the shipped predicate before the fix was restored.

**Not device-verified.** No new motion was added, so no `--fps` scene is implicated, but the head is a new draw path and the television has not seen it. Three fixes are not host-testable and were graded by reading: the rect parking (needs a `Painter`/GL), the popover scope at its call site (goes through `TableView`, which measures text), and the telemetry send (`diag::event` is consent-gated with no test sink) — the last two are pinned one layer down, where the decision actually lives.

## Follow-ups from testing it on the television

**The row is a `TabStrip` now, not a hand-drawn one.** The first cut was built from the toolbar chip's own primitives, and the owner named both halves of what that cost: *"deselected pill has no background, no animations like on season."* Both are properties of the shared component. It is `TabStrip` + `TabPill::plated()` — the same pair the Filmography route's department filter uses — so every pill lays its own ground, both capsules travel on the strip's own springs, and the focused pill wears the `CTRL_FOCUS_SCALE` pop and press dip through one `CtlPop<1>`.

`SelMark::Travels`, matching the department filter rather than the season strip's `Lands`: the season plate lands because selection there only ever changes with the focus capsule already sitting on the destination, so its travel would be hidden. Neither holds here — the library also changes from the Sources panel behind `+N` and from a pointer click, and in both the plate's path from the old library to the new one is the whole statement.

Using the component properly meant the strip's **pill geometry** had to stop being private to `detail.rs`. `TabStrip` and `TabPill` were already shared; the numbers that *place* their pills were not, so a second consumer's only options were a private import or a copy — the fork `ui/CLAUDE.md`'s directive above `widgets::TAB_PILL_H` forbids, arrived at from underneath. `STRIP_PAD` / `STRIP_GAP` / `STRIP_ADVANCE` / `StripLay` / `strip_pill_rect` / `strip_span` / `strip_layout` now live beside `TabStrip`, and `detail.rs` is migrated onto them. The row height stays the caller's — the two strips genuinely differ there.

**It remembers the last library, per tab, per profile.** New `Session::last_library`, keyed by profile uuid and by `(machineIdentifier, section key)` like `HomePins` — never a section index, which renumbers on a `browse::reset`. Per *type*, or picking a film library would forget which shows you browse. `section_of_kind` prefers it while the library is still granted and still a favourite, and falls through to the old owned-first resolution otherwise. Written from the commit of a page change the viewer asked for, never from `set_cur`: `repoint_cur` also goes through there, and recording a forced move would invent a preference and then open there next launch.

Without this the row makes the second library one press away *every launch, forever* — which is the half of #68 a switcher alone does not fix.

**The head hides when one library is enabled.** `head_on()` no longer inherits `lib_chip_on()`'s count of *servers*: a second server drew a chevron over a one-row panel on a page with nowhere to go. It is now the row (more than one favourite of the browsed type), a lone borrowed library (the only surface naming an owner), or a failed listing on a multi-source roster — that last kept deliberately, since the Sources panel is the documented escape off a dead source. Two tests encoded the old "two servers ⇒ a chip" rule and were moved onto the new contract.

`make check` 2209 / 2230 green, `--no-default-features` clean, ARM cross-build links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
