### PR TITLE
fix: register Original MDE before the Part GET

### DIFF
--- a/docs/plex-api-catalog.md
+++ b/docs/plex-api-catalog.md
@@ -302,7 +302,10 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   id, or `0` so a selected sidecar or unadvertised codec does not force a burn). If
   `/decision` is unreachable the app does **not**
   return the Part URL (that would 503); it remuxes or re-encodes instead. An explicit MDE
-  `transcode` also refuses a local codec-copy remux. (Catalog **D-7** still describes
+  `transcode` still remuxes when the video stream's own decision is `copy` or unnamed
+  (`Part.decision` is a container change); only a video-stream `transcode` forbids the
+  codec-copy. Remote Auto's Original probe then samples that remux `start.mkv` rather than
+  the Part (a Part GET after a transcode decision is 503). (Catalog **D-7** still describes
   `audioStreamID`/`subtitleStreamID` on *transcode* start/decision GETs as undocumented relative
   to the PUT selection API; the MDE handshake above is a separate use of those query names.)
 - **Divergences:** none (the key comes straight from `part.key`). The middle path segment is a

--- a/docs/plex-api-catalog.md
+++ b/docs/plex-api-catalog.md
@@ -224,9 +224,9 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
 
 - **Response:** no body (200) / 400 if the stream doesn't belong to the part.
 - **App reads:** only the HTTP status. Confirmed.
-- **Divergences:** none. This is the **correct** mechanism for stream selection (the app also
-  redundantly appends `audioStreamID`/`subtitleStreamID` to the transcode GET — those are
-  undocumented no-ops there; see D-7). `partId` is an integer in the spec — keep parsing it as
+- **Divergences:** none. This is the **correct** mechanism for stream selection. Transcode
+  start/decision GETs still copy the same ids (they match this PUT); MDE GETs use them as
+  load-bearing query names — **D-7**. `partId` is an integer in the spec — keep parsing it as
   numeric.
 
 ### 9. `transcodeDecision` — register/handshake a transcode session
@@ -270,9 +270,13 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
     **query params**. The spec declares these as **HTTP headers** (`X-Plex-Client-Identifier`
     is a **required header**). PMS accepts X-Plex-* as either, so it works, but header form is
     spec-correct and avoids leaking identity into cached URLs.
-  - **D-7:** `audioStreamID` / `subtitleStreamID` on the transcode GET are **not documented**
-    params of `transcodeDecision`/`transcodeStart`; server-side selection is done via
-    `libraryPutPartsPart` (which the app already does). The GET copies are no-ops — safe to drop.
+  - **D-7:** `audioStreamID` / `subtitleStreamID` are **not documented** params of
+    `transcodeDecision`/`transcodeStart`. Their meaning splits on `directPlay`:
+    - **MDE** (`hasMDE=1`, `directPlay=1`): both are load-bearing (smart-DP sibling as
+      `audioStreamID`; `subtitleStreamID=0` so a sidecar or unadvertised codec does not burn).
+      Not safe to drop.
+    - **Transcode** start/decision (`directPlay=0`): PUT `/library/parts/{id}`
+      (`libraryPutPartsPart`) remains the selection API; GET copies match that PUT.
 
 ### 10. `transcodeStart` — the actual transcoded MKV stream
 - **Method / canonical path:** `GET /{transcodeType}/:/transcode/universal/start.*`
@@ -305,9 +309,8 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   `transcode` still remuxes when the video stream's own decision is `copy` or unnamed
   (`Part.decision` is a container change); only a video-stream `transcode` forbids the
   codec-copy. Remote Auto's Original probe then samples that remux `start.mkv` rather than
-  the Part (a Part GET after a transcode decision is 503). (Catalog **D-7** still describes
-  `audioStreamID`/`subtitleStreamID` on *transcode* start/decision GETs as undocumented relative
-  to the PUT selection API; the MDE handshake above is a separate use of those query names.)
+  the Part (a Part GET after a transcode decision is 503). See **D-7** for the MDE vs transcode
+  split on those query names.
 - **Divergences:** none (the key comes straight from `part.key`). The middle path segment is a
   **changestamp** (part updatedAt), not a byte offset — the app treats it as opaque, which is
   correct.
@@ -386,7 +389,7 @@ These documented operations cover things the app currently improvises or doesn't
 | **D-6a** | transcode decision/start | `maxVideoBitrate` → spec name `videoBitrate` (or `peakBitrate`). | low |
 | **D-6b** | transcode decision/start | `session=` → spec name `transcodeSessionId` (+ `X-Plex-Session-Identifier` header). | low |
 | **D-6c** | transcode decision/start | `X-Plex-*` sent as query params; spec declares them as **headers** (`X-Plex-Client-Identifier` required). | low |
-| **D-7** | transcode decision/start | `audioStreamID`/`subtitleStreamID` on the GET are undocumented no-ops; correct mechanism is `libraryPutPartsPart` (already used). Drop the GET copies. | low |
+| **D-7** | transcode decision/start | Undocumented `audioStreamID`/`subtitleStreamID` on the GET. **MDE** (`hasMDE=1`, `directPlay=1`): load-bearing (smart-DP sibling; `subtitleStreamID=0` so a sidecar does not burn) — do not drop. **Transcode** (`directPlay=0`): PUT `libraryPutPartsPart` is the selection API; GET copies match that PUT. | low |
 | **D-8a** | `/:/timeline` | App uses **GET**; spec verb is **POST** (`timelinePostSlash`). | medium |
 | **D-8b** | `/:/timeline` | `X-Plex-Client-Identifier` sent as query; spec = required **header**. | low |
 | **D-9** | `/video/:/transcode/universal/stop` | Undocumented endpoint (works); no spec drop-in. Nearest: `statusPostTerminate`. | low |

--- a/docs/plex-api-catalog.md
+++ b/docs/plex-api-catalog.md
@@ -247,7 +247,7 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   | `videoResolution` | query | no | string | `1920x1080` | ✅ |
   | `offset` | query | no | number | seconds, on seek/retranscode | ✅ |
   | `subtitleSize` | query | no | integer | `100` | ✅ |
-  | `subtitles` | query | no | enum(auto/burn/none/sidecar/embedded/segmented/unknown) | `burn` | ✅ |
+  | `subtitles` | query | no | enum(auto/burn/none/sidecar/embedded/segmented/unknown) | `burn` on transcode; `none` on MDE | ✅ |
   | `videoBitrate` / `peakBitrate` | query | no | integer | — | app instead sends `maxVideoBitrate` (D-6a) |
   | `transcodeSessionId` | query | no | string | — | app instead sends `session` (D-6b) |
   | `audioStreamID` / `subtitleStreamID` | — | — | — | app sends them | **not documented on this op** (D-7) |
@@ -274,7 +274,8 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
     `transcodeDecision`/`transcodeStart`. Their meaning splits on `directPlay`:
     - **MDE** (`hasMDE=1`, `directPlay=1`): both are load-bearing (smart-DP sibling as
       `audioStreamID`; `subtitleStreamID=0` so a sidecar or unadvertised codec does not burn).
-      Not safe to drop.
+      Always `subtitles=none` (client-rendered). Omitting it leaves PMS on `auto`, which 1.43.4
+      HTTP 400s when the part already has a selected subtitle. Not safe to drop.
     - **Transcode** start/decision (`directPlay=0`): PUT `/library/parts/{id}`
       (`libraryPutPartsPart`) remains the selection API; GET copies match that PUT.
 
@@ -303,7 +304,9 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   `GET /video/:/transcode/universal/decision?hasMDE=1&directPlay=1` first so the session is
   admitted; smart-DP names the chosen AAC/AC3/EAC3 track as `audioStreamID` on that query, and
   the decision always carries `subtitleStreamID` (an advertised embedded client-rendered
-  id, or `0` so a selected sidecar or unadvertised codec does not force a burn). If
+  id, or `0` so a selected sidecar or unadvertised codec does not force a burn) and
+  `subtitles=none` (PMS 1.43.4 400s `hasMDE`+`directPlay` with a selected subtitle and
+  the default `auto`). If
   `/decision` is unreachable the app does **not**
   return the Part URL (that would 503); it remuxes or re-encodes instead. An explicit MDE
   `transcode` still remuxes when the video stream's own decision is `copy` or unnamed
@@ -389,7 +392,7 @@ These documented operations cover things the app currently improvises or doesn't
 | **D-6a** | transcode decision/start | `maxVideoBitrate` → spec name `videoBitrate` (or `peakBitrate`). | low |
 | **D-6b** | transcode decision/start | `session=` → spec name `transcodeSessionId` (+ `X-Plex-Session-Identifier` header). | low |
 | **D-6c** | transcode decision/start | `X-Plex-*` sent as query params; spec declares them as **headers** (`X-Plex-Client-Identifier` required). | low |
-| **D-7** | transcode decision/start | Undocumented `audioStreamID`/`subtitleStreamID` on the GET. **MDE** (`hasMDE=1`, `directPlay=1`): load-bearing (smart-DP sibling; `subtitleStreamID=0` so a sidecar does not burn) — do not drop. **Transcode** (`directPlay=0`): PUT `libraryPutPartsPart` is the selection API; GET copies match that PUT. | low |
+| **D-7** | transcode decision/start | Undocumented `audioStreamID`/`subtitleStreamID` on the GET. **MDE** (`hasMDE=1`, `directPlay=1`): load-bearing (smart-DP sibling; `subtitleStreamID=0` so a sidecar does not burn; `subtitles=none` so a selected subtitle does not 400) — do not drop. **Transcode** (`directPlay=0`): PUT `libraryPutPartsPart` is the selection API; GET copies match that PUT. | low |
 | **D-8a** | `/:/timeline` | App uses **GET**; spec verb is **POST** (`timelinePostSlash`). | medium |
 | **D-8b** | `/:/timeline` | `X-Plex-Client-Identifier` sent as query; spec = required **header**. | low |
 | **D-9** | `/video/:/transcode/universal/stop` | Undocumented endpoint (works); no spec drop-in. Nearest: `statusPostTerminate`. | low |

--- a/docs/plex-api-catalog.md
+++ b/docs/plex-api-catalog.md
@@ -295,9 +295,16 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   a decision and no decision could be inferred" — i.e. some server configs require a
   `transcodeDecision` call even for direct-play. PMS 1.43 logs that 503 as "Denying access due
   to session lacking permission to direct play" (or "due to terminated session" after
-  `/stop?closeResourceSession=1`). Every Original Part GET now registers
+  `/stop?closeResourceSession=1`). Every Original Part GET registers
   `GET /video/:/transcode/universal/decision?hasMDE=1&directPlay=1` first so the session is
-  admitted; smart-DP names the chosen AAC/AC3/EAC3 track as `audioStreamID` on that query.
+  admitted; smart-DP names the chosen AAC/AC3/EAC3 track as `audioStreamID` on that query, and
+  the decision always carries `subtitleStreamID` (an advertised embedded client-rendered
+  id, or `0` so a selected sidecar or unadvertised codec does not force a burn). If
+  `/decision` is unreachable the app does **not**
+  return the Part URL (that would 503); it remuxes or re-encodes instead. An explicit MDE
+  `transcode` also refuses a local codec-copy remux. (Catalog **D-7** still describes
+  `audioStreamID`/`subtitleStreamID` on *transcode* start/decision GETs as undocumented relative
+  to the PUT selection API; the MDE handshake above is a separate use of those query names.)
 - **Divergences:** none (the key comes straight from `part.key`). The middle path segment is a
   **changestamp** (part updatedAt), not a byte offset — the app treats it as opaque, which is
   correct.

--- a/docs/plex-api-catalog.md
+++ b/docs/plex-api-catalog.md
@@ -293,8 +293,11 @@ and `Directory[].key` — **confirmed** (Directory items are `librarySection`, n
   `download` (query, 0/1, not used).
 - **Response:** raw media bytes. Notable error codes: **503/509** = "requested the part without
   a decision and no decision could be inferred" — i.e. some server configs require a
-  `transcodeDecision` call even for direct-play. The app's h264+ac3 direct-play path works
-  today without one; keep this in mind if a direct-play 503 ever appears.
+  `transcodeDecision` call even for direct-play. PMS 1.43 logs that 503 as "Denying access due
+  to session lacking permission to direct play" (or "due to terminated session" after
+  `/stop?closeResourceSession=1`). Every Original Part GET now registers
+  `GET /video/:/transcode/universal/decision?hasMDE=1&directPlay=1` first so the session is
+  admitted; smart-DP names the chosen AAC/AC3/EAC3 track as `audioStreamID` on that query.
 - **Divergences:** none (the key comes straight from `part.key`). The middle path segment is a
   **changestamp** (part updatedAt), not a byte offset — the app treats it as opaque, which is
   correct.

--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -1637,10 +1637,10 @@ pub(crate) struct PlayingItem {
     pub(crate) subs: Vec<Stream>,
     pub(crate) video_fps: f64, // the played leaf's video fps (0 = unknown) — feeds the Load esInfo
     /// The source's stored frame size, `Media[0]` (0 = unknown). `route.rs`'s local direct-play
-    /// gate tests it against the device table's bound: the smart-DP branch never asks PMS, so
-    /// the profile's `*`-scoped width/height limitation cannot stop a 4K source from reaching a
-    /// 1080p-bounded decoder unless the client also checks it here (issue #22's over-claim
-    /// class — docs/plex-pass-audit.md, closing section).
+    /// gate tests it against the device table's bound: when `/decision` is unreachable the
+    /// fallback still never asks PMS, so the profile's `*`-scoped width/height limitation cannot
+    /// stop a 4K source from reaching a 1080p-bounded decoder unless the client also checks it
+    /// here (issue #22's over-claim class — docs/plex-pass-audit.md, closing section).
     pub(crate) width: i64,
     pub(crate) height: i64,
     /// Whole-file bitrate in kbps (`Media[0].bitrate`). Auto uses this—not merely the video
@@ -1648,7 +1648,7 @@ pub(crate) struct PlayingItem {
     /// original file, because the transport also has to carry audio and container overhead.
     pub(crate) bitrate: i64,
     /// The played leaf's Dolby Vision layering — the direct-play gate's other refusal, beside the
-    /// frame size above and for the same reason: the smart-DP branch never asks PMS, so a file
+    /// frame size above and for the same reason: the local fallback never asks PMS, so a file
     /// whose base layer we cannot display correctly (Profile 5, or a dual-layer Profile 7) would
     /// otherwise be fed to the decoder verbatim and shown in the wrong colours. See [`Dovi`].
     pub(crate) dovi: Dovi,

--- a/rust-modules/src/metadata.rs
+++ b/rust-modules/src/metadata.rs
@@ -1637,10 +1637,10 @@ pub(crate) struct PlayingItem {
     pub(crate) subs: Vec<Stream>,
     pub(crate) video_fps: f64, // the played leaf's video fps (0 = unknown) — feeds the Load esInfo
     /// The source's stored frame size, `Media[0]` (0 = unknown). `route.rs`'s local direct-play
-    /// gate tests it against the device table's bound: when `/decision` is unreachable the
-    /// fallback still never asks PMS, so the profile's `*`-scoped width/height limitation cannot
-    /// stop a 4K source from reaching a 1080p-bounded decoder unless the client also checks it
-    /// here (issue #22's over-claim class — docs/plex-pass-audit.md, closing section).
+    /// gate tests it against the device table's bound before MDE (`!video_dp` → `skip_mde`). An
+    /// unreachable MDE still remuxes through `transcode_decision`; the client checks
+    /// width/height here so a 4K source on a 1080p-bounded SoC does not wait on a missing
+    /// `/decision` (issue #22's over-claim class — docs/plex-pass-audit.md, closing section).
     pub(crate) width: i64,
     pub(crate) height: i64,
     /// Whole-file bitrate in kbps (`Media[0].bitrate`). Auto uses this—not merely the video

--- a/rust-modules/src/plex/mod.rs
+++ b/rust-modules/src/plex/mod.rs
@@ -116,8 +116,13 @@ pub(crate) use servers::{
 pub use timeline::{queue_index_of, QueueRow};
 // DP_AUDIO_CODECS rides along for `devcaps`, which intersects it with the device's own codec
 // table — the caps snapshot is what `is_dp_audio` and the profile string then both read.
+// `DP_SUBTITLE_CODECS` / `is_dp_subtitle` are the subtitle twin: the profile's `subtitleCodec=`
+// list and route's MDE `subtitleStreamID` gate, so a selected PGS cannot be advertised in one
+// and omitted from the other.
 // `link_policy` is the other gate on the same decision: `is_dp_audio` asks what the PIPELINE can
 // decode, `link_policy` asks what the CONNECTION can carry, and `route::build_stream` must pass
 // both before it streams a file itself.
 #[allow(unused_imports)]
-pub use transcoder::{is_dp_audio, link_policy, LinkPolicy, DP_AUDIO_CODECS};
+pub use transcoder::{
+    DP_AUDIO_CODECS, DP_SUBTITLE_CODECS, LinkPolicy, is_dp_audio, is_dp_subtitle, link_policy,
+};

--- a/rust-modules/src/plex/models.rs
+++ b/rust-modules/src/plex/models.rs
@@ -406,6 +406,18 @@ pub struct MediaPart {
     pub stream: Vec<Stream>,
 }
 
+impl MediaPart {
+    /// `/decision` only. `Part.decision=transcode` means the *container* changes; a codec-copy
+    /// remux is still right unless the VIDEO stream's own decision is `transcode` (bit depth,
+    /// an undecodable codec, …). `docs/pms-api.md` measured Profile 5 as `Part=transcode` with
+    /// video `copy`. Absent streams, `copy`, or any other spelling do not forbid a remux.
+    pub fn video_forbids_copy(&self) -> bool {
+        self.stream
+            .iter()
+            .any(|s| s.stream_type == 1 && s.decision == "transcode")
+    }
+}
+
 /// D-2: channels/title/hearingImpaired/audioDescription/forced are real PMS fields the spec
 /// omits — kept here. Plex 0/1 booleans stay i64; the app tests `!= 0`.
 #[derive(Deserialize, Default)]
@@ -426,6 +438,10 @@ pub struct Stream {
     pub key: String,
     #[serde(default)]
     pub codec: String,
+    /// `/decision` only: this lane's verdict — `"directplay"` | `"transcode"` | `"copy"`.
+    /// [`MediaPart::video_forbids_copy`] is the playback reader; a library metadata body omits it.
+    #[serde(default)]
+    pub decision: String,
     #[serde(default)]
     pub language: String,
     #[serde(rename = "languageCode", default)]
@@ -978,6 +994,33 @@ mod tests {
                 mc.transcode_decision_text.as_str()
             ),
             ("", "")
+        );
+    }
+
+    /// `Part.decision=transcode` is a container change. A remux that copies video is forbidden
+    /// only when the VIDEO stream itself is `transcode` — the measured P5 shape was video `copy`.
+    #[test]
+    fn a_transcode_part_forbids_copy_only_when_the_video_stream_is_transcode() {
+        let copy: super::MediaPart = serde_json::from_slice(
+            br#"{"decision":"transcode","Stream":[{"streamType":1,"decision":"copy"},{"streamType":2,"decision":"transcode"}]}"#,
+        )
+        .expect("parse");
+        assert!(
+            !copy.video_forbids_copy(),
+            "audio transcode + video copy is a remux"
+        );
+
+        let video_tc: super::MediaPart = serde_json::from_slice(
+            br#"{"decision":"transcode","Stream":[{"streamType":1,"decision":"transcode"}]}"#,
+        )
+        .expect("parse");
+        assert!(video_tc.video_forbids_copy());
+
+        let unnamed: super::MediaPart =
+            serde_json::from_slice(br#"{"decision":"transcode"}"#).expect("parse");
+        assert!(
+            !unnamed.video_forbids_copy(),
+            "a part with no Stream[] cannot claim the video must re-encode"
         );
     }
 

--- a/rust-modules/src/plex/models.rs
+++ b/rust-modules/src/plex/models.rs
@@ -407,10 +407,12 @@ pub struct MediaPart {
 }
 
 impl MediaPart {
-    /// `/decision` only. `Part.decision=transcode` means the *container* changes; a codec-copy
-    /// remux is still right unless the VIDEO stream's own decision is `transcode` (bit depth,
-    /// an undecodable codec, …). `docs/pms-api.md` measured Profile 5 as `Part=transcode` with
-    /// video `copy`. Absent streams, `copy`, or any other spelling do not forbid a remux.
+    /// Veto: a remux that copies video is forbidden only when a video `Stream` on this part
+    /// is `decision=transcode`. Silence is not a video re-encode — missing `Stream[]`, `copy`,
+    /// unnamed, or any other spelling leave copy allowed. Library metadata omits
+    /// `Stream.decision`; this reader is for `/decision` bodies. `Part.decision=transcode` is a
+    /// container change: TrueHD-only and Profile 5 are `Part=transcode` with video `copy`
+    /// (`docs/pms-api.md`).
     pub fn video_forbids_copy(&self) -> bool {
         self.stream
             .iter()

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -10,9 +10,10 @@
 //!     The caller MUST read the OUTPUT codecs off the returned body (Part.Stream[].codec):
 //!     the Load payload has to describe what the server will actually send, not the source
 //!     (see route::apply_decision_codecs and [[audio-payload-codecs]]).
-//! The ordinary calls return the parsed MediaContainer; a `?`/None degrades exactly like the old
-//! raw-body scan (caller falls back to the local codec heuristic / skips the codec override). The
-//! ABR deadline-bearing twin retains HTTP, deadline and transport causes for route policy.
+//! The ordinary calls return the parsed MediaContainer; a `?`/None from MDE means the caller
+//! must not Original (PMS 1.43 503s a Part without a registered decision) and may still remux
+//! or re-encode via a separate `transcode_decision`. The ABR deadline-bearing twin retains
+//! HTTP, deadline and transport causes for route policy.
 use super::client::{Client, JsonDeadlineOutcome, QueryBuilder, StreamUrl};
 use super::models::MediaContainer;
 use super::params::{Ceiling, TranscodeDelivery, TranscodeSpec};
@@ -28,6 +29,22 @@ use super::probe::Location;
 pub const DP_AUDIO_CODECS: &str = "aac,ac3,eac3";
 pub fn is_dp_audio(codec: &str) -> bool {
     crate::devcaps::caps().audio_has(codec)
+}
+
+/// Subtitle codecs Original client-renders (`ff.rs` / the track menu). This is the
+/// `subtitleCodec=` list on the direct-play profile **and** the gate on MDE's
+/// `subtitleStreamID`: a selected embedded track whose codec is here is named on `/decision`,
+/// anything else (sidecar, or a codec we render but do not advertise) is sent as `0` so MDE
+/// does not burn/transcode a sub the demuxer will draw itself.
+///
+/// Spellings are PMS profile names plus the FFmpeg/Stream.codec aliases they arrive as
+/// (`movtext` as in Roku; `dvd` beside `vobsub` / `dvd_subtitle`). Obscure `ff.rs` Plain
+/// aliases (`vplayer`, `jacosub`, …) stay off this list on purpose — unknown selected codecs
+/// take the `0` path rather than a full re-encode.
+pub const DP_SUBTITLE_CODECS: &str = "srt,subrip,ass,ssa,mov_text,movtext,webvtt,text,pgs,hdmv_pgs_subtitle,vobsub,dvd,dvd_subtitle,dvdsub,dvb_subtitle,dvbsub";
+pub fn is_dp_subtitle(codec: &str) -> bool {
+    let codec = codec.to_ascii_lowercase();
+    DP_SUBTITLE_CODECS.split(',').any(|c| c == codec)
 }
 
 // ---- the relay policy: what the LINK to a server allows a plan to ask for -------------------
@@ -194,12 +211,13 @@ fn profile_for_delivery(caps: &crate::devcaps::Caps, delivery: TranscodeDelivery
                 .to_string()
         }
     };
-    // pgs,vobsub: the demuxer client-renders those bitmaps (`ff.rs` / the track menu). Leaving
-    // them off made MDE answer transcode whenever a Blu-ray image sub was selected, which then
-    // 503'd the Original part GET ("decision is for a transcode").
+    // Image + text subs the demuxer client-renders (`ff.rs` / the track menu). Leaving a
+    // selected bitmap off made MDE answer transcode, which then 503'd the Original part GET
+    // ("decision is for a transcode"). [`DP_SUBTITLE_CODECS`] is the one list — MDE's
+    // `subtitleStreamID` gate reads the same constant.
     format!(
         "add-direct-play-profile(type=videoProfile&container=mkv,mp4&videoCodec={dp_video}\
-         &audioCodec={dp_audio}&subtitleCodec=srt,subrip,ass,ssa,pgs,vobsub)\
+         &audioCodec={dp_audio}&subtitleCodec={DP_SUBTITLE_CODECS})\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.width&value={w}&replace=true)\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.height&value={h}&replace=true)\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.bitDepth&value=10&replace=true)\
@@ -336,11 +354,16 @@ impl Client {
     /// `audio_stream_id` is the track the demuxer will actually feed (0 = omit, PMS uses the
     /// part default). Smart direct-play names the AAC/AC3/EAC3 sibling here so MDE does not
     /// veto a TrueHD/DTS default we never intended to play.
+    ///
+    /// `subtitle_stream_id` is always sent: a positive id is an advertised embedded track Original
+    /// will client-render; **0** tells MDE to evaluate with subs off so a selected sidecar or
+    /// unadvertised codec does not force a burn/transcode. (`opt_int` would omit 0.)
     pub fn mde_decision(
         &self,
         rating_key: &str,
         session: &str,
         audio_stream_id: i64,
+        subtitle_stream_id: i64,
     ) -> Option<MediaContainer> {
         let q = QueryBuilder::new("/video/:/transcode/universal/decision")
             .str("path", &format!("/library/metadata/{rating_key}"))
@@ -354,7 +377,8 @@ impl Client {
             .int("mediaBufferSize", 20971)
             .str("session", session)
             .str("X-Plex-Session-Identifier", session)
-            .opt_int("audioStreamID", audio_stream_id);
+            .opt_int("audioStreamID", audio_stream_id)
+            .int("subtitleStreamID", subtitle_stream_id);
         let q = self
             .playback_identity(q)
             .str("X-Plex-Client-Profile-Name", "Generic")
@@ -1099,6 +1123,25 @@ mod tests {
         assert_eq!(list_of(target_of(&p), "audioCodec="), ["aac"]);
     }
 
+    /// The profile's `subtitleCodec=` list IS [`DP_SUBTITLE_CODECS`] — MDE's stream-id gate
+    /// reads the same constant, so a selected PGS/mov_text/dvd_subtitle cannot be advertised
+    /// here and omitted from `/decision`, or the other way around.
+    #[test]
+    fn the_direct_play_subtitle_list_is_the_shared_constant() {
+        let p = super::profile_for(&Caps::assumed());
+        assert!(
+            p.contains(&format!("subtitleCodec={})", super::DP_SUBTITLE_CODECS)),
+            "profile must interpolate DP_SUBTITLE_CODECS verbatim: {p}"
+        );
+        assert!(super::is_dp_subtitle("MOV_TEXT"));
+        assert!(super::is_dp_subtitle("dvd_subtitle"));
+        assert!(super::is_dp_subtitle("hdmv_pgs_subtitle"));
+        assert!(
+            !super::is_dp_subtitle("vplayer"),
+            "obscure aliases stay off the advertised set"
+        );
+    }
+
     /// PIN: the assumed (table-unreadable) profile is byte-identical to the constant string the
     /// app sent before devcaps existed. This is the fallback half of devcaps' contract — the
     /// derivation may never drift for a device that was working yesterday, and any deliberate
@@ -1108,7 +1151,7 @@ mod tests {
         assert_eq!(
             super::profile_for(&Caps::assumed()),
             "add-direct-play-profile(type=videoProfile&container=mkv,mp4&videoCodec=h264,hevc\
-             &audioCodec=aac,ac3,eac3&subtitleCodec=srt,subrip,ass,ssa,pgs,vobsub)\
+             &audioCodec=aac,ac3,eac3&subtitleCodec=srt,subrip,ass,ssa,mov_text,movtext,webvtt,text,pgs,hdmv_pgs_subtitle,vobsub,dvd,dvd_subtitle,dvdsub,dvb_subtitle,dvbsub)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.width&value=3840&replace=true)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.height&value=2176&replace=true)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.bitDepth&value=10&replace=true)\

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -1142,10 +1142,11 @@ mod tests {
         );
     }
 
-    /// PIN: the assumed (table-unreadable) profile is byte-identical to the constant string the
-    /// app sent before devcaps existed. This is the fallback half of devcaps' contract — the
-    /// derivation may never drift for a device that was working yesterday, and any deliberate
-    /// profile change must update this literal to say so.
+    /// PIN: `Caps::assumed()` must emit this exact profile string. This is the assumed-caps
+    /// contract, not a claim that the string predates device-capability tables. A deliberate
+    /// profile edit must update this literal so the change is visible;
+    /// `the_direct_play_subtitle_list_is_the_shared_constant` is the interpolation gate
+    /// against [`DP_SUBTITLE_CODECS`].
     #[test]
     fn the_assumed_profile_is_byte_identical_to_the_shipped_one() {
         assert_eq!(

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -358,6 +358,11 @@ impl Client {
     /// `subtitle_stream_id` is always sent: a positive id is an advertised embedded track Original
     /// will client-render; **0** tells MDE to evaluate with subs off so a selected sidecar or
     /// unadvertised codec does not force a burn/transcode. (`opt_int` would omit 0.)
+    ///
+    /// `subtitles=none` is the client-rendered mode. Omitting it leaves PMS on `auto`, and
+    /// 1.43.4 HTTP 400s `hasMDE`+`directPlay` when the part already has a selected subtitle
+    /// (`invalid subtitle setting 'auto'`). That `None` fail-closes Original into remux and a
+    /// PUT `subtitleStreamID=0`, which clears the selection. `burn` would force a transcode.
     pub fn mde_decision(
         &self,
         rating_key: &str,
@@ -378,7 +383,8 @@ impl Client {
             .str("session", session)
             .str("X-Plex-Session-Identifier", session)
             .opt_int("audioStreamID", audio_stream_id)
-            .int("subtitleStreamID", subtitle_stream_id);
+            .int("subtitleStreamID", subtitle_stream_id)
+            .str("subtitles", "none");
         let q = self
             .playback_identity(q)
             .str("X-Plex-Client-Profile-Name", "Generic")

--- a/rust-modules/src/plex/transcoder.rs
+++ b/rust-modules/src/plex/transcoder.rs
@@ -194,9 +194,12 @@ fn profile_for_delivery(caps: &crate::devcaps::Caps, delivery: TranscodeDelivery
                 .to_string()
         }
     };
+    // pgs,vobsub: the demuxer client-renders those bitmaps (`ff.rs` / the track menu). Leaving
+    // them off made MDE answer transcode whenever a Blu-ray image sub was selected, which then
+    // 503'd the Original part GET ("decision is for a transcode").
     format!(
         "add-direct-play-profile(type=videoProfile&container=mkv,mp4&videoCodec={dp_video}\
-         &audioCodec={dp_audio}&subtitleCodec=srt,subrip,ass,ssa)\
+         &audioCodec={dp_audio}&subtitleCodec=srt,subrip,ass,ssa,pgs,vobsub)\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.width&value={w}&replace=true)\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.height&value={h}&replace=true)\
          +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.bitDepth&value=10&replace=true)\
@@ -329,7 +332,16 @@ impl Client {
     /// Decision Engine whether the item direct-plays given our capability profile. Registers
     /// the session as a side effect. The caller reads `Part.decision` ("directplay" vs
     /// "transcode") and the verdict codes off the returned container.
-    pub fn mde_decision(&self, rating_key: &str, session: &str) -> Option<MediaContainer> {
+    ///
+    /// `audio_stream_id` is the track the demuxer will actually feed (0 = omit, PMS uses the
+    /// part default). Smart direct-play names the AAC/AC3/EAC3 sibling here so MDE does not
+    /// veto a TrueHD/DTS default we never intended to play.
+    pub fn mde_decision(
+        &self,
+        rating_key: &str,
+        session: &str,
+        audio_stream_id: i64,
+    ) -> Option<MediaContainer> {
         let q = QueryBuilder::new("/video/:/transcode/universal/decision")
             .str("path", &format!("/library/metadata/{rating_key}"))
             .int("mediaIndex", 0)
@@ -341,7 +353,8 @@ impl Client {
             .int("directStreamAudio", 1)
             .int("mediaBufferSize", 20971)
             .str("session", session)
-            .str("X-Plex-Session-Identifier", session);
+            .str("X-Plex-Session-Identifier", session)
+            .opt_int("audioStreamID", audio_stream_id);
         let q = self
             .playback_identity(q)
             .str("X-Plex-Client-Profile-Name", "Generic")
@@ -410,6 +423,9 @@ impl Client {
     /// [`super::library::Client::scrobble`], it does not tell a 200 from a 404: `get_ok` is
     /// `http_get`'s own success, which is the honest limit of a GET whose body carries nothing.
     pub fn transcode_stop(&self, session: &str) -> bool {
+        if session.is_empty() {
+            return false;
+        }
         self.get_ok(&self.transcode_stop_query(session, true))
     }
 
@@ -417,6 +433,9 @@ impl Client {
     /// HLS→direct recovery uses this after decoded source frames: that raw Part is exact-borrowing
     /// the same resource, and terminating it here would make the next Range/seek return 503.
     pub(crate) fn transcode_stop_physical(&self, session: &str) -> bool {
+        if session.is_empty() {
+            return false;
+        }
         self.get_ok(&self.transcode_stop_query(session, false))
     }
 
@@ -442,6 +461,9 @@ impl Client {
     /// For the same authenticated owner, 404 is the idempotent already-closed answer; every other
     /// non-2xx status and transport failure remains inconclusive.
     pub fn transcode_resource_reconciled(&self, session: &str) -> Option<bool> {
+        if session.is_empty() {
+            return None;
+        }
         let q =
             QueryBuilder::new("/status/sessions/close").str("X-Plex-Session-Identifier", session);
         match self.post_status(&q.build())? {
@@ -458,6 +480,9 @@ impl Client {
     /// physical half; callers must follow it with [`Client::transcode_resource_reconciled`]. Every
     /// other response remains unknown.
     pub fn transcode_session_present(&self, session: &str) -> Option<bool> {
+        if session.is_empty() {
+            return None;
+        }
         let q = QueryBuilder::new("/video/:/transcode/universal/ping").str("session", session);
         match self.get_status(&q.build())? {
             200..=299 => Some(true),
@@ -643,6 +668,30 @@ mod tests {
             );
         }
         server.join().unwrap();
+    }
+
+    /// An empty `session=` is not a transcode identity. PMS logs "without a valid session GUID"
+    /// (and the matching ping warning) for that request; nothing on the server can be retired.
+    #[test]
+    fn an_empty_transcode_session_does_not_hit_the_wire() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port() as i32;
+        let client = Client::new(
+            ServerId::from_raw(1),
+            "mach",
+            Origin::http("127.0.0.1", port),
+            "tok",
+            "cid",
+        );
+        assert!(!client.transcode_stop(""));
+        assert!(!client.transcode_stop_physical(""));
+        assert_eq!(client.transcode_session_present(""), None);
+        assert_eq!(client.transcode_resource_reconciled(""), None);
+        match listener.accept() {
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            other => panic!("empty session must not open a socket: {other:?}"),
+        }
     }
 
     /// **`directStream` is the server's permission to copy the video track, and the ordinary
@@ -1059,7 +1108,7 @@ mod tests {
         assert_eq!(
             super::profile_for(&Caps::assumed()),
             "add-direct-play-profile(type=videoProfile&container=mkv,mp4&videoCodec=h264,hevc\
-             &audioCodec=aac,ac3,eac3&subtitleCodec=srt,subrip,ass,ssa)\
+             &audioCodec=aac,ac3,eac3&subtitleCodec=srt,subrip,ass,ssa,pgs,vobsub)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.width&value=3840&replace=true)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.height&value=2176&replace=true)\
              +add-limitation(scope=videoCodec&scopeName=*&type=upperBound&name=video.bitDepth&value=10&replace=true)\

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -8597,6 +8597,19 @@ mod tests {
                                     .write_all(&vec![0x55; bytes])
                                     .expect("start.mkv body");
                             }
+                        } else if first.contains("/decision?")
+                            && first.contains("hasMDE=1")
+                            && first.contains("directPlay=1")
+                            && query_param(&first, "subtitles") != Some("none")
+                        {
+                            // PMS 1.43.4: hasMDE+directPlay with a selected subtitle and
+                            // subtitles=auto (the default when omitted) is HTTP 400.
+                            use std::io::Write;
+                            write!(
+                                socket,
+                                "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            )
+                            .expect("400");
                         } else {
                             let body = if first.contains("/decision?") {
                                 mde_body
@@ -8711,6 +8724,11 @@ mod tests {
             query_param(decision, "subtitleStreamID"),
             Some("0"),
             "no selectable embedded sub → explicit 0: {decision}"
+        );
+        assert_eq!(
+            query_param(decision, "subtitles"),
+            Some("none"),
+            "MDE must name client-rendered mode; auto 400s a selected sub: {decision}"
         );
         assert!(
             plan.url.contains("/library/parts/36013/"),
@@ -9093,8 +9111,9 @@ mod tests {
         crate::plex::reset_servers_for_test();
     }
 
-    /// TrueHD default `id=1` is what `env.audio_sid` still carries (play-path PUT / transcode_spec).
-    /// MDE and the remux probe must name the AC3 sibling `id=2` that smart-DP will actually feed.
+    /// TrueHD default `id=1` is what `env.audio_sid` still carries at resolve start.
+    /// MDE, the remux probe, the play-path PUT, and the installed start.mkv must all name the
+    /// AC3 sibling `id=2` that smart-DP will actually feed.
     #[test]
     fn remote_auto_truehd_remux_probe_names_the_ac3_sibling_not_env_audio_sid() {
         use std::time::Duration;
@@ -9145,7 +9164,7 @@ mod tests {
         );
         item.bitrate = 320;
         env.cached_item = Some(item);
-        let _plan = build_stream(
+        let plan = build_stream(
             "rk-4k",
             "/library/parts/36013/1/file.mkv",
             "hevc",
@@ -9179,6 +9198,26 @@ mod tests {
             query_param(remux_probe, "audioStreamID"),
             Some("2"),
             "remux probe must name the AC3 sibling, not env.audio_sid=1: {remux_probe}"
+        );
+        let put = requests
+            .iter()
+            .find(|line| line.contains("PUT /library/parts/"))
+            .unwrap_or_else(|| panic!("play-path PUT was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(put, "audioStreamID"),
+            Some("2"),
+            "PUT must select the AC3 sibling, not env.audio_sid=1: {put}"
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "Remote Auto remux installs start.mkv: {}",
+            plan.url
+        );
+        assert_eq!(
+            query_param(&plan.url, "audioStreamID"),
+            Some("2"),
+            "playback URL must name the AC3 sibling, not env.audio_sid=1: {}",
+            plan.url
         );
         restore_quality(Quality::Original);
         crate::plex::reset_servers_for_test();
@@ -9317,6 +9356,63 @@ mod tests {
         crate::plex::reset_servers_for_test();
     }
 
+    /// Selected embedded SRT is client-rendered on Original. MDE must name that stream id
+    /// *and* `subtitles=none`: 1.43.4 400s hasMDE+directPlay with a selected subtitle and
+    /// the default `auto`. The mock PMS rejects that shape, so omitting the mode fail-closes
+    /// into remux + PUT sub=0 (the selected subtitle disappears).
+    #[test]
+    fn selected_embedded_srt_names_id_and_client_rendered_mode_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-srt",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-srt-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item_with_subs(
+            sid,
+            vec![eac3_track()],
+            vec![selected_sub(55001, "srt")],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("55001"),
+            "MDE must evaluate the SRT track Original will render: {decision}"
+        );
+        assert_eq!(
+            query_param(decision, "subtitles"),
+            Some("none"),
+            "client-rendered mode; auto is the 1.43.4 400: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "selected SRT must stay Original, not remux: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
     /// Selected PGS is client-rendered on Original; MDE must see that stream id (and the profile
     /// must list pgs) so the decision stays directplay.
     #[test]
@@ -9353,6 +9449,11 @@ mod tests {
             query_param(decision, "subtitleStreamID"),
             Some("99001"),
             "MDE must evaluate the PGS track Original will render: {decision}"
+        );
+        assert_eq!(
+            query_param(decision, "subtitles"),
+            Some("none"),
+            "named bitmap still client-rendered, not auto/burn: {decision}"
         );
         assert!(
             plan.url.contains("/library/parts/36013/"),

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -4821,25 +4821,26 @@ fn apply_quality_choice(ps: &mut PlaybackSession, q: Quality) {
     crate::player::request_transcode_refresh(ps);
 }
 
-pub(super) fn measure_remote_original(
-    client: &crate::plex::Client,
-    part_key: &str,
-    logical_session: &str,
-    source_kbps: i64,
-) -> Option<crate::abr::CapacityObservation> {
+/// **One bounded measurement of the actual file, as an observation and nothing more.** It reports
+/// bytes, active duration and whether the target was reached, because all three decide how much
+/// the measurement is worth: a 40 KiB read that finished instantly honestly reports a huge rate
+/// and proves nothing. What it does NOT do is decide anything — [`crate::abr::bootstrap`] owns the
+/// admission rule, so the policy is stated once and is host-testable without a network.
+///
+/// `None` means there is nothing to reason from (no source bitrate, or the transfer never
+/// returned), which is deliberately distinct from a completed slow probe.
+pub(super) fn measure_remote_original(url: &str, source_kbps: i64) -> Option<crate::abr::CapacityObservation> {
     let Some(plan) = remote_probe_plan(source_kbps) else {
         crate::player::log(
             "auto: remote Original unavailable — source bitrate is unknown; using HLS",
         );
         return None;
     };
-    // Use the playback's own identity. If the bounded GET establishes a Streaming Resource, the
-    // winning route — Original or the initial HLS encoder — exact-reuses it. A throwaway
-    // `source-N` forces an exact miss and makes PMS run a second AdHoc admission decision whose
-    // 500 says nothing about transport capacity.
-    let url = client.direct_play_url(part_key, logical_session).to_url();
+    // `url` already names the playback's own identity. Direct play samples the Part; a remux
+    // Original samples start.mkv. A throwaway `source-N` forces an exact miss and makes PMS run a
+    // second AdHoc admission decision whose 500 says nothing about transport capacity.
     let sample = match crate::curlio::sample_throughput_result(
-        &url,
+        url,
         plan.target_bytes,
         std::time::Duration::from_millis(plan.budget_ms),
         std::time::Duration::from_millis(plan.budget_ms),
@@ -4867,10 +4868,48 @@ pub(super) fn measure_remote_original(
     })
 }
 
-/// Ask PMS whether `rk` should direct-play (Some(true) → serve the raw Part) or transcode
-/// (Some(false) → start.mkv). None when the server returns no usable Media decision: the caller
-/// must not Original (PMS 1.43 503s a Part without a registered decision) but may still remux
-/// or re-encode via a separate `transcode_decision`. Registers the session as a side effect.
+/// PMS 1.43 503s a Part GET after a transcode MDE. The Original we would actually play is a
+/// codec-copy remux, so the Remote capacity sample has to be that `start.mkv`, under the same
+/// session identity a direct Part probe uses.
+pub(super) fn measure_remote_remux(
+    client: &crate::plex::Client,
+    rk: &str,
+    session: &str,
+    audio_stream_id: i64,
+    subtitle_stream_id: i64,
+    source_kbps: i64,
+) -> Option<crate::abr::CapacityObservation> {
+    let spec = transcode_spec(
+        rk,
+        session,
+        session,
+        true,
+        false,
+        crate::plex::TranscodeOffset::Fresh,
+        audio_stream_id,
+        subtitle_stream_id,
+        None,
+        crate::plex::TranscodeDelivery::ProgressiveMkv,
+    );
+    if client.transcode_decision(&spec).is_none() {
+        crate::player::log("auto: remote remux preflight had no /decision; using HLS");
+        return None;
+    }
+    measure_remote_original(&client.transcode_start_url(&spec).to_url(), source_kbps)
+}
+
+/// MDE handshake result. `None` from [`server_decision`] means the body was missing or unusable:
+/// the caller must not Original, but remux is still allowed. `Part.decision=transcode` is a
+/// container change, not a video-copy veto — see [`crate::plex::MediaPart::video_forbids_copy`].
+pub(super) struct MdeVerdict {
+    pub(super) original: bool,
+    pub(super) video_forbids_copy: bool,
+}
+
+/// Ask PMS whether `rk` should direct-play (`original`) or go through start.mkv. None when the
+/// server returns no usable Media decision: the caller must not Original (PMS 1.43 503s a Part
+/// without a registered decision) but may still remux or re-encode via a separate
+/// `transcode_decision`. Registers the session as a side effect.
 ///
 /// Takes the `Client` rather than looking one up: this runs on the resolve worker, and `rk` is only
 /// an item on the server the caller resolved from this playback's captured `ServerId`.
@@ -4880,7 +4919,7 @@ pub(super) fn server_decision(
     session: &str,
     audio_stream_id: i64,
     subtitle_stream_id: i64,
-) -> Option<bool> {
+) -> Option<MdeVerdict> {
     let mc = match c.mde_decision(rk, session, audio_stream_id, subtitle_stream_id) {
         Some(mc) => mc,
         None => {
@@ -4889,7 +4928,8 @@ pub(super) fn server_decision(
             return None;
         }
     };
-    // Part.decision is the authoritative verdict (Media/container carry none)
+    // Part.decision is the Original-vs-not verdict (Media/container carry none). Video copy
+    // is the VIDEO stream's own decision — Part=transcode + video=copy is a remux.
     let part = match mc
         .metadata
         .first()
@@ -4905,15 +4945,31 @@ pub(super) fn server_decision(
             return None;
         }
     };
-    let direct = part.decision == "directplay";
+    let original = part.decision == "directplay";
+    let video_forbids_copy = part.video_forbids_copy();
+    let video = part
+        .stream
+        .iter()
+        .find(|s| s.stream_type == 1)
+        .map(|s| s.decision.as_str())
+        .unwrap_or("-");
     crate::player::log(&format!(
-        "decision: part={} general={:?} mde={:?} -> {}",
+        "decision: part={} video={video} general={:?} mde={:?} -> {}",
         part.decision,
         mc.general_decision_code,
         mc.mde_decision_code,
-        if direct { "DIRECT PLAY" } else { "TRANSCODE" }
+        if original {
+            "DIRECT PLAY"
+        } else if video_forbids_copy {
+            "TRANSCODE"
+        } else {
+            "REMUX"
+        }
     ));
-    Some(direct)
+    Some(MdeVerdict {
+        original,
+        video_forbids_copy,
+    })
 }
 
 /// Select the audio + subtitle streams server-side for the current part before a
@@ -5615,7 +5671,9 @@ fn apply_plan(ps: &mut PlaybackSession, plan: Plan, rk: &str) -> Option<RouteSta
         String::new()
     };
     let resolve_failed = plan.url.is_empty() && plan.verdict.is_none();
-    crate::stores::metadata::apply(crate::stores::metadata::MetadataCmd::InstallPlaying(plan.playing));
+    crate::stores::metadata::apply(crate::stores::metadata::MetadataCmd::InstallPlaying(
+        plan.playing,
+    ));
     // main thread only — `up_next()`/`with_queue()` lend out of this (see their docs). The rows
     // arrive already projected: the worker never retained a `Metadata` tree to install here.
     { let s = &mut *ps; {
@@ -6205,6 +6263,17 @@ mod tests {
             present: true,
             profile: 8,
             bl_compat: 1,
+            el_present: false,
+            ..crate::metadata::Dovi::NONE
+        }
+    }
+
+    /// Same provenance as `plan::tests::p5`: single-layer IPT-PQ with no HDR10 fallback.
+    fn p5() -> crate::metadata::Dovi {
+        crate::metadata::Dovi {
+            present: true,
+            profile: 5,
+            bl_compat: 0,
             el_present: false,
             ..crate::metadata::Dovi::NONE
         }
@@ -7287,7 +7356,10 @@ mod tests {
             .expect("a granted transaction mints one physical Load attempt");
         assert!(settle_route_start(&mut ps, attempt, RouteStartResult::Started));
         assert_eq!(
-            PLAYER_CONTROL.lock().unwrap_or_else(|e| e.into_inner()).phase,
+            PLAYER_CONTROL
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .phase,
             ControlPhase::Stable,
             "the replayed Load settles into an ordinary publishable route",
         );
@@ -8115,9 +8187,10 @@ mod tests {
             "cid-probe-cold",
         );
         let client = crate::plex::client_for(sid).expect("test server installed");
-        let sample =
-            measure_remote_original(client, "/library/parts/1/file.mkv", "cold-logical", 320)
-                .expect("completed cold sample");
+        let url = client
+            .direct_play_url("/library/parts/1/file.mkv", "cold-logical")
+            .to_url();
+        let sample = measure_remote_original(&url, 320).expect("completed cold sample");
         assert!(sample.completed);
 
         let requests = rx.recv().expect("captured cold requests");
@@ -8383,6 +8456,10 @@ mod tests {
         br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"directplay"}]}]}]}}"#;
     const MDE_TRANSCODE: &[u8] =
         br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"transcode"}]}]}]}}"#;
+    /// Part.decision=transcode, video copied, audio transcoded — the measured TrueHD-only shape.
+    const MDE_TRANSCODE_COPY: &[u8] = br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"transcode","Stream":[{"streamType":1,"decision":"copy"},{"streamType":2,"decision":"transcode"}]}]}]}]}}"#;
+    /// Part.decision=transcode AND the video lane itself is transcode (bit depth, …).
+    const MDE_TRANSCODE_VIDEO: &[u8] = br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"transcode","Stream":[{"streamType":1,"decision":"transcode"}]}]}]}]}}"#;
     const EMPTY_MC: &[u8] = br#"{"MediaContainer":{}}"#;
 
     fn drain_http(socket: &mut std::net::TcpStream) -> String {
@@ -8438,6 +8515,33 @@ mod tests {
         std::sync::mpsc::Receiver<Vec<String>>,
         std::thread::JoinHandle<()>,
     ) {
+        plan_pms_inner(n, mde_body, None)
+    }
+
+    /// Same as [`plan_pms`], plus a bounded `start.mkv` body so Remote Auto can probe a remux.
+    /// A Part GET is 503 — that is PMS 1.43 after a transcode MDE, and the test grades that we
+    /// never ask.
+    fn plan_pms_with_start_mkv(
+        n: usize,
+        mde_body: &'static [u8],
+        start_bytes: usize,
+    ) -> (
+        i32,
+        std::sync::mpsc::Receiver<Vec<String>>,
+        std::thread::JoinHandle<()>,
+    ) {
+        plan_pms_inner(n, mde_body, Some(start_bytes))
+    }
+
+    fn plan_pms_inner(
+        n: usize,
+        mde_body: &'static [u8],
+        start_bytes: Option<usize>,
+    ) -> (
+        i32,
+        std::sync::mpsc::Receiver<Vec<String>>,
+        std::thread::JoinHandle<()>,
+    ) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().unwrap().port() as i32;
         let (tx, rx) = std::sync::mpsc::channel();
@@ -8450,14 +8554,39 @@ mod tests {
                     Ok((mut socket, _)) => {
                         // The listener is nonblocking; on macOS the accepted fd inherits that,
                         // and a parallel suite can accept before the request line is buffered.
-                        socket.set_nonblocking(false).expect("blocking accepted socket");
+                        socket
+                            .set_nonblocking(false)
+                            .expect("blocking accepted socket");
                         let first = drain_http(&mut socket);
-                        let body = if first.contains("/decision?") {
-                            mde_body
+                        if start_bytes.is_some() && first.contains("/library/parts/") {
+                            use std::io::Write;
+                            write!(
+                                socket,
+                                "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            )
+                            .expect("503");
+                        } else if let Some(bytes) =
+                            start_bytes.filter(|_| first.contains("start.mkv"))
+                        {
+                            use std::io::Write;
+                            write!(
+                                socket,
+                                "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-{}/{}\r\nContent-Length: {bytes}\r\nConnection: close\r\n\r\n",
+                                bytes.saturating_sub(1),
+                                bytes.saturating_mul(2),
+                            )
+                            .expect("start.mkv headers");
+                            socket
+                                .write_all(&vec![0x55; bytes])
+                                .expect("start.mkv body");
                         } else {
-                            EMPTY_MC
-                        };
-                        write_json(&mut socket, body);
+                            let body = if first.contains("/decision?") {
+                                mde_body
+                            } else {
+                                EMPTY_MC
+                            };
+                            write_json(&mut socket, body);
+                        }
                         requests.push(first);
                     }
                     Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -8648,8 +8777,8 @@ mod tests {
     }
 
     /// OpenAPI: a Part GET whose decision is a transcode is HTTP 503. Honour MDE rather than
-    /// returning the part URL the local codec test would have chosen — and do not remux-copy
-    /// either, or we still ignore the veto.
+    /// returning the part URL the local codec test would have chosen. A `/decision` body that
+    /// names no video stream cannot claim the video must re-encode, so this unnamed shape remuxes.
     #[test]
     fn mde_transcode_does_not_return_the_part_url() {
         use std::time::Duration;
@@ -8694,9 +8823,251 @@ mod tests {
             plan.url
         );
         assert!(
-            !plan.remux,
-            "explicit MDE transcode forbids a local codec-copy remux"
+            plan.remux,
+            "Part.decision=transcode with no Stream[] cannot claim a video re-encode: {}",
+            plan.url
         );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// HEVC+TrueHD with no AAC/AC3/EAC3 sibling: MDE transcodes the part (TrueHD is not in the
+    /// profile) but the video can still be copied. A Part-level veto would re-encode 4K for an
+    /// audio problem.
+    #[test]
+    fn mde_transcode_for_truehd_only_still_remuxes() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(4, MDE_TRANSCODE_COPY);
+        let sid = crate::plex::register_for_test(
+            "mde-truehd",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-truehd-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![crate::metadata::Stream {
+                id: 36014,
+                index: 1,
+                lang_code: "eng".into(),
+                codec: "truehd".into(),
+                channels: 8,
+                default: true,
+                selected: true,
+                ..Default::default()
+            }],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "truehd",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("/decision?") && line.contains("hasMDE=1")),
+            "MDE was still asked: {requests:?}"
+        );
+        assert!(
+            !plan.url.contains("/library/parts/36013/"),
+            "TrueHD-only cannot Original: {}",
+            plan.url
+        );
+        assert!(
+            plan.remux,
+            "TrueHD-only must codec-copy remux, not re-encode 4K: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// A video-stream `transcode` (bit depth past the profile, …) is the copy veto. Remux here
+    /// would ship pixels the decoder cannot take.
+    #[test]
+    fn mde_video_stream_transcode_forbids_remux() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(4, MDE_TRANSCODE_VIDEO);
+        let sid = crate::plex::register_for_test(
+            "mde-vid-tc",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-vid-tc-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(sid, vec![eac3_track()]));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("/decision?") && line.contains("hasMDE=1")),
+            "MDE was still asked: {requests:?}"
+        );
+        assert!(
+            !plan.url.contains("/library/parts/36013/"),
+            "video transcode must not Original: {}",
+            plan.url
+        );
+        assert!(
+            !plan.remux,
+            "video-stream transcode forbids a codec-copy remux"
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Declared Profile 5 can Original, but a remux copy carries no `DolbyHdrInfo`. MDE's
+    /// video=`copy` (the measured P5 shape) must not override `no_video_copy`.
+    #[test]
+    fn mde_transcode_copy_still_refuses_a_profile_5_remux() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(4, MDE_TRANSCODE_COPY);
+        let sid = crate::plex::register_for_test(
+            "mde-p5-copy",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-p5-copy-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        let mut item = fourk_item(sid, vec![eac3_track()]);
+        item.dovi = p5();
+        env.cached_item = Some(item);
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("/decision?") && line.contains("hasMDE=1")),
+            "declared P5 still asks MDE: {requests:?}"
+        );
+        assert!(
+            !plan.remux,
+            "a P5 remux is the IPT-PQ bitstream with no declaration: {}",
+            plan.url
+        );
+        assert!(
+            plan.no_video_copy,
+            "the copy permission has to be withdrawn or PMS copies anyway"
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Remote Auto used to probe the Part after MDE registered transcode, which 503s, so bootstrap
+    /// fell through to HLS and re-encoded 4K for an audio-only veto. The probe has to sample the
+    /// remux `start.mkv` we would actually play.
+    #[test]
+    fn remote_auto_truehd_remux_probes_start_mkv_not_the_part() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        if !crate::net::global_init() || !crate::curlio::available() {
+            return;
+        }
+        restore_quality(Quality::Auto);
+        let probe_bytes = crate::abr::source_probe_plan(320, crate::abr::PROBE_BUDGET_MS)
+            .expect("tiny source still has a probe object")
+            .target_bytes;
+        let (port, rx, server) = plan_pms_with_start_mkv(6, MDE_TRANSCODE_COPY, probe_bytes);
+        let sid = crate::plex::register_for_test(
+            "mde-remote-truehd",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-remote-truehd-client",
+        );
+        crate::plex::client_for(sid)
+            .expect("registered")
+            .set_link(crate::plex::probe::Location::Remote);
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        let mut item = fourk_item(
+            sid,
+            vec![crate::metadata::Stream {
+                id: 36014,
+                index: 1,
+                lang_code: "eng".into(),
+                codec: "truehd".into(),
+                channels: 8,
+                default: true,
+                selected: true,
+                ..Default::default()
+            }],
+        );
+        item.bitrate = 320;
+        env.cached_item = Some(item);
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "truehd",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("/decision?") && line.contains("hasMDE=1")),
+            "MDE was still asked: {requests:?}"
+        );
+        assert!(
+            !requests
+                .iter()
+                .any(|line| line.contains("GET /library/parts/")),
+            "a Part GET after transcode MDE is 503: {requests:?}"
+        );
+        assert!(
+            requests.iter().any(|line| line.contains("start.mkv")),
+            "Remote Auto must probe the remux: {requests:?}"
+        );
+        assert!(
+            plan.remux,
+            "TrueHD-only Remote Auto must codec-copy remux, not HLS-encode 4K: {}",
+            plan.url
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "the installed route is the remux: {}",
+            plan.url
+        );
+        restore_quality(Quality::Original);
         crate::plex::reset_servers_for_test();
     }
 

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -4868,8 +4868,9 @@ pub(super) fn measure_remote_original(
 }
 
 /// Ask PMS whether `rk` should direct-play (Some(true) → serve the raw Part) or transcode
-/// (Some(false) → start.mkv). None when the server returns no usable Media decision, so the
-/// caller falls back to the local codec test. Registers the session as a side effect.
+/// (Some(false) → start.mkv). None when the server returns no usable Media decision: the caller
+/// must not Original (PMS 1.43 503s a Part without a registered decision) but may still remux
+/// or re-encode via a separate `transcode_decision`. Registers the session as a side effect.
 ///
 /// Takes the `Client` rather than looking one up: this runs on the resolve worker, and `rk` is only
 /// an item on the server the caller resolved from this playback's captured `ServerId`.
@@ -4878,13 +4879,13 @@ pub(super) fn server_decision(
     rk: &str,
     session: &str,
     audio_stream_id: i64,
+    subtitle_stream_id: i64,
 ) -> Option<bool> {
-    let mc = match c.mde_decision(rk, session, audio_stream_id) {
+    let mc = match c.mde_decision(rk, session, audio_stream_id, subtitle_stream_id) {
         Some(mc) => mc,
         None => {
-            // failed fetch OR unparseable (XML/truncated) body — keep the fallback visible
-            // in the event log, like the old raw-body scan did
-            crate::player::log("decision: no/unparseable response -> local heuristic");
+            // failed fetch OR unparseable (XML/truncated) body — no Original Part
+            crate::player::log("decision: no/unparseable response -> no Original");
             return None;
         }
     };
@@ -4898,7 +4899,7 @@ pub(super) fn server_decision(
         Some(p) => p,
         None => {
             crate::player::log(&format!(
-                "decision: no media (general={:?}) -> local heuristic",
+                "decision: no media (general={:?}) -> no Original",
                 mc.general_decision_code
             ));
             return None;
@@ -4916,11 +4917,12 @@ pub(super) fn server_decision(
 }
 
 /// Select the audio + subtitle streams server-side for the current part before a
-/// transcode. The transcoder encodes the part's SELECTED audio and BURNS its SELECTED
-/// subtitle (our client profile advertises no soft-sub support, so Plex's decision is
-/// always burn) — a query-param subtitleStreamID does NOT suppress a default-selected
-/// sub, only the PUT does. So we PUT subtitleStreamID=0 to keep subs OFF (no burn), or
-/// the chosen id to burn it; audioStreamID only when the user switched (else keep default).
+/// transcode. The transcoder encodes the part's SELECTED audio and, when a subtitle id is
+/// non-zero, BURNS that subtitle (query-param subtitleStreamID does NOT suppress a
+/// default-selected sub, only the PUT does). The direct-play profile advertises text and
+/// client-rendered bitmap codecs; burn is still the remux/re-encode path when we PUT a
+/// positive subtitle id. We PUT subtitleStreamID=0 to keep subs OFF (no burn), or the chosen
+/// id to burn it; audioStreamID only when the user switched (else keep default).
 ///
 /// `sid` names the server that owns `part` — the resolve worker passes the id it was given, and the
 /// in-playback callers pass [`cur_sid`]. A `Part.id` is server-local, so a PUT sent to the wrong
@@ -8182,6 +8184,7 @@ mod tests {
 
 
 
+
     // ---- video_direct_plays: the local codec + resolution + Dolby Vision direct-play gate ----
 
 
@@ -8405,6 +8408,16 @@ mod tests {
         first
     }
 
+    /// Exact `key=value` on a request-line query, so `subtitleStreamID=0` cannot match `88001`.
+    fn query_param<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+        let query = line.split_once('?')?.1;
+        let query = query.split_whitespace().next().unwrap_or(query);
+        query.split('&').find_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            (k == key).then_some(v)
+        })
+    }
+
     fn write_json(socket: &mut std::net::TcpStream, body: &[u8]) {
         use std::io::Write;
         write!(
@@ -8435,6 +8448,9 @@ mod tests {
             while requests.len() < n && std::time::Instant::now() < deadline {
                 match listener.accept() {
                     Ok((mut socket, _)) => {
+                        // The listener is nonblocking; on macOS the accepted fd inherits that,
+                        // and a parallel suite can accept before the request line is buffered.
+                        socket.set_nonblocking(false).expect("blocking accepted socket");
                         let first = drain_http(&mut socket);
                         let body = if first.contains("/decision?") {
                             mde_body
@@ -8459,11 +8475,19 @@ mod tests {
         sid: ServerId,
         audio: Vec<crate::metadata::Stream>,
     ) -> crate::metadata::PlayingItem {
+        fourk_item_with_subs(sid, audio, Vec::new())
+    }
+
+    fn fourk_item_with_subs(
+        sid: ServerId,
+        audio: Vec<crate::metadata::Stream>,
+        subs: Vec<crate::metadata::Stream>,
+    ) -> crate::metadata::PlayingItem {
         crate::metadata::PlayingItem {
             sid,
             rk: "rk-4k".into(),
             audio,
-            subs: Vec::new(),
+            subs,
             video_fps: 23.976,
             width: 3840,
             height: 2160,
@@ -8471,6 +8495,31 @@ mod tests {
             dovi: crate::metadata::Dovi::NONE,
             markers: Vec::new(),
             chapters: Vec::new(),
+        }
+    }
+
+    fn eac3_track() -> crate::metadata::Stream {
+        crate::metadata::Stream {
+            id: 36014,
+            index: 1,
+            lang_code: "eng".into(),
+            codec: "eac3".into(),
+            channels: 6,
+            default: true,
+            selected: true,
+            profile: "dolby digital plus + dolby atmos".into(),
+            ..Default::default()
+        }
+    }
+
+    fn selected_sub(id: i64, codec: &str) -> crate::metadata::Stream {
+        crate::metadata::Stream {
+            id,
+            index: 0,
+            lang_code: "eng".into(),
+            codec: codec.into(),
+            selected: true,
+            ..Default::default()
         }
     }
 
@@ -8491,20 +8540,7 @@ mod tests {
             "mde-dp-client",
         );
         let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
-        env.cached_item = Some(fourk_item(
-            sid,
-            vec![crate::metadata::Stream {
-                id: 36014,
-                index: 1,
-                lang_code: "eng".into(),
-                codec: "eac3".into(),
-                channels: 6,
-                default: true,
-                selected: true,
-                profile: "dolby digital plus + dolby atmos".into(),
-                ..Default::default()
-            }],
-        ));
+        env.cached_item = Some(fourk_item(sid, vec![eac3_track()]));
         let plan = build_stream(
             "rk-4k",
             "/library/parts/36013/1/file.mkv",
@@ -8524,6 +8560,11 @@ mod tests {
         assert!(decision.contains("hasMDE=1"), "{decision}");
         assert!(decision.contains("directPlay=1"), "{decision}");
         assert!(decision.contains("audioStreamID=36014"), "{decision}");
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("0"),
+            "no selectable embedded sub → explicit 0: {decision}"
+        );
         assert!(
             plan.url.contains("/library/parts/36013/"),
             "admitted Original is the raw part: {}",
@@ -8597,16 +8638,18 @@ mod tests {
             decision.contains("audioStreamID=2"),
             "MDE must see the AC3 sibling, not TrueHD: {decision}"
         );
-        assert!(
-            plan.url.contains("/library/parts/36013/"),
-            "{}",
-            plan.url
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("0"),
+            "{decision}"
         );
+        assert!(plan.url.contains("/library/parts/36013/"), "{}", plan.url);
         crate::plex::reset_servers_for_test();
     }
 
     /// OpenAPI: a Part GET whose decision is a transcode is HTTP 503. Honour MDE rather than
-    /// returning the part URL the local codec test would have chosen.
+    /// returning the part URL the local codec test would have chosen — and do not remux-copy
+    /// either, or we still ignore the veto.
     #[test]
     fn mde_transcode_does_not_return_the_part_url() {
         use std::time::Duration;
@@ -8621,19 +8664,7 @@ mod tests {
             "mde-tc-client",
         );
         let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
-        env.cached_item = Some(fourk_item(
-            sid,
-            vec![crate::metadata::Stream {
-                id: 36014,
-                index: 1,
-                lang_code: "eng".into(),
-                codec: "eac3".into(),
-                channels: 6,
-                default: true,
-                selected: true,
-                ..Default::default()
-            }],
-        ));
+        env.cached_item = Some(fourk_item(sid, vec![eac3_track()]));
         let plan = build_stream(
             "rk-4k",
             "/library/parts/36013/1/file.mkv",
@@ -8660,6 +8691,267 @@ mod tests {
         assert!(
             !plan.url.contains("/library/parts/36013/"),
             "a transcode decision must not be served as Original: {}",
+            plan.url
+        );
+        assert!(
+            !plan.remux,
+            "explicit MDE transcode forbids a local codec-copy remux"
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// An empty / unusable MDE body must not fall back to Original — that Part GET 503s on 1.43.
+    /// Remux/re-encode via a separate registering decision is still allowed.
+    #[test]
+    fn unreachable_mde_does_not_return_the_part_url() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(4, EMPTY_MC);
+        let sid = crate::plex::register_for_test(
+            "mde-empty",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-empty-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(sid, vec![eac3_track()]));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("/decision?") && line.contains("hasMDE=1")),
+            "MDE was still asked: {requests:?}"
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "no usable MDE → remux/re-encode, not Original: {}",
+            plan.url
+        );
+        assert!(
+            !plan.url.contains("/library/parts/36013/"),
+            "unreachable MDE must not serve the Part: {}",
+            plan.url
+        );
+        assert!(
+            plan.remux,
+            "HEVC+EAC3 with unreachable MDE still codec-copy remuxes: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Selected PGS is client-rendered on Original; MDE must see that stream id (and the profile
+    /// must list pgs) so the decision stays directplay.
+    #[test]
+    fn selected_pgs_names_subtitle_stream_id_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid =
+            crate::plex::register_for_test("mde-pgs", "127.0.0.1", port, "token", "mde-pgs-client");
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item_with_subs(
+            sid,
+            vec![eac3_track()],
+            vec![selected_sub(99001, "pgs")],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("99001"),
+            "MDE must evaluate the PGS track Original will render: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "PGS + EAC3 stays Original when MDE allows: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// A selected external sidecar is not in the container — Original leaves subs off. MDE must
+    /// see subtitleStreamID=0 so it does not force a burn/transcode for a sub we will not render.
+    #[test]
+    fn external_selected_sub_sends_subtitle_stream_id_zero_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-ext-sub",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-ext-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item_with_subs(
+            sid,
+            vec![eac3_track()],
+            vec![{
+                let mut s = selected_sub(88001, "srt");
+                s.external = true;
+                s
+            }],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("0"),
+            "sidecar is not burned on Original: {decision}"
+        );
+        assert_ne!(
+            query_param(decision, "subtitleStreamID"),
+            Some("88001"),
+            "must not advertise the external id: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "MDE with subs off stays Original: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Selected embedded `mov_text` (iTunes MP4) is client-rendered; the profile lists it so
+    /// MDE must see the stream id and stay Original rather than re-encoding.
+    #[test]
+    fn selected_mov_text_names_subtitle_stream_id_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-mov-text",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-mov-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item_with_subs(
+            sid,
+            vec![eac3_track()],
+            vec![selected_sub(77001, "mov_text")],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("77001"),
+            "MDE must evaluate the mov_text track Original will render: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "mov_text + EAC3 stays Original when MDE allows: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// PMS reports DVD bitmaps as `dvd_subtitle`; listing only `dvd` would MDE-transcode and
+    /// then forbid remux. The stream id must land on `/decision`.
+    #[test]
+    fn selected_dvd_subtitle_names_subtitle_stream_id_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-dvd-sub",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-dvd-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item_with_subs(
+            sid,
+            vec![eac3_track()],
+            vec![selected_sub(66001, "dvd_subtitle")],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(decision, "subtitleStreamID"),
+            Some("66001"),
+            "MDE must evaluate the dvd_subtitle track: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "dvd_subtitle + EAC3 stays Original when MDE allows: {}",
             plan.url
         );
         crate::plex::reset_servers_for_test();

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -9223,6 +9223,350 @@ mod tests {
         crate::plex::reset_servers_for_test();
     }
 
+    /// 720p denies remux, so the encoder can transcode the selected DTS. Putting the smart-DP
+    /// AC3 sibling here replaced English with the Russian default (reproduced on PMS 1.43.4).
+    #[test]
+    fn a_720p_reencode_puts_the_selected_dts_not_the_ac3_sibling() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        restore_quality(Quality::P720);
+        let (port, rx, server) = plan_pms(3, EMPTY_MC);
+        let sid = crate::plex::register_for_test(
+            "reencode-selected-dts",
+            "127.0.0.1",
+            port,
+            "token",
+            "reencode-selected-dts-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.quality = Quality::P720;
+        env.src_kbps = 48_000;
+        env.audio_sid = 0;
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 2663,
+                    index: 0,
+                    lang_code: "rus".into(),
+                    codec: "ac3".into(),
+                    channels: 6,
+                    default: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 2669,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "dca".into(),
+                    channels: 6,
+                    selected: true,
+                    ..Default::default()
+                },
+            ],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "dca",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            !plan.remux,
+            "720p must re-encode, not copy: {}",
+            plan.url
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "re-encode installs start.mkv: {}",
+            plan.url
+        );
+        let put = requests
+            .iter()
+            .find(|line| line.contains("PUT /library/parts/"))
+            .unwrap_or_else(|| panic!("play-path PUT was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(put, "audioStreamID"),
+            Some("2669"),
+            "PUT must keep selected English DTS, not the Russian AC3 sibling: {put}"
+        );
+        assert_eq!(
+            query_param(&plan.url, "audioStreamID"),
+            Some("2669"),
+            "start.mkv must name that DTS, not the AC3 sibling: {}",
+            plan.url
+        );
+        assert_eq!(plan.audio_sid, 2669);
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// 720p with a selected flag that only echoes the Russian default must still PUT English,
+    /// the same sibling smart-DP / pref-lang would copy. Treating that echo as a pick would
+    /// open The Morning Show in the foreign dub at 720p.
+    #[test]
+    fn a_720p_reencode_does_not_put_a_default_echo_over_english() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        restore_quality(Quality::P720);
+        let (port, rx, server) = plan_pms(3, EMPTY_MC);
+        let sid = crate::plex::register_for_test(
+            "reencode-default-echo",
+            "127.0.0.1",
+            port,
+            "token",
+            "reencode-default-echo-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.quality = Quality::P720;
+        env.src_kbps = 48_000;
+        env.audio_sid = 0;
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 10975,
+                    index: 0,
+                    lang_code: "rus".into(),
+                    codec: "eac3".into(),
+                    channels: 6,
+                    default: true,
+                    selected: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 10976,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "eac3".into(),
+                    channels: 6,
+                    ..Default::default()
+                },
+            ],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            !plan.remux,
+            "720p must re-encode, not copy: {}",
+            plan.url
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "re-encode installs start.mkv: {}",
+            plan.url
+        );
+        let put = requests
+            .iter()
+            .find(|line| line.contains("PUT /library/parts/"))
+            .unwrap_or_else(|| panic!("play-path PUT was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(put, "audioStreamID"),
+            Some("10976"),
+            "PUT must keep English, not the echoed Russian default: {put}"
+        );
+        assert_eq!(
+            query_param(&plan.url, "audioStreamID"),
+            Some("10976"),
+            "start.mkv must name English, not the echoed Russian default: {}",
+            plan.url
+        );
+        assert_eq!(plan.audio_sid, 10976);
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// 720p can transcode unselected English DTS when the smart-DP sibling is a foreign AC3.
+    /// Treating pref-lang as DP-only would keep the Russian copy the encoder does not need.
+    #[test]
+    fn a_720p_reencode_puts_pref_lang_dts_not_the_foreign_ac3_sibling() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        restore_quality(Quality::P720);
+        let (port, rx, server) = plan_pms(3, EMPTY_MC);
+        let sid = crate::plex::register_for_test(
+            "reencode-pref-lang-dts",
+            "127.0.0.1",
+            port,
+            "token",
+            "reencode-pref-lang-dts-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.quality = Quality::P720;
+        env.src_kbps = 48_000;
+        env.audio_sid = 0;
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 2663,
+                    index: 0,
+                    lang_code: "rus".into(),
+                    codec: "ac3".into(),
+                    channels: 6,
+                    default: true,
+                    selected: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 2669,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "dca".into(),
+                    channels: 6,
+                    ..Default::default()
+                },
+            ],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "dca",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            !plan.remux,
+            "720p must re-encode, not copy: {}",
+            plan.url
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "re-encode installs start.mkv: {}",
+            plan.url
+        );
+        let put = requests
+            .iter()
+            .find(|line| line.contains("PUT /library/parts/"))
+            .unwrap_or_else(|| panic!("play-path PUT was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(put, "audioStreamID"),
+            Some("2669"),
+            "PUT must name pref-lang English DTS, not the Russian AC3 sibling: {put}"
+        );
+        assert_eq!(
+            query_param(&plan.url, "audioStreamID"),
+            Some("2669"),
+            "start.mkv must name that DTS, not the AC3 sibling: {}",
+            plan.url
+        );
+        assert_eq!(plan.audio_sid, 2669);
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Relay Auto cannot Original, so bootstrap installs HLS. The play-path PUT and start.m3u8
+    /// must still name selected English DTS, not the Russian AC3 sibling a remux would copy.
+    #[test]
+    fn a_auto_hls_reencode_puts_the_selected_dts_not_the_ac3_sibling() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        restore_quality(Quality::Auto);
+        let (port, rx, server) = plan_pms(3, EMPTY_MC);
+        let sid = crate::plex::register_for_test(
+            "reencode-auto-hls-dts",
+            "127.0.0.1",
+            port,
+            "token",
+            "reencode-auto-hls-dts-client",
+        );
+        crate::plex::client_for(sid)
+            .expect("registered")
+            .set_link(crate::plex::probe::Location::Relay);
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.quality = Quality::Auto;
+        env.src_kbps = 48_000;
+        env.audio_sid = 0;
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 2663,
+                    index: 0,
+                    lang_code: "rus".into(),
+                    codec: "ac3".into(),
+                    channels: 6,
+                    default: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 2669,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "dca".into(),
+                    channels: 6,
+                    selected: true,
+                    ..Default::default()
+                },
+            ],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "dca",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            !plan.remux,
+            "Relay Auto must HLS-encode, not copy: {}",
+            plan.url
+        );
+        assert!(
+            plan.url.contains("start.m3u8"),
+            "Relay Auto installs start.m3u8: {}",
+            plan.url
+        );
+        let put = requests
+            .iter()
+            .find(|line| line.contains("PUT /library/parts/"))
+            .unwrap_or_else(|| panic!("play-path PUT was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(put, "audioStreamID"),
+            Some("2669"),
+            "PUT must keep selected English DTS, not the Russian AC3 sibling: {put}"
+        );
+        assert_eq!(
+            query_param(&plan.url, "audioStreamID"),
+            Some("2669"),
+            "start.m3u8 must name that DTS, not the AC3 sibling: {}",
+            plan.url
+        );
+        assert_eq!(plan.audio_sid, 2669);
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
     /// A remux probe that registers `/decision` and then gets no `start.mkv` body must
     /// physical-stop (`closeResourceSession=0`) so the HLS `/decision` on the same identity
     /// is not 503'd. Closing the Streaming Resource would.

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -4871,6 +4871,10 @@ pub(super) fn measure_remote_original(url: &str, source_kbps: i64) -> Option<cra
 /// PMS 1.43 503s a Part GET after a transcode MDE. The Original we would actually play is a
 /// codec-copy remux, so the Remote capacity sample has to be that `start.mkv`, under the same
 /// session identity a direct Part probe uses.
+///
+/// Encoder spin-up stays inside the existing 4s probe budget; a miss fails toward HLS rather
+/// than waiting longer. First-byte wait on this sample is the remux coming up, not a measure of
+/// transport capacity.
 pub(super) fn measure_remote_remux(
     client: &crate::plex::Client,
     rk: &str,
@@ -4895,7 +4899,13 @@ pub(super) fn measure_remote_remux(
         crate::player::log("auto: remote remux preflight had no /decision; using HLS");
         return None;
     }
-    measure_remote_original(&client.transcode_start_url(&spec).to_url(), source_kbps)
+    let sample = measure_remote_original(&client.transcode_start_url(&spec).to_url(), source_kbps);
+    if sample.is_none() {
+        // Same playback identity the HLS/remux that follows will register. closeResourceSession=1
+        // would 503 that next start; physical-stop keeps the Streaming Resource.
+        let _ = client.transcode_stop_physical(session);
+    }
+    sample
 }
 
 /// MDE handshake result. `None` from [`server_decision`] means the body was missing or unusable:
@@ -8569,16 +8579,24 @@ mod tests {
                             start_bytes.filter(|_| first.contains("start.mkv"))
                         {
                             use std::io::Write;
-                            write!(
-                                socket,
-                                "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-{}/{}\r\nContent-Length: {bytes}\r\nConnection: close\r\n\r\n",
-                                bytes.saturating_sub(1),
-                                bytes.saturating_mul(2),
-                            )
-                            .expect("start.mkv headers");
-                            socket
-                                .write_all(&vec![0x55; bytes])
-                                .expect("start.mkv body");
+                            if bytes == 0 {
+                                write!(
+                                    socket,
+                                    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                                )
+                                .expect("empty start.mkv");
+                            } else {
+                                write!(
+                                    socket,
+                                    "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-{}/{}\r\nContent-Length: {bytes}\r\nConnection: close\r\n\r\n",
+                                    bytes.saturating_sub(1),
+                                    bytes.saturating_mul(2),
+                                )
+                                .expect("start.mkv headers");
+                                socket
+                                    .write_all(&vec![0x55; bytes])
+                                    .expect("start.mkv body");
+                            }
                         } else {
                             let body = if first.contains("/decision?") {
                                 mde_body
@@ -9065,6 +9083,181 @@ mod tests {
         assert!(
             plan.url.contains("start.mkv"),
             "the installed route is the remux: {}",
+            plan.url
+        );
+        assert!(
+            !requests.iter().any(|line| line.contains("/transcode/universal/stop")),
+            "a successful remux Original leaves the session for the play-path decision: {requests:?}"
+        );
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// TrueHD default `id=1` is what `env.audio_sid` still carries (play-path PUT / transcode_spec).
+    /// MDE and the remux probe must name the AC3 sibling `id=2` that smart-DP will actually feed.
+    #[test]
+    fn remote_auto_truehd_remux_probe_names_the_ac3_sibling_not_env_audio_sid() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        if !crate::net::global_init() || !crate::curlio::available() {
+            return;
+        }
+        restore_quality(Quality::Auto);
+        let probe_bytes = crate::abr::source_probe_plan(320, crate::abr::PROBE_BUDGET_MS)
+            .expect("tiny source still has a probe object")
+            .target_bytes;
+        let (port, rx, server) = plan_pms_with_start_mkv(6, MDE_TRANSCODE_COPY, probe_bytes);
+        let sid = crate::plex::register_for_test(
+            "mde-remote-truehd-ids",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-remote-truehd-ids-client",
+        );
+        crate::plex::client_for(sid)
+            .expect("registered")
+            .set_link(crate::plex::probe::Location::Remote);
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.audio_sid = 1;
+        let mut item = fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 1,
+                    index: 0,
+                    lang_code: "eng".into(),
+                    codec: "truehd".into(),
+                    channels: 8,
+                    default: true,
+                    selected: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 2,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "ac3".into(),
+                    channels: 6,
+                    ..Default::default()
+                },
+            ],
+        );
+        item.bitrate = 320;
+        env.cached_item = Some(item);
+        let _plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "truehd",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let mde = requests
+            .iter()
+            .find(|line| line.contains("/decision?") && line.contains("hasMDE=1"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(mde, "audioStreamID"),
+            Some("2"),
+            "MDE must see the AC3 sibling, not env.audio_sid=1: {mde}"
+        );
+        let remux_probe = requests
+            .iter()
+            .find(|line| {
+                line.contains("start.mkv")
+                    || (line.contains("/decision?")
+                        && line.contains("directPlay=0")
+                        && !line.contains("hasMDE=1"))
+            })
+            .unwrap_or_else(|| panic!("remux probe was never asked: {requests:?}"));
+        assert_eq!(
+            query_param(remux_probe, "audioStreamID"),
+            Some("2"),
+            "remux probe must name the AC3 sibling, not env.audio_sid=1: {remux_probe}"
+        );
+        restore_quality(Quality::Original);
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// A remux probe that registers `/decision` and then gets no `start.mkv` body must
+    /// physical-stop (`closeResourceSession=0`) so the HLS `/decision` on the same identity
+    /// is not 503'd. Closing the Streaming Resource would.
+    #[test]
+    fn remote_auto_failed_remux_sample_physical_stops_before_hls() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        if !crate::net::global_init() || !crate::curlio::available() {
+            return;
+        }
+        restore_quality(Quality::Auto);
+        let (port, rx, server) = plan_pms_with_start_mkv(8, MDE_TRANSCODE_COPY, 0);
+        let sid = crate::plex::register_for_test(
+            "mde-remote-truehd-stop",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-remote-truehd-stop-client",
+        );
+        crate::plex::client_for(sid)
+            .expect("registered")
+            .set_link(crate::plex::probe::Location::Remote);
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        let mut item = fourk_item(
+            sid,
+            vec![crate::metadata::Stream {
+                id: 36014,
+                index: 1,
+                lang_code: "eng".into(),
+                codec: "truehd".into(),
+                channels: 8,
+                default: true,
+                selected: true,
+                ..Default::default()
+            }],
+        );
+        item.bitrate = 320;
+        env.cached_item = Some(item);
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "truehd",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests.iter().any(|line| line.contains("start.mkv")),
+            "the remux probe still ran: {requests:?}"
+        );
+        let stop = requests
+            .iter()
+            .find(|line| line.contains("/transcode/universal/stop"))
+            .unwrap_or_else(|| panic!("failed remux sample must /stop: {requests:?}"));
+        assert_eq!(
+            query_param(stop, "closeResourceSession"),
+            Some("0"),
+            "physical-stop keeps the Streaming Resource for the HLS that follows: {stop}"
+        );
+        assert!(
+            !requests.iter().any(|line| {
+                line.contains("/transcode/universal/stop")
+                    && query_param(line, "closeResourceSession") == Some("1")
+            }),
+            "closeResourceSession=1 would 503 the next start: {requests:?}"
+        );
+        assert!(
+            !plan.remux,
+            "no remux sample → Auto falls through to HLS: {}",
             plan.url
         );
         restore_quality(Quality::Original);

--- a/rust-modules/src/route/decision.rs
+++ b/rust-modules/src/route/decision.rs
@@ -4873,8 +4873,13 @@ pub(super) fn measure_remote_original(
 ///
 /// Takes the `Client` rather than looking one up: this runs on the resolve worker, and `rk` is only
 /// an item on the server the caller resolved from this playback's captured `ServerId`.
-pub(super) fn server_decision(c: &crate::plex::Client, rk: &str, session: &str) -> Option<bool> {
-    let mc = match c.mde_decision(rk, session) {
+pub(super) fn server_decision(
+    c: &crate::plex::Client,
+    rk: &str,
+    session: &str,
+    audio_stream_id: i64,
+) -> Option<bool> {
+    let mc = match c.mde_decision(rk, session, audio_stream_id) {
         Some(mc) => mc,
         None => {
             // failed fetch OR unparseable (XML/truncated) body — keep the fallback visible
@@ -8369,6 +8374,295 @@ mod tests {
             source_decodable(&ps),
             "and the session carries the same silence"
         );
+    }
+
+    const MDE_DIRECTPLAY: &[u8] =
+        br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"directplay"}]}]}]}}"#;
+    const MDE_TRANSCODE: &[u8] =
+        br#"{"MediaContainer":{"Metadata":[{"Media":[{"Part":[{"decision":"transcode"}]}]}]}}"#;
+    const EMPTY_MC: &[u8] = br#"{"MediaContainer":{}}"#;
+
+    fn drain_http(socket: &mut std::net::TcpStream) -> String {
+        use std::io::{BufRead, BufReader, Read};
+        let mut reader = BufReader::new(socket.try_clone().expect("clone"));
+        let mut first = String::new();
+        reader.read_line(&mut first).expect("request line");
+        let mut content_length = 0usize;
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("header");
+            if line == "\r\n" || line.is_empty() {
+                break;
+            }
+            if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                content_length = v.trim().parse().unwrap_or(0);
+            }
+        }
+        if content_length > 0 {
+            let mut body = vec![0; content_length];
+            let _ = reader.read_exact(&mut body);
+        }
+        first
+    }
+
+    fn write_json(socket: &mut std::net::TcpStream, body: &[u8]) {
+        use std::io::Write;
+        write!(
+            socket,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len(),
+        )
+        .expect("headers");
+        socket.write_all(body).expect("body");
+    }
+
+    /// Loopback PMS that answers PlayQueue / PUT / `/decision` long enough for `build_stream`.
+    fn plan_pms(
+        n: usize,
+        mde_body: &'static [u8],
+    ) -> (
+        i32,
+        std::sync::mpsc::Receiver<Vec<String>>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port() as i32;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            listener.set_nonblocking(true).unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+            let mut requests = Vec::new();
+            while requests.len() < n && std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut socket, _)) => {
+                        let first = drain_http(&mut socket);
+                        let body = if first.contains("/decision?") {
+                            mde_body
+                        } else {
+                            EMPTY_MC
+                        };
+                        write_json(&mut socket, body);
+                        requests.push(first);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(4));
+                    }
+                    Err(error) => panic!("accept plan request: {error}"),
+                }
+            }
+            tx.send(requests).expect("publish plan requests");
+        });
+        (port, rx, handle)
+    }
+
+    fn fourk_item(
+        sid: ServerId,
+        audio: Vec<crate::metadata::Stream>,
+    ) -> crate::metadata::PlayingItem {
+        crate::metadata::PlayingItem {
+            sid,
+            rk: "rk-4k".into(),
+            audio,
+            subs: Vec::new(),
+            video_fps: 23.976,
+            width: 3840,
+            height: 2160,
+            bitrate: 48_000,
+            dovi: crate::metadata::Dovi::NONE,
+            markers: Vec::new(),
+            chapters: Vec::new(),
+        }
+    }
+
+    /// PMS 1.43 503s a Part GET whose session has no MDE decision. A 4K HEVC+EAC3 title used
+    /// to skip `/decision` because EAC3 is a direct-play audio codec; the plan URL must not
+    /// be that part until MDE has registered the session.
+    #[test]
+    fn original_hevc_eac3_registers_mde_before_returning_the_part() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-dp-test",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-dp-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![crate::metadata::Stream {
+                id: 36014,
+                index: 1,
+                lang_code: "eng".into(),
+                codec: "eac3".into(),
+                channels: 6,
+                default: true,
+                selected: true,
+                profile: "dolby digital plus + dolby atmos".into(),
+                ..Default::default()
+            }],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert!(decision.contains("hasMDE=1"), "{decision}");
+        assert!(decision.contains("directPlay=1"), "{decision}");
+        assert!(decision.contains("audioStreamID=36014"), "{decision}");
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "admitted Original is the raw part: {}",
+            plan.url
+        );
+        assert!(
+            !plan.url.contains("start.mkv"),
+            "MDE said directplay, so this is not a transcode: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// Smart-DP used to skip MDE so a TrueHD default would not veto the AC3 sibling. The
+    /// `/decision` query must name that sibling; otherwise PMS evaluates TrueHD and the part
+    /// GET 503s or the title is sent to a video-downscaling transcode.
+    #[test]
+    fn smart_dp_names_the_ac3_sibling_on_mde() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(2, MDE_DIRECTPLAY);
+        let sid = crate::plex::register_for_test(
+            "mde-smart-dp",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-smart-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![
+                crate::metadata::Stream {
+                    id: 1,
+                    index: 0,
+                    lang_code: "eng".into(),
+                    codec: "truehd".into(),
+                    channels: 8,
+                    default: true,
+                    selected: true,
+                    ..Default::default()
+                },
+                crate::metadata::Stream {
+                    id: 2,
+                    index: 1,
+                    lang_code: "eng".into(),
+                    codec: "ac3".into(),
+                    channels: 6,
+                    ..Default::default()
+                },
+            ],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "truehd",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        let decision = requests
+            .iter()
+            .find(|line| line.contains("/decision?"))
+            .unwrap_or_else(|| panic!("MDE was never asked: {requests:?}"));
+        assert!(
+            decision.contains("audioStreamID=2"),
+            "MDE must see the AC3 sibling, not TrueHD: {decision}"
+        );
+        assert!(
+            plan.url.contains("/library/parts/36013/"),
+            "{}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
+    }
+
+    /// OpenAPI: a Part GET whose decision is a transcode is HTTP 503. Honour MDE rather than
+    /// returning the part URL the local codec test would have chosen.
+    #[test]
+    fn mde_transcode_does_not_return_the_part_url() {
+        use std::time::Duration;
+        let mut ps = crate::route::PlaybackSession::IDLE;
+        let _g = fresh_registry(&mut ps);
+        let (port, rx, server) = plan_pms(4, MDE_TRANSCODE);
+        let sid = crate::plex::register_for_test(
+            "mde-tc-test",
+            "127.0.0.1",
+            port,
+            "token",
+            "mde-tc-client",
+        );
+        let mut env = ResolveEnv::snapshot(&ps, sid, "rk-4k");
+        env.cached_item = Some(fourk_item(
+            sid,
+            vec![crate::metadata::Stream {
+                id: 36014,
+                index: 1,
+                lang_code: "eng".into(),
+                codec: "eac3".into(),
+                channels: 6,
+                default: true,
+                selected: true,
+                ..Default::default()
+            }],
+        ));
+        let plan = build_stream(
+            "rk-4k",
+            "/library/parts/36013/1/file.mkv",
+            "hevc",
+            "eac3",
+            &env,
+        );
+        let requests = rx
+            .recv_timeout(Duration::from_secs(15))
+            .expect("PMS never saw the resolve");
+        server.join().unwrap();
+
+        assert!(
+            requests
+                .iter()
+                .any(|line| line.contains("hasMDE=1") && line.contains("directPlay=1")),
+            "the first ask is still the MDE handshake: {requests:?}"
+        );
+        assert!(
+            plan.url.contains("start.mkv"),
+            "MDE said transcode, so the plan must not GET the part: {}",
+            plan.url
+        );
+        assert!(
+            !plan.url.contains("/library/parts/36013/"),
+            "a transcode decision must not be served as Original: {}",
+            plan.url
+        );
+        crate::plex::reset_servers_for_test();
     }
 
     /// The gate's verdict reaches the session, and it is the SOURCE codec that decides it.

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -901,8 +901,10 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on the
         // query is what keeps that class on Original. subtitleStreamID is an advertised embedded
         // track Original will client-render, or 0 so a sidecar / unadvertised codec does not
-        // force a burn. Same audio id goes on the remux probe, the play-path PUT, and
-        // transcode_spec so MDE / start.mkv / selection name one track.
+        // force a burn. MDE and the remux probe always name that sibling (a copy cannot carry
+        // TrueHD/DTS). The play-path PUT and start.mkv use `encode_audio_id`: remux still names
+        // the sibling; a re-encode names a real selected pick or pref-lang English so 720p
+        // does not copy a foreign AC3 sibling.
         server_decision(client, rk, &session, audio_id, subtitle_id)
     };
     let mut directplay = mde.as_ref().is_some_and(|v| v.original);
@@ -1203,6 +1205,12 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // `transcode` must not be answered with a local codec-copy remux. Part.decision=transcode
     // alone is not that veto.
     let remux = video_dp && allowed.remux && !no_video_copy && !mde_forbids_copy;
+    // Remux copies, so this PUT names the smart-DP sibling. A re-encode transcodes a real
+    // selected source track (English DTS → AC3) and must not PUT that sibling or a 720p start
+    // replaces the pick with a foreign AC3 copy. A selected flag that only echoes default is
+    // not a pick; `encode_audio_id` then keeps an English sibling or, if the sibling is a
+    // foreign dub, the first English track (unselected DTS included).
+    let encode_audio = encode_audio_id(remux, audio_id, env.audio_sid, tracks);
     if remux {
         let achosen = audio_sel
             .as_ref()
@@ -1220,13 +1228,12 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         plan.vcodec = crate::devcaps::caps().encode_vcodec().into();
         plan.acodec = "ac3".into();
     }
-    // Carry the picked SOURCE track into the server-side selection (put_selection +
-    // &audioStreamID on the transcode query): the remux copies — and the re-encode encodes —
-    // the CHOSEN track instead of the part default. The demuxer is NOT pointed at a source
-    // ordinal here (the old set_audio_track(aidx) indexed the SERVER's output, whose stream
-    // layout is the transcoder's, not the source's) — the payload-codec match finds the lane.
-    if let Some((_, _, asid)) = &audio_sel {
-        plan.audio_sid = *asid;
+    // Carry the SOURCE track this path will PUT and name on start.mkv. The demuxer is NOT
+    // pointed at a source ordinal here (the old set_audio_track(aidx) indexed the SERVER's
+    // output, whose stream layout is the transcoder's, not the source's) — the payload-codec
+    // match finds the lane.
+    if encode_audio > 0 {
+        plan.audio_sid = encode_audio;
     }
     // keep the flavor so a later seek rebuilds the same query for start.mkv?...&offset=T
     // Both halves of this line landed in the same batch from different units and each is
@@ -1242,10 +1249,11 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // reasoning `remux` and `no_video_copy` carry: a seek and an audio switch rebuild this query
     // from `Session`, and one that dropped the ceiling would hand the encoder back the full
     // 4K/60 Mbps bound the moment the user touched the scrubber.
-    // Same audio id MDE and the remux probe already named. `env.audio_sid` is the part default
-    // (TrueHD) at resolve start; putting that undoes smart-DP. Subtitle stays `env.sub_sid`:
-    // a positive id here is a burn, and Original client-renders instead.
-    put_selection(env.sid, plan.part_id, audio_id, env.sub_sid);
+    // Remux: the smart-DP sibling MDE and the remux probe already named — `env.audio_sid` is
+    // the part default (TrueHD) at resolve start; putting that undoes smart-DP. Re-encode:
+    // `encode_audio_id` (a real selected pick, else English, else that sibling). Subtitle stays
+    // `env.sub_sid`: a positive id here is a burn, and Original client-renders instead.
+    put_selection(env.sid, plan.part_id, encode_audio, env.sub_sid);
     if remux_probed && adaptive {
         // Probe registered start.mkv on this playback identity. HLS `/decision` reuses it;
         // closeResourceSession=1 would 503 the next start. A failed sample already stopped
@@ -1260,7 +1268,7 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         remux,
         no_video_copy,
         crate::plex::TranscodeOffset::Fresh,
-        audio_id,
+        encode_audio,
         env.sub_sid,
         plan.ceiling,
         plan.delivery,
@@ -1382,6 +1390,58 @@ pub(super) fn pick_dp_audio(
         .iter()
         .position(|s| dp(&s.codec.to_lowercase()))
         .map(pick)
+}
+
+
+/// Stream id named on the remux/re-encode PUT and start.mkv.
+///
+/// A remux COPIES, so this is the smart-DP sibling (`dp_audio_id`) — putting a selected
+/// TrueHD/DTS track would ship audio the TV cannot decode. A re-encode can transcode a real
+/// selected pick (`selected && !default`) to AC3, so naming the sibling would replace English
+/// DTS with a foreign AC3 copy. A `selected` flag that only echoes `default` is not a choice
+/// (The Morning Show: the Russian default reads `selected`); that falls through rather than
+/// beating English.
+///
+/// After that pick, a sibling already in [`PREF_AUDIO_LANG`] stays — taking "first English, any
+/// codec" would PUT English TrueHD on 720p when an English AC3 sibling exists, undoing smart-DP.
+/// Only when the sibling is a foreign dub does the first English track win, so an unselected
+/// English DTS is encoded instead of a Russian AC3 copy. Never `0` (an omitted PUT encodes the
+/// part default).
+/// `env_audio_sid` is the session/retry pick and wins on re-encode when set, including a remux
+/// leftover sibling (mid-play quality drop keeps what is already playing). A cold play zeros
+/// it (`request_play`).
+fn encode_audio_id(
+    remux: bool,
+    dp_audio_id: i64,
+    env_audio_sid: i64,
+    tracks: &[crate::metadata::Stream],
+) -> i64 {
+    if remux {
+        return dp_audio_id;
+    }
+    if env_audio_sid > 0 {
+        return env_audio_sid;
+    }
+    if let Some(id) = tracks
+        .iter()
+        .find(|s| s.selected && !s.default)
+        .map(|s| s.id)
+        .filter(|&id| id > 0)
+    {
+        return id;
+    }
+    let sibling_is_pref = tracks
+        .iter()
+        .any(|s| s.id == dp_audio_id && s.lang_code == PREF_AUDIO_LANG);
+    if sibling_is_pref {
+        return dp_audio_id;
+    }
+    tracks
+        .iter()
+        .find(|s| s.lang_code == PREF_AUDIO_LANG)
+        .map(|s| s.id)
+        .filter(|&id| id > 0)
+        .unwrap_or(dp_audio_id)
 }
 
 
@@ -2164,6 +2224,161 @@ mod tests {
             trk(2673, "ac3", "eng", false),
         ];
         assert_eq!(pick_dp_audio(&tracks, "dca"), Some((2, "ac3".into(), 2673)));
+    }
+
+    /// The 720p re-encode must name the selected DTS, not the Russian AC3 sibling smart-DP
+    /// would copy. Remux still names that sibling — a copy of DTS would not play.
+    #[test]
+    fn a_reencode_keeps_the_selected_dts_instead_of_the_ac3_sibling() {
+        let tracks = [
+            trk(2663, "ac3", "rus", true),
+            server_selected(trk(2669, "dca", "eng", false)),
+        ];
+        let dp = pick_dp_audio(&tracks, "dca")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 2663, "smart-DP sibling is the Russian AC3");
+        assert_eq!(
+            encode_audio_id(true, dp, 0, &tracks),
+            2663,
+            "remux copies the sibling"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            2669,
+            "cold re-encode keeps the selected DTS"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 2669, &tracks),
+            2669,
+            "a retry/session pick of that DTS is kept"
+        );
+        assert_eq!(
+            encode_audio_id(true, dp, 2669, &tracks),
+            2663,
+            "remux still copies the sibling even when a DTS pick is in env"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, dp, &tracks),
+            dp,
+            "retry after remux keeps the sibling already playing"
+        );
+    }
+
+    /// A selected flag that only echoes the container default is not a 720p pick. Treating it
+    /// as one would open The Morning Show in the Russian default the English rung exists to skip.
+    #[test]
+    fn a_reencode_does_not_treat_a_default_echo_as_a_pick() {
+        let tracks = [
+            server_selected(trk(10975, "eac3", "rus", true)),
+            trk(10976, "eac3", "eng", false),
+        ];
+        let dp = pick_dp_audio(&tracks, "eac3")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 10976, "smart-DP / pref-lang sibling is English");
+        assert_eq!(
+            encode_audio_id(true, dp, 0, &tracks),
+            10976,
+            "remux copies English"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            10976,
+            "cold re-encode keeps English, not the echoed Russian default"
+        );
+    }
+
+    /// Live three-track shape: selected English DTS plus an English AC3 sibling. Remux copies
+    /// the AC3; re-encode names the DTS.
+    #[test]
+    fn a_reencode_names_selected_dts_not_the_english_ac3_sibling() {
+        let tracks = [
+            trk(2663, "ac3", "rus", true),
+            server_selected(trk(2669, "dca", "eng", false)),
+            trk(2673, "ac3", "eng", false),
+        ];
+        let dp = pick_dp_audio(&tracks, "dca")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 2673, "smart-DP sibling is the English AC3");
+        assert_eq!(
+            encode_audio_id(true, dp, 0, &tracks),
+            2673,
+            "remux copies the English AC3"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            2669,
+            "cold re-encode keeps the selected DTS"
+        );
+    }
+
+    /// Unselected English DTS beside a Russian AC3 sibling: remux still copies the sibling, but
+    /// a re-encode can consume the English track PREF_AUDIO_LANG would have taken if it were DP.
+    #[test]
+    fn a_reencode_names_pref_lang_dts_when_the_sibling_is_foreign() {
+        let tracks = [
+            server_selected(trk(2663, "ac3", "rus", true)),
+            trk(2669, "dca", "eng", false),
+        ];
+        let dp = pick_dp_audio(&tracks, "dca")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 2663, "smart-DP sibling is the Russian AC3");
+        assert_eq!(
+            encode_audio_id(true, dp, 0, &tracks),
+            2663,
+            "remux copies the sibling"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            2669,
+            "cold re-encode names unselected English DTS, not the Russian AC3"
+        );
+    }
+
+    /// First-English-any-codec would PUT TrueHD here. The sibling is already English, so 720p
+    /// keeps that AC3 copy instead of re-encoding lossless.
+    #[test]
+    fn a_reencode_keeps_an_english_ac3_sibling_over_truehd() {
+        let tracks = [
+            server_selected(trk(1, "truehd", "eng", true)),
+            trk(2, "ac3", "eng", false),
+        ];
+        let dp = pick_dp_audio(&tracks, "truehd")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 2, "smart-DP sibling is the English AC3");
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            2,
+            "re-encode must not replace the English AC3 with TrueHD"
+        );
+    }
+
+    /// No AC3 sibling: smart-DP has nothing to copy. A real selected DTS must still be named,
+    /// not omitted (PUT 0 encodes the TrueHD default).
+    #[test]
+    fn a_reencode_names_selected_dts_when_there_is_no_ac3_sibling() {
+        let tracks = [
+            trk(1, "truehd", "eng", true),
+            server_selected(trk(2, "dca", "eng", false)),
+        ];
+        let dp = pick_dp_audio(&tracks, "truehd")
+            .map(|(_, _, id)| id)
+            .unwrap_or(0);
+        assert_eq!(dp, 0, "no direct-playable track");
+        assert_eq!(
+            encode_audio_id(true, dp, 0, &tracks),
+            0,
+            "remux has no sibling to name"
+        );
+        assert_eq!(
+            encode_audio_id(false, dp, 0, &tracks),
+            2,
+            "cold re-encode names the selected DTS, not 0"
+        );
     }
 
     /// The whole ladder, rung by rung, with the selected flag switched on and off — the order is

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -12,8 +12,9 @@ use crate::plex::ServerId;
 use std::sync::atomic::Ordering;
 
 use super::decision::{
-    measure_remote_original, put_selection, resolve_playqueue, server_decision,
-    ActiveEncoderState, AutomaticRouteIntent, PlayerControl, ENCODER_GENERATION,
+    measure_remote_original, measure_remote_remux, put_selection, resolve_playqueue,
+    server_decision, ActiveEncoderState, AutomaticRouteIntent, MdeVerdict, PlayerControl,
+    ENCODER_GENERATION,
 };
 
 /// One worker's right to observe or replace the active route. Both fields are required: `encoder`
@@ -358,15 +359,6 @@ pub(super) fn remote_probe_plan(source_kbps: i64) -> Option<crate::abr::SourcePr
 pub(super) fn remote_probe_target_bytes(source_kbps: i64) -> Option<usize> {
     remote_probe_plan(source_kbps).map(|plan| plan.target_bytes)
 }
-
-/// **One bounded measurement of the actual file, as an observation and nothing more.** It reports
-/// bytes, active duration and whether the target was reached, because all three decide how much
-/// the measurement is worth: a 40 KiB read that finished instantly honestly reports a huge rate
-/// and proves nothing. What it does NOT do is decide anything — [`crate::abr::bootstrap`] owns the
-/// admission rule, so the policy is stated once and is host-testable without a network.
-///
-/// `None` means there is nothing to reason from (no source bitrate, or the transfer never
-/// returned), which is deliberately distinct from a completed slow probe.
 
 /// **Two ceilings mean the stricter one**, per flavor, and this is the only place the two are put
 /// together. A ceiling can only ever REMOVE a flavor: a fast link cannot restore what a low rung
@@ -890,10 +882,13 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // by `link`. Fixed rungs retain their ordinary ceiling policy.
     let tentative_quality = quality_policy(env.quality, true, env.src_kbps, src_w, src_h);
     let mut allowed = flavors_allowed(link, tentative_quality);
-    // MDE verdict for this resolve: Some(true)=Original, Some(false)=explicit transcode (also
-    // forbids remux), None=unreachable/unusable OR never asked (gates already refused Original).
+    // MDE verdict for this resolve: Some(original)=Part.decision=directplay, Some(!original)=
+    // start.mkv, None=unreachable/unusable OR never asked (gates already refused Original).
     // PMS 1.43 503s a Part GET without a registered decision, so None must never become Original.
-    let mde: Option<bool> = if !allowed.direct_play || !video_dp || !streamable || rk.is_empty() {
+    // `video_forbids_copy` is independent: Part=transcode + video=copy (TrueHD-only, a selected
+    // sub MDE still refuses, …) is a remux, not a full re-encode.
+    let skip_mde = !allowed.direct_play || !video_dp || !streamable || rk.is_empty();
+    let mde: Option<MdeVerdict> = if skip_mde {
         None
     } else {
         // Register the session before any Part GET. Smart-DP used to skip this because MDE would
@@ -909,11 +904,10 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
             .unwrap_or(0);
         server_decision(client, rk, &session, audio_id, subtitle_id)
     };
-    let mut directplay = matches!(mde, Some(true));
-    // An explicit MDE transcode vetoes a local codec-copy remux (bit depth, image-sub, etc.).
+    let mut directplay = mde.as_ref().is_some_and(|v| v.original);
     // An unreachable MDE (None after we asked, or never asked) still allows remux when the
-    // video gate and link policy do.
-    let mde_forbids_copy = matches!(mde, Some(false));
+    // video gate and link policy do. A video-stream `transcode` (bit depth, …) forbids remux.
+    let mde_forbids_copy = mde.as_ref().is_some_and(|v| v.video_forbids_copy);
 
     // A container-only remux also preserves the original video and avoids the GPU, so it belongs
     // to Auto's Original state and must pass the same remote bandwidth gate as direct play.
@@ -1023,7 +1017,24 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
             // answer: a direct Remote with a feasible Original. Local needs no proof and Relay
             // cannot be talked into carrying a remux.
             let probe = (link == crate::abr::LinkKind::Remote && original_feasible)
-                .then(|| measure_remote_original(&client, part, &session, source_transport_kbps))
+                .then(|| {
+                    if directplay {
+                        measure_remote_original(
+                            &client.direct_play_url(part, &session).to_url(),
+                            source_transport_kbps,
+                        )
+                    } else {
+                        // Part GET 503s after a transcode MDE. Sample the remux we would actually play.
+                        measure_remote_remux(
+                            client,
+                            rk,
+                            &session,
+                            env.audio_sid,
+                            env.sub_sid,
+                            source_transport_kbps,
+                        )
+                    }
+                })
                 .flatten();
             Some(crate::abr::bootstrap(
                 link,
@@ -1182,8 +1193,9 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // `allowed.remux` is `link.remux` AND the user's ceiling — see `flavors_allowed` above. The
     // ceiling is the newer of the two terms and it denies a remux for the reason the relay does: a
     // copy ships the source at the source's own rate, which is precisely what the rung says the
-    // link cannot carry. `!mde_forbids_copy` is the MDE half: an explicit Part.decision=transcode
-    // must not be answered with a local codec-copy remux.
+    // link cannot carry. `!mde_forbids_copy` is the MDE half: a VIDEO stream decision of
+    // `transcode` must not be answered with a local codec-copy remux. Part.decision=transcode
+    // alone is not that veto.
     let remux = video_dp && allowed.remux && !no_video_copy && !mde_forbids_copy;
     if remux {
         let achosen = audio_sel

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -771,19 +771,17 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         .clone()
         .or_else(|| crate::metadata::fetch_playing_item(env.sid, rk));
     // Server-adjudicated: the Media Decision Engine decides direct-play vs transcode from our
-    // capability profile. Falls back to the local codec test if the server returns no usable
-    // decision; the local-sample/demo path (rk empty) skips the decision entirely.
-    // Server-adjudicated (Phase 2). HEVC now direct-plays (Phase 3 demuxer + native decode);
-    // the guard that forced non-h264 to transcode is gone.
+    // capability profile. An unusable / unreachable `/decision` must not Original (PMS 1.43
+    // 503s a Part without a registered decision); remux/re-encode still registers via a
+    // separate `transcode_decision`. The local-sample/demo path (rk empty) skips MDE entirely.
     // Smart direct-play: the video decodes natively (H264/HEVC) AND some audio track is
     // direct-playable (AAC/AC3/E-AC3) — even if the DEFAULT track isn't. We own the demuxer, so
     // we direct-play the raw file and FEED a direct-playable track (e.g. a 4K HEVC item: TrueHD
     // default + an AC3 track → native 4K HEVC + AC3, no transcode — beats the server's
     // video-downscaling transcode). The chosen audio rides `audioStreamID` on `/decision` so MDE
-    // evaluates that sibling rather than vetoing the TrueHD/DTS default. Falls back to the local
-    // codec test when the server returns no usable decision. PMS 1.43 503s a Part GET without a
-    // registered decision ("session lacking permission to direct play"), so the smart-DP audio
-    // pick is no longer a reason to skip `/decision`.
+    // evaluates that sibling rather than vetoing the TrueHD/DTS default. When `/decision` is
+    // unreachable the plan fails closed (no Original Part — PMS 1.43 503s without a registered
+    // decision) and may still remux/re-encode; an explicit MDE transcode also forbids remux.
     // The video gate consults the DEVICE's own decoder table (devcaps), not this codebase's
     // memory of the dev TV: "the panel decodes HEVC" was the last dev-environment claim still
     // asserted as universal (issue #22's bug class — docs/plex-pass-audit.md, closing section).
@@ -892,36 +890,34 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // by `link`. Fixed rungs retain their ordinary ceiling policy.
     let tentative_quality = quality_policy(env.quality, true, env.src_kbps, src_w, src_h);
     let mut allowed = flavors_allowed(link, tentative_quality);
-    let mut directplay = if !allowed.direct_play {
-        false
-    } else if !video_dp {
-        // The buffer-feed pipeline only decodes what the Load payload declares — H264/H265,
-        // and H265 only on a SoC whose table lists the decoder (devcaps). Anything else
-        // (AV1/VP9/MPEG-2/…) MUST transcode: we can't feed it even if the server's /decision
-        // says directplay (it adjudicates the panel's decoders, not our payload). This gate is
-        // why the local sample path (rk empty) is the only other non-transcode case. A source
-        // exceeding the device's width/height bound lands here too, and deliberately on the
-        // RE-ENCODE side of the branch below (a remux would copy the too-big pixels verbatim);
-        // its /decision carries the profile's own bound, so PMS scales the video down.
-        false
-    } else if !streamable || rk.is_empty() {
-        // non-streamable container → remux (transcode branch copies the source codecs);
-        // empty rk (local sample) → no MDE / no Original
-        false
+    // MDE verdict for this resolve: Some(true)=Original, Some(false)=explicit transcode (also
+    // forbids remux), None=unreachable/unusable OR never asked (gates already refused Original).
+    // PMS 1.43 503s a Part GET without a registered decision, so None must never become Original.
+    let mde: Option<bool> = if !allowed.direct_play || !video_dp || !streamable || rk.is_empty() {
+        None
     } else {
-        // Register the session before any Part GET. PMS 1.43 maps a part without a decision
-        // (or whose decision is a transcode) to HTTP 503: "Denying access due to session
-        // lacking permission to direct play". Smart-DP used to skip this because MDE would
-        // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on
-        // the query is what keeps that class on Original.
+        // Register the session before any Part GET. Smart-DP used to skip this because MDE would
+        // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on the
+        // query is what keeps that class on Original. subtitleStreamID is an advertised embedded
+        // track Original will client-render, or 0 so a sidecar / unadvertised codec does not
+        // force a burn.
         let audio_id = audio_sel.as_ref().map(|(_, _, id)| *id).unwrap_or(0);
-        server_decision(client, rk, &session, audio_id)
-            .unwrap_or_else(|| audio_sel.is_some() || crate::plex::is_dp_audio(acodec))
+        let subtitle_id = plan
+            .playing
+            .as_ref()
+            .map(|p| mde_subtitle_stream_id(&p.subs))
+            .unwrap_or(0);
+        server_decision(client, rk, &session, audio_id, subtitle_id)
     };
+    let mut directplay = matches!(mde, Some(true));
+    // An explicit MDE transcode vetoes a local codec-copy remux (bit depth, image-sub, etc.).
+    // An unreachable MDE (None after we asked, or never asked) still allows remux when the
+    // video gate and link policy do.
+    let mde_forbids_copy = matches!(mde, Some(false));
 
     // A container-only remux also preserves the original video and avoids the GPU, so it belongs
     // to Auto's Original state and must pass the same remote bandwidth gate as direct play.
-    let remux_candidate = video_dp && allowed.remux && !no_video_copy;
+    let remux_candidate = video_dp && allowed.remux && !no_video_copy && !mde_forbids_copy;
     let source_transport_kbps = plan
         .playing
         .as_ref()
@@ -1186,8 +1182,9 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // `allowed.remux` is `link.remux` AND the user's ceiling — see `flavors_allowed` above. The
     // ceiling is the newer of the two terms and it denies a remux for the reason the relay does: a
     // copy ships the source at the source's own rate, which is precisely what the rung says the
-    // link cannot carry.
-    let remux = video_dp && allowed.remux && !no_video_copy;
+    // link cannot carry. `!mde_forbids_copy` is the MDE half: an explicit Part.decision=transcode
+    // must not be answered with a local codec-copy remux.
+    let remux = video_dp && allowed.remux && !no_video_copy && !mde_forbids_copy;
     if remux {
         let achosen = audio_sel
             .as_ref()
@@ -1404,6 +1401,23 @@ pub(super) fn pick_dp_subtitle(subs: &[crate::metadata::Stream]) -> Option<(i64,
         return None;
     }
     Some((subs[i].id, ord))
+}
+
+/// Stream id named on the MDE `/decision` handshake, or `0`.
+///
+/// [`pick_dp_subtitle`] is what Original will client-render. MDE only sees that id when the
+/// codec is in [`crate::plex::DP_SUBTITLE_CODECS`]: a sidecar, or a selected embedded track
+/// we render but do not advertise (`vplayer`, …), is sent as `0` so MDE evaluates subs off
+/// instead of answering transcode (which then forbids a codec-copy remux).
+fn mde_subtitle_stream_id(subs: &[crate::metadata::Stream]) -> i64 {
+    pick_dp_subtitle(subs)
+        .and_then(|(id, _)| {
+            subs.iter()
+                .find(|s| s.id == id)
+                .filter(|s| crate::plex::is_dp_subtitle(&s.codec))
+                .map(|_| id)
+        })
+        .unwrap_or(0)
 }
 
 
@@ -2221,6 +2235,32 @@ mod tests {
             sub(11, 4, "rus", false),
         ];
         assert_eq!(pick_dp_subtitle(&subs), None);
+    }
+
+    #[test]
+    fn mde_subtitle_stream_id_names_advertised_codecs_and_zeroes_the_rest() {
+        assert_eq!(mde_subtitle_stream_id(&[]), 0);
+        assert_eq!(
+            mde_subtitle_stream_id(&[server_selected(sub(10, 3, "eng", true))]),
+            0,
+            "sidecar → 0"
+        );
+        let mut pgs = server_selected(sub(12, 4, "eng", false));
+        pgs.codec = "pgs".into();
+        assert_eq!(mde_subtitle_stream_id(&[pgs]), 12);
+        let mut mov = server_selected(sub(14, 4, "eng", false));
+        mov.codec = "mov_text".into();
+        assert_eq!(mde_subtitle_stream_id(&[mov]), 14);
+        let mut dvd = server_selected(sub(15, 4, "eng", false));
+        dvd.codec = "dvd_subtitle".into();
+        assert_eq!(mde_subtitle_stream_id(&[dvd]), 15);
+        let mut obscure = server_selected(sub(13, 4, "eng", false));
+        obscure.codec = "vplayer".into();
+        assert_eq!(
+            mde_subtitle_stream_id(&[obscure]),
+            0,
+            "unadvertised but still client-rendered → 0 so MDE does not transcode"
+        );
     }
 
     #[test]

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -901,7 +901,8 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on the
         // query is what keeps that class on Original. subtitleStreamID is an advertised embedded
         // track Original will client-render, or 0 so a sidecar / unadvertised codec does not
-        // force a burn. Same ids go on the remux probe so MDE and start.mkv name one track.
+        // force a burn. Same audio id goes on the remux probe, the play-path PUT, and
+        // transcode_spec so MDE / start.mkv / selection name one track.
         server_decision(client, rk, &session, audio_id, subtitle_id)
     };
     let mut directplay = mde.as_ref().is_some_and(|v| v.original);
@@ -1241,7 +1242,10 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // reasoning `remux` and `no_video_copy` carry: a seek and an audio switch rebuild this query
     // from `Session`, and one that dropped the ceiling would hand the encoder back the full
     // 4K/60 Mbps bound the moment the user touched the scrubber.
-    put_selection(env.sid, plan.part_id, env.audio_sid, env.sub_sid); // audio/subtitle selection drives the encode/remux + burn
+    // Same audio id MDE and the remux probe already named. `env.audio_sid` is the part default
+    // (TrueHD) at resolve start; putting that undoes smart-DP. Subtitle stays `env.sub_sid`:
+    // a positive id here is a burn, and Original client-renders instead.
+    put_selection(env.sid, plan.part_id, audio_id, env.sub_sid);
     if remux_probed && adaptive {
         // Probe registered start.mkv on this playback identity. HLS `/decision` reuses it;
         // closeResourceSession=1 would 503 the next start. A failed sample already stopped
@@ -1256,7 +1260,7 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         remux,
         no_video_copy,
         crate::plex::TranscodeOffset::Fresh,
-        env.audio_sid,
+        audio_id,
         env.sub_sid,
         plan.ceiling,
         plan.delivery,

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -779,18 +779,21 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // direct-playable (AAC/AC3/E-AC3) — even if the DEFAULT track isn't. We own the demuxer, so
     // we direct-play the raw file and FEED a direct-playable track (e.g. a 4K HEVC item: TrueHD
     // default + an AC3 track → native 4K HEVC + AC3, no transcode — beats the server's
-    // video-downscaling transcode). Falls back to the server /decision (then the local codec
-    // test) when the video isn't direct-playable or NO audio track is (TrueHD/DTS-only → transcode).
+    // video-downscaling transcode). The chosen audio rides `audioStreamID` on `/decision` so MDE
+    // evaluates that sibling rather than vetoing the TrueHD/DTS default. Falls back to the local
+    // codec test when the server returns no usable decision. PMS 1.43 503s a Part GET without a
+    // registered decision ("session lacking permission to direct play"), so the smart-DP audio
+    // pick is no longer a reason to skip `/decision`.
     // The video gate consults the DEVICE's own decoder table (devcaps), not this codebase's
     // memory of the dev TV: "the panel decodes HEVC" was the last dev-environment claim still
     // asserted as universal (issue #22's bug class — docs/plex-pass-audit.md, closing section).
     // This is belt-and-braces with the profile — a no-hevc profile means PMS should never
-    // *offer* hevc direct-play, but the smart-DP branch below can bypass the server's /decision
-    // entirely, so the local gate must agree with the profile on BOTH axes it asserts: the codec
+    // *offer* hevc direct-play, and when `/decision` is unreachable the local gate must still
+    // agree with the profile on BOTH axes it asserts: the codec
     // AND the width/height bound. Codec agreement alone left the resolution half open — the
     // profile's `*`-scoped limitation makes PMS transcode a 4K source down for a 1080p-bounded
-    // SoC, but a branch that never asks the server never meets the limitation, so a 4K file with
-    // any AAC/AC3 track (nearly every file has one) direct-played straight onto the bounded
+    // SoC, but a fallback that never asked the server never meets the limitation, so a 4K file with
+    // any AAC/AC3 track (nearly every file has one) would direct-play straight onto the bounded
     // decoder. See `video_direct_plays` for the gate itself.
     let (src_w, src_h) = plan
         .playing
@@ -901,14 +904,19 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         // RE-ENCODE side of the branch below (a remux would copy the too-big pixels verbatim);
         // its /decision carries the profile's own bound, so PMS scales the video down.
         false
-    } else if !streamable {
-        false // non-MKV container → remux (the transcode branch copies the source codecs)
-    } else if audio_sel.is_some() {
-        true
-    } else if rk.is_empty() {
+    } else if !streamable || rk.is_empty() {
+        // non-streamable container → remux (transcode branch copies the source codecs);
+        // empty rk (local sample) → no MDE / no Original
         false
     } else {
-        server_decision(client, rk, &session).unwrap_or_else(|| crate::plex::is_dp_audio(acodec))
+        // Register the session before any Part GET. PMS 1.43 maps a part without a decision
+        // (or whose decision is a transcode) to HTTP 503: "Denying access due to session
+        // lacking permission to direct play". Smart-DP used to skip this because MDE would
+        // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on
+        // the query is what keeps that class on Original.
+        let audio_id = audio_sel.as_ref().map(|(_, _, id)| *id).unwrap_or(0);
+        server_decision(client, rk, &session, audio_id)
+            .unwrap_or_else(|| audio_sel.is_some() || crate::plex::is_dp_audio(acodec))
     };
 
     // A container-only remux also preserves the original video and avoids the GPU, so it belongs
@@ -1405,10 +1413,11 @@ pub(super) fn pick_dp_subtitle(subs: &[crate::metadata::Stream]) -> Option<(i64,
 /// The codec half: h264 unconditionally (every webOS SoC decodes it), hevc only when the table
 /// lists the decoder — anything else the pipeline cannot feed at all. The resolution half is the
 /// local agreement with the profile's `*`-scoped `video.width`/`video.height` limitation: the
-/// profile makes PMS transcode a 4K source down for a 1080p-bounded SoC, but the smart-DP branch
-/// never asks PMS, so without this test a 4K file with one direct-playable audio track was fed
-/// verbatim to a decoder whose table says 1920x1088 — the wrong-side failure devcaps' own doc
-/// names (issue #22's over-claim class), invisible on the dev TV, whose bound is 4096x2176.
+/// profile makes PMS transcode a 4K source down for a 1080p-bounded SoC, but when `/decision` is
+/// unreachable the fallback never asks PMS, so without this test a 4K file with one
+/// direct-playable audio track was fed verbatim to a decoder whose table says 1920x1088 — the
+/// wrong-side failure devcaps' own doc names (issue #22's over-claim class), invisible on the
+/// dev TV, whose bound is 4096x2176.
 ///
 /// **The Dolby Vision half is the same shape of bug, found the same way, and it is NOT about the
 /// decoder.** Every profile's base layer is ordinary HEVC and every one of them decodes here — so
@@ -2632,10 +2641,11 @@ mod tests {
         );
     }
 
-    /// The RESOLUTION half of the gate (issue #22's over-claim class): the smart-DP branch never
-    /// asks PMS, so the profile's `*`-scoped width/height limitation cannot save a 4K source from
-    /// direct-playing onto a 1080p-bounded decoder — the client must refuse it locally. Invisible
-    /// on the dev TV (bound 4096x2176); this drives the gate with the reviewer-class caps.
+    /// The RESOLUTION half of the gate (issue #22's over-claim class): when `/decision` is
+    /// unreachable the fallback never asks PMS, so the profile's `*`-scoped width/height limitation
+    /// cannot save a 4K source from direct-playing onto a 1080p-bounded decoder — the client must
+    /// refuse it locally. Invisible on the dev TV (bound 4096x2176); this drives the gate with the
+    /// reviewer-class caps.
     #[test]
     fn a_source_beyond_the_device_bound_does_not_direct_play() {
         let caps = crate::devcaps::Caps {

--- a/rust-modules/src/route/plan.rs
+++ b/rust-modules/src/route/plan.rs
@@ -865,6 +865,12 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     } else {
         pick_dp_audio(tracks, acodec)
     };
+    let audio_id = audio_sel.as_ref().map(|(_, _, id)| *id).unwrap_or(0);
+    let subtitle_id = plan
+        .playing
+        .as_ref()
+        .map(|p| mde_subtitle_stream_id(&p.subs))
+        .unwrap_or(0);
     // What the CONNECTION to this server allows, beside what the pipeline can decode: a Plex
     // relay is a ~2 Mbit/s tunnel, so neither of the two flavors that ship the file's own bytes
     // (direct play, and the uncapped container remux) can be asked for over one. Unrestricted on
@@ -895,13 +901,7 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         // evaluate a TrueHD/DTS default and veto; naming the chosen AAC/AC3/EAC3 sibling on the
         // query is what keeps that class on Original. subtitleStreamID is an advertised embedded
         // track Original will client-render, or 0 so a sidecar / unadvertised codec does not
-        // force a burn.
-        let audio_id = audio_sel.as_ref().map(|(_, _, id)| *id).unwrap_or(0);
-        let subtitle_id = plan
-            .playing
-            .as_ref()
-            .map(|p| mde_subtitle_stream_id(&p.subs))
-            .unwrap_or(0);
+        // force a burn. Same ids go on the remux probe so MDE and start.mkv name one track.
         server_decision(client, rk, &session, audio_id, subtitle_id)
     };
     let mut directplay = mde.as_ref().is_some_and(|v| v.original);
@@ -1011,6 +1011,10 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
         Some(crate::plex::probe::Location::Relay) => Some(crate::abr::LinkKind::Relay),
         None => None,
     };
+    // Captured before Auto overwrites `directplay` for HLS: a remux probe registered start.mkv
+    // on this playback identity, and a later HLS `/decision` must physical-stop that encoder
+    // first. A successful remux Original leaves the session for the play-path decision.
+    let mut remux_probed = false;
     let decision = match (env.quality, link_kind) {
         (Quality::Auto, Some(link)) => {
             // The probe is the only expensive input, so it is only taken where it can change the
@@ -1025,12 +1029,13 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
                         )
                     } else {
                         // Part GET 503s after a transcode MDE. Sample the remux we would actually play.
+                        remux_probed = true;
                         measure_remote_remux(
                             client,
                             rk,
                             &session,
-                            env.audio_sid,
-                            env.sub_sid,
+                            audio_id,
+                            subtitle_id,
                             source_transport_kbps,
                         )
                     }
@@ -1237,6 +1242,13 @@ pub(super) fn build_stream(rk: &str, part: &str, vcodec: &str, acodec: &str, env
     // from `Session`, and one that dropped the ceiling would hand the encoder back the full
     // 4K/60 Mbps bound the moment the user touched the scrubber.
     put_selection(env.sid, plan.part_id, env.audio_sid, env.sub_sid); // audio/subtitle selection drives the encode/remux + burn
+    if remux_probed && adaptive {
+        // Probe registered start.mkv on this playback identity. HLS `/decision` reuses it;
+        // closeResourceSession=1 would 503 the next start. A failed sample already stopped
+        // inside measure_remote_remux; this covers a completed sample that still falls to HLS.
+        // Stay-remux Original does not stop: the play-path decision owns that session.
+        let _ = client.transcode_stop_physical(&session);
+    }
     let sp = transcode_spec(
         rk,
         &session,

--- a/tools/plxnative-lab
+++ b/tools/plxnative-lab
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import base64
 import collections
+import errno
 import gzip
 import hashlib
 import hmac
@@ -214,11 +215,13 @@ class Upnp:
                     loc = m.group(1).decode()
                     if loc not in locations:
                         locations.append(loc)
-        except OSError:
-            # macOS EHOSTUNREACH ("No route to host") when the laptop has no multicast route —
-            # offline, VPN-only, no default. Selftest must still pass with no router in the room;
-            # `start` already turns a missing IGD into a status string.
-            pass
+        except OSError as e:
+            # No multicast route (offline, VPN-only, no default): macOS EHOSTUNREACH /
+            # ENETUNREACH. Selftest must still return None with no router in the room; `start`
+            # already turns a missing IGD into a status string. Any other OSError is a real
+            # failure and must not be swallowed.
+            if e.errno not in (errno.EHOSTUNREACH, errno.ENETUNREACH):
+                raise
         finally:
             s.close()
         for loc in locations:

--- a/tools/plxnative-lab
+++ b/tools/plxnative-lab
@@ -214,6 +214,11 @@ class Upnp:
                     loc = m.group(1).decode()
                     if loc not in locations:
                         locations.append(loc)
+        except OSError:
+            # macOS EHOSTUNREACH ("No route to host") when the laptop has no multicast route —
+            # offline, VPN-only, no default. Selftest must still pass with no router in the room;
+            # `start` already turns a missing IGD into a status string.
+            pass
         finally:
             s.close()
         for loc in locations:
@@ -1193,6 +1198,7 @@ def selftest(_args) -> int:
         srv.shutdown()
 
     # UPnP is the one half a selftest cannot fake: report what is on this LAN rather than assert.
+    # A missing multicast route is "not found", not a crash — this gate has to pass offline.
     igd = Upnp.discover(timeout=2.0)
     print(f"note  UPnP IGD on this LAN: {'yes — ' + igd.control_url if igd else 'not found'}")
     if igd:


### PR DESCRIPTION
PMS 1.43 503s an Original Part GET whose session never registered a Media Decision Engine handshake (`Denying access due to session lacking permission to direct play`). Smart direct-play used to skip `/decision` so a TrueHD/DTS default would not veto an AAC/AC3/EAC3 sibling, which is exactly the path that then 503'd.

## What this PR changes

Every Original plan now asks `GET /video/:/transcode/universal/decision?hasMDE=1&directPlay=1` first. The query names the track Original will actually play:

- `audioStreamID` is the chosen AAC/AC3/EAC3 sibling (smart-DP), so MDE does not evaluate TrueHD/DTS and force a video-downscaling transcode.
- `subtitleStreamID` is always sent. An advertised embedded codec Original client-renders (PGS, mov_text, dvd_subtitle, …) is named; a sidecar or unadvertised codec is `0` so MDE evaluates subs off instead of burning.

If `/decision` is unreachable or unusable, the plan fails closed: it does not return the Part URL. Remux or re-encode can still register via a separate `transcode_decision`.

`Part.decision=transcode` is a container change, not a video-copy veto. A remux that copies video is forbidden only when the **video stream's** own decision is `transcode` (bit depth, an undecodable codec). The measured TrueHD-only and Profile 5 shapes are `Part=transcode` with video `copy`; treating the part as a re-encode would transcode 4K for an audio problem. Remote Auto's Original probe then samples that remux `start.mkv` rather than the Part (a Part GET after a transcode decision is 503).

The direct-play profile's `subtitleCodec=` list is the same `DP_SUBTITLE_CODECS` constant the MDE stream-id gate reads, so a selected PGS cannot be advertised in one and omitted from the other.

Empty `session=` stop/ping/close calls no longer hit the wire (PMS logs those as "without a valid session GUID").

`tools/plxnative-lab` treats a missing multicast route as "UPnP not found" instead of crashing the selftest offline.

## Verification

Host tests in `route.rs` / `plex/{models,transcoder}.rs` cover:

- HEVC+EAC3 registers MDE before returning the Part
- smart-DP names the AC3 sibling on `/decision`
- `Part.decision=transcode` with no video stream remuxes (does not GET the Part)
- TrueHD-only remuxes; a video-stream `transcode` forbids remux; Profile 5 still refuses a remux copy
- Remote Auto probes `start.mkv` after a transcode MDE, never the Part
- unreachable/empty MDE does not return the Part URL
- selected PGS / mov_text / dvd_subtitle named; sidecar and unadvertised codecs send `0`