### PR TITLE
Settings: Automatically Sign In skips the profile picker on boot

### DIFF
--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -1644,7 +1644,7 @@ path. Never run only this one before a release. `tests/README.md` has the tier t
   `tests/run.py` always injects (it reads the owner token from the gitignored
   `src/config.local.h` on the HOST; that macro is never compiled in). An interactive boot with
   no session lands on the QR sign-in screen.
-- Normal interactive flow: who's-watching picker (multi-user) → Home; D-pad/pointer to focus a
+- Normal interactive flow: who's-watching picker (multi-user, unless Automatically Sign In is on) → Home; D-pad/pointer to focus a
   card → **OK** opens the detail page → Play starts playback; OK toggles play/pause, LEFT/RIGHT
   scrub-seek, **BACK/Stop** returns. The strip's **last pill is Search** (a mark, not a word) — a
   peer of Home and the Library, not a page stacked over them, so BACK from it returns to Home. BACK

--- a/docs/plex-pass-audit.md
+++ b/docs/plex-pass-audit.md
@@ -26,7 +26,7 @@ is the final verification for the fixes.
 | **Intro detection** | Skip Intro pill | no marker → no pill; nothing dangles | graceful, nothing to do |
 | **Hardware transcoding** | transcode throughput | software transcode: a weak free server re-encoding 4K will buffer | documented; nothing client-side to do — direct-play-first already minimizes exposure (after the mp4 fix, only genuinely undecodable sources transcode) |
 | **HDR tone mapping** | HDR source that must re-encode on a free server | h264 8-bit without tone mapping → washed-out colors | documented; **cannot be fixed client-side.** Narrow in practice: this panel decodes HEVC/HDR natively, so only undecodable HDR (e.g. AV1 on this SoC) hits it |
-| **Plex Home (managed users)** | boot who's-watching picker | free account = roster of 1 → `app.rs` skips the picker (`home_users.len() > 1`) | graceful by construction |
+| **Plex Home (managed users)** | boot who's-watching picker | free account = roster of 1 → boot skips the picker (`Session::boot_shows_picker`); Automatically Sign In skips it on a multi-user roster too | graceful by construction |
 | **Video preview thumbnails (BIF)** | chapter card thumbnails (`chapters_panel.rs`) | `thumb` empty → placeholder card; chapters themselves (embedded) still work | graceful |
 | **Trailers / extras** | `Extras` appears in an include-list string (`plex/library.rs`) and is never rendered | server returns none; nothing requests or draws them | no-op |
 | Live TV / DVR, music (sonic analysis, lyrics), photos, downloads/sync | not in scope of this app | — | n/a |

--- a/rust-modules/src/app/boot.rs
+++ b/rust-modules/src/app/boot.rs
@@ -648,7 +648,7 @@ pub(crate) unsafe fn boot(
             crate::auth::refresh_roster();
             if session.auto_sign_in()
                 && session.home_users.len() > 1
-                && !session.user.uuid.is_empty()
+                && session.seated_in_roster()
                 && !automated_boot()
                 && pick_user.is_none()
             {

--- a/rust-modules/src/app/boot.rs
+++ b/rust-modules/src/app/boot.rs
@@ -219,92 +219,91 @@ pub(crate) enum BootTo {
     Profiles,
 }
 
-    // Everything that has to happen when the server `plex::client()` answers with CHANGES —
-    // whether because a new identity signed in or because the user walked into another source.
-    // EVERY store below is keyed to whichever server was current when it was filled, and none
-    // of them carries a server in its keys, so leaving one behind means server A's ratingKeys
-    // being fetched from server B: the same catalog index opening a different film.
+// Everything that has to happen when the server `plex::client()` answers with CHANGES —
+// whether because a new identity signed in or because the user walked into another source.
+// EVERY store below is keyed to whichever server was current when it was filled, and none
+// of them carries a server in its keys, so leaving one behind means server A's ratingKeys
+// being fetched from server B: the same catalog index opening a different film.
 pub(crate) fn activate_server() {
-        // the browse store must never carry the previous user's (or server's) cached grid,
-        // watched-state angles, or section tabs forward
-        crate::stores::browse::apply(crate::stores::browse::BrowseCmd::Reset);
-        // …and the search store, for the same reason: a query, its results and the recent
-        // terms are all one person's.
-        crate::stores::search::apply(crate::stores::search::SearchCmd::Reset);
-        // …and the hub twin: a FAILED fetch now keeps the catalog it already had (so one
-        // wifi hiccup can't blank a populated Home), which makes this the one place that
-        // must still wipe it — otherwise a profile switch whose fetch fails would leave the
-        // previous user's shelves on screen.
-        crate::stores::hubs::apply(crate::stores::hubs::HubsCmd::Reset);
-        crate::stores::person::apply(crate::stores::person::PersonCmd::Reset); // ditto for an open person page's shelves
-                                // …and any view-state write still queued or owed a refresh. It belongs to the account
-                                // that pressed it, and the refresh it owes would land on shelves this reset just wiped.
-        crate::stores::viewstate::apply(crate::stores::viewstate::ViewStateCmd::Reset);
-        // Catalog activation is request-only. Home and section discovery both use their
-        // existing worker/mailbox pumps, so a remote endpoint cannot park the SDL loop here.
-        crate::stores::hubs::apply(crate::stores::hubs::HubsCmd::RefetchHubs);
-        crate::stores::browse::discover_pump();
-        log("pms: catalog activation queued");
+    // the browse store must never carry the previous user's (or server's) cached grid,
+    // watched-state angles, or section tabs forward
+    crate::stores::browse::apply(crate::stores::browse::BrowseCmd::Reset);
+    // …and the search store, for the same reason: a query, its results and the recent
+    // terms are all one person's.
+    crate::stores::search::apply(crate::stores::search::SearchCmd::Reset);
+    // …and the hub twin: a FAILED fetch now keeps the catalog it already had (so one
+    // wifi hiccup can't blank a populated Home), which makes this the one place that
+    // must still wipe it — otherwise a profile switch whose fetch fails would leave the
+    // previous user's shelves on screen.
+    crate::stores::hubs::apply(crate::stores::hubs::HubsCmd::Reset);
+    crate::stores::person::apply(crate::stores::person::PersonCmd::Reset); // ditto for an open person page's shelves
+                                                                           // …and any view-state write still queued or owed a refresh. It belongs to the account
+                                                                           // that pressed it, and the refresh it owes would land on shelves this reset just wiped.
+    crate::stores::viewstate::apply(crate::stores::viewstate::ViewStateCmd::Reset);
+    // Catalog activation is request-only. Home and section discovery both use their
+    // existing worker/mailbox pumps, so a remote endpoint cannot park the SDL loop here.
+    crate::stores::hubs::apply(crate::stores::hubs::HubsCmd::RefetchHubs);
+    crate::stores::browse::discover_pump();
+    log("pms: catalog activation queued");
 }
 
-    // Install the PMS client (the read layer AND the playback path) as the CURRENT server,
-    // then fetch the catalog. Used by the boot gate and again when a login resolves; a later
-    // call for the same address just swaps the token (profile switch).
-    // Takes an ORIGIN and not a `(host, port)` pair: the pair cannot say `https`, and the host
-    // a certificate is issued for is the `plex.direct` NAME rather than the address behind it
-    // (`plex::origin`). Discovery and persisted sessions may supply either scheme; the client
-    // routes control and media requests through the matching transport.
+// Install the PMS client (the read layer AND the playback path) as the CURRENT server,
+// then fetch the catalog. Used by the boot gate and again when a login resolves; a later
+// call for the same address just swaps the token (profile switch).
+// Takes an ORIGIN and not a `(host, port)` pair: the pair cannot say `https`, and the host
+// a certificate is issued for is the `plex.direct` NAME rather than the address behind it
+// (`plex::origin`). Discovery and persisted sessions may supply either scheme; the client
+// routes control and media requests through the matching transport.
 pub(crate) fn install_pms(
     origin: &crate::plex::Origin,
     token: &str,
     tier: Option<crate::plex::probe::Location>,
     pin: Option<&crate::plex::ResolvePin>,
 ) {
-        crate::plex::install(origin, token, pin); // a (re)install is a login / profile switch
-                                             // `install` may re-point the slot by publishing a fresh Client, whose link starts
-                                             // unknown. Restore the persisted/raced winner only after that publication.
-        if let Some(link) = tier {
-            crate::plex::client()
-                .set_connection(link, crate::plex::IpVersion::of_host(origin.host()));
-        }
-        // Every additional server this boot was handed credentials for joins the REGISTRY
-        // beside it — the granted roster `browse` addresses its section table by. Registration
-        // is not activation: `install` above has already made the session's own server current,
-        // and `register` deliberately does not steal that, so a share appears as a source to
-        // browse rather than as a server the app has switched to.
-        //
-        // AFTER `install`, so slot 0 is always the session's own server and the roster reads in
-        // the order the Sources list wants to draw it. Registering here (rather than at the boot
-        // gate) also means a profile switch re-registers them, which is what keeps a share in
-        // the roster across a switch — and it must precede `activate_server`, whose refetch is
-        // what turns a newly registered source into shelves and section tabs.
-        for s in crate::dev::servers()
-            .unwrap_or_default()
-            .iter()
-            .filter(|s| s.usable())
-        {
-            // `usable()` IS `origin().is_some()`, so this `else` cannot be taken; it is a
-            // `continue` rather than an `expect` because an injected server has never been
-            // allowed to cost more than itself.
-            let Some(origin) = s.origin() else { continue };
-            let id = crate::plex::register_origin(
-                &s.machine_id,
-                &origin,
-                &s.token,
-                s.resolve_pin().as_ref(),
-            );
-            if let Some(tier) = s.tier {
-                // The endpoint may be a LAN conditioner in front of a Remote PMS.  Preserve
-                // the discovery fact the harness supplied; the private proxy address itself
-                // cannot prove Local, and an omitted tier deliberately proves nothing.
-                if let Some(client) = crate::plex::client_for(id) {
-                    client.set_link(tier);
-                }
+    crate::plex::install(origin, token, pin); // a (re)install is a login / profile switch
+                                              // `install` may re-point the slot by publishing a fresh Client, whose link starts
+                                              // unknown. Restore the persisted/raced winner only after that publication.
+    if let Some(link) = tier {
+        crate::plex::client().set_connection(link, crate::plex::IpVersion::of_host(origin.host()));
+    }
+    // Every additional server this boot was handed credentials for joins the REGISTRY
+    // beside it — the granted roster `browse` addresses its section table by. Registration
+    // is not activation: `install` above has already made the session's own server current,
+    // and `register` deliberately does not steal that, so a share appears as a source to
+    // browse rather than as a server the app has switched to.
+    //
+    // AFTER `install`, so slot 0 is always the session's own server and the roster reads in
+    // the order the Sources list wants to draw it. Registering here (rather than at the boot
+    // gate) also means a profile switch re-registers them, which is what keeps a share in
+    // the roster across a switch — and it must precede `activate_server`, whose refetch is
+    // what turns a newly registered source into shelves and section tabs.
+    for s in crate::dev::servers()
+        .unwrap_or_default()
+        .iter()
+        .filter(|s| s.usable())
+    {
+        // `usable()` IS `origin().is_some()`, so this `else` cannot be taken; it is a
+        // `continue` rather than an `expect` because an injected server has never been
+        // allowed to cost more than itself.
+        let Some(origin) = s.origin() else { continue };
+        let id = crate::plex::register_origin(
+            &s.machine_id,
+            &origin,
+            &s.token,
+            s.resolve_pin().as_ref(),
+        );
+        if let Some(tier) = s.tier {
+            // The endpoint may be a LAN conditioner in front of a Remote PMS.  Preserve
+            // the discovery fact the harness supplied; the private proxy address itself
+            // cannot prove Local, and an omitted tier deliberately proves nothing.
+            if let Some(client) = crate::plex::client_for(id) {
+                client.set_link(tier);
             }
-            // the roster's own answer about this server: a handle means someone else's.
-            crate::plex::describe_server(id, &s.name, &s.handle, s.handle.is_empty());
         }
-        activate_server();
+        // the roster's own answer about this server: a handle means someone else's.
+        crate::plex::describe_server(id, &s.name, &s.handle, s.handle.is_empty());
+    }
+    activate_server();
 }
 
 /// Everything before the loop: SDL and the window, GL, text, the poster workers, the boot gate
@@ -527,7 +526,6 @@ pub(crate) unsafe fn boot(
         .to_string_lossy()
         .into_owned();
 
-
     // UI infra + poster workers always come up — the owned login/profiles screens use them too.
     //
     // **No `ui::login::init()` / `ui::profiles::init()` here any more (phase 6 retirement).**
@@ -560,8 +558,10 @@ pub(crate) unsafe fn boot(
     //  1. /tmp/plxnative-login forces the QR login screen (to exercise the flow on demand).
     //  2. /tmp/plxnative-token (the harness / headless runs) beats the stored session — automation
     //     must run as the injected test identity no matter who is signed in on the TV.
-    //  3. A stored session (offline-capable LAN server) → Home, through the who's-watching
-    //     picker first when the account has a multi-user Plex Home roster (interactive boots).
+    //  3. A stored session (offline-capable LAN server) → Home. A multi-user Plex Home roster
+    //     still goes through the who's-watching picker first on interactive boots, unless
+    //     Automatically Sign In is on and a profile is already seated (that skip is an explicit
+    //     opt-in, PIN included). Automated boots and a roster of one still skip the picker.
     //  4. Nothing → the QR sign-in flow (no credentials are compiled in — like a real client).
     // The destination itself is [`BootTo`], at module scope with the rest of the vocabulary.
     //
@@ -600,7 +600,7 @@ pub(crate) unsafe fn boot(
         );
         BootTo::Home
     } else if session.can_go_local() {
-        if session.home_users.len() > 1 && (!automated_boot() || pick_user.is_some()) {
+        if session.boot_shows_picker(automated_boot(), pick_user.is_some()) {
             // Who's watching first. Only the read client is installed here (the avatars proxy
             // through the PMS photo transcoder); the catalog fetch + playback config happen in
             // take_ready once a profile is picked — done now they'd be thrown out on a switch.
@@ -619,11 +619,12 @@ pub(crate) unsafe fn boot(
         } else {
             // The persisted roster FIRST, then the primary. This is the one boot path that does
             // not go through `auth::start_switch` — a stored session with a single Plex Home
-            // user, or any automated run — so without this line it registered exactly one
-            // server and every share was invisible until the next sign-in: no second source in
-            // the Sources panel, no borrowed shelves, nothing to attribute. `install_roster`
-            // leaves `current` alone and sorts owned first, and `install_pms` below retargets to
-            // the session's own server regardless, so ordering cannot land us on a friend's box.
+            // user, an automated run, or Automatically Sign In with a seated profile — so without
+            // this line it registered exactly one server and every share was invisible until the
+            // next sign-in: no second source in the Sources panel, no borrowed shelves, nothing
+            // to attribute. `install_roster` leaves `current` alone and sorts owned first, and
+            // `install_pms` below retargets to the session's own server regardless, so ordering
+            // cannot land us on a friend's box.
             // Before, not after, because `install_pms` ends in the catalog + section fetch that
             // turns a registered source into something on screen.
             crate::auth::install_stored_roster(&session);
@@ -645,7 +646,16 @@ pub(crate) unsafe fn boot(
             // put the dead origin back into the live registry for the rest of this run.
             // Non-destructive on failure; the stored roster above remains available offline.
             crate::auth::refresh_roster();
-            log("boot: stored session — local server (offline-capable)");
+            if session.auto_sign_in()
+                && session.home_users.len() > 1
+                && !session.user.uuid.is_empty()
+                && !automated_boot()
+                && pick_user.is_none()
+            {
+                log("boot: stored session — auto sign-in");
+            } else {
+                log("boot: stored session — local server (offline-capable)");
+            }
             BootTo::Home
         }
     } else {

--- a/rust-modules/src/auth.rs
+++ b/rust-modules/src/auth.rs
@@ -722,14 +722,17 @@ fn may_resume(from: Picker, stored_is_protected: bool) -> bool {
 ///
 /// So a RESTART re-attaches through the BOOT GATE rather than through this one, and what happens
 /// there is that gate's policy, not this one's: with a roster of more than one it raises a picker
-/// and [`Picker::Boot`]'s rule applies, and with a roster of one or none `app.rs` installs the
-/// stored profile directly, PIN or no PIN. Two known staleness/policy gaps sit behind that
-/// sentence and are deliberately NOT closed here — the single-user boot restore, and the fact that
-/// `protected` is read from a CACHED roster that plex.tv may have moved on from. Both are older
-/// than this rule, both are one owner decision about what to do with no network, and the obvious
-/// fix for the first (gating boot on [`Session::active_profile_is_protected`]) is worse than the
-/// bug: that predicate answers TRUE for an empty or unknown roster by design, so it would put a PIN
-/// screen in front of every single-account user who has no PIN at all.
+/// unless Automatically Sign In is on and a profile is already seated
+/// ([`crate::plex::session::Session::boot_shows_picker`]), and with a roster of one or none
+/// `app.rs` installs the stored profile directly, PIN or no PIN. Two known staleness/policy gaps
+/// sit behind that sentence and are deliberately NOT closed here — the single-user boot restore,
+/// and the fact that `protected` is read from a CACHED roster that plex.tv may have moved on from.
+/// Both are older than this rule, both are one owner decision about what to do with no network,
+/// and the obvious fix for the first (gating boot on [`Session::active_profile_is_protected`]) is
+/// worse than the bug: that predicate answers TRUE for an empty or unknown roster by design, so it
+/// would put a PIN screen in front of every single-account user who has no PIN at all.
+/// Automatically Sign In is the explicit opt-in that extends the single-user restore to a
+/// multi-user roster, PIN included.
 ///
 /// The previous profile's per-user PMS token also stays installed in the server registry. It has to
 /// — the roster's own avatars are fetched through it (`ui::profiles`'s `Art::Thumb`), so revoking
@@ -1078,7 +1081,12 @@ pub(crate) enum LoginProgress {
     /// observation time, so a generation is only ever spent on a code that actually reaches the
     /// screen — exactly the property the old synchronous write had, and the reason the allocation
     /// does not travel on this variant.
-    CodeReady { epoch: u64, id: i64, code: String, qr_png: Vec<u8> },
+    CodeReady {
+        epoch: u64,
+        id: i64,
+        code: String,
+        qr_png: Vec<u8>,
+    },
     /// The user authorized on their phone; discovery is starting.
     Authorized { epoch: u64, token: String },
     /// The whole attempt failed for the stated, already-user-facing reason — no server on the
@@ -1361,9 +1369,7 @@ fn login_thread(epoch: u64, cid: String) {
     let (server, sources) = match discover_and_store(&ac, epoch) {
         Discovery::Ok { server, sources } => (server, sources),
         Discovery::Cancelled => return,
-        Discovery::NoServers => {
-            return push_failed(epoch, "This Plex account has no server yet.")
-        }
+        Discovery::NoServers => return push_failed(epoch, "This Plex account has no server yet."),
         Discovery::Refused => {
             return push_failed(
                 epoch,
@@ -1495,7 +1501,10 @@ fn finish_sign_in(ac: &AccountClient, epoch: u64, server: ServerRef, sources: Ve
     // `log_form`, not `base()`: byte-identical to the `{addr}:{port}` this line always printed
     // for a plaintext origin (so an archived log stays comparable), and the whole URL as soon as
     // the scheme is worth saying. See `Origin::log_form`.
-    log(&format!("auth: PMS client installed {}", server.origin().log_form()));
+    log(&format!(
+        "auth: PMS client installed {}",
+        server.origin().log_form()
+    ));
 
     // 4) Plex Home roster → who's-watching, or straight in if there's a single user. The roster is
     // kept on the session so it persists with the creds — the boot picker and every later
@@ -2918,21 +2927,25 @@ pub fn refresh_roster() {
             let _ = with_live_epoch(epoch, || activate_candidate(plan, c, origin, &credit));
         };
         let mut settled = Vec::new();
-        let found =
-            match resolve_roster_live(&resources, &household, &mut activate, &mut |plan, outcome, tier| {
+        let found = match resolve_roster_live(
+            &resources,
+            &household,
+            &mut activate,
+            &mut |plan, outcome, tier| {
                 let probe = settled_probe(plan, outcome, tier);
                 settled.push(probe.clone());
                 let _ = with_live_epoch(epoch, || publish_settled_probe(&probe));
-            }) {
-                Resolved::Reached(f) => f,
-                // "no server answered" is not evidence that the grant is gone: the friend's box may
-                // simply be off. Dropping the roster here would make an offline share un-browsable
-                // for good rather than until it comes back.
-                _ => {
-                    log("auth: roster refresh — nothing answered, keeping the stored roster");
-                    return;
-                }
-            };
+            },
+        ) {
+            Resolved::Reached(f) => f,
+            // "no server answered" is not evidence that the grant is gone: the friend's box may
+            // simply be off. Dropping the roster here would make an offline share un-browsable
+            // for good rather than until it comes back.
+            _ => {
+                log("auth: roster refresh — nothing answered, keeping the stored roster");
+                return;
+            }
+        };
         // The comparison, primary reconcile, CTL merge, registry replacement and write are one
         // auth-generation step. The resources response is the grant list; `found` is only the
         // subset that happened to answer. Preserve a cached address for a still-granted offline
@@ -3277,7 +3290,12 @@ fn install_roster(sources: &[SourceRef], primary: Option<usize>) -> Vec<ServerId
         // so this `else` is unreachable today and is a `continue` rather than an `expect` because
         // a roster entry has never been allowed to cost more than itself (`de_soft_vec`).
         let Some(origin) = s.origin() else { continue };
-        let id = crate::plex::register_origin(&s.machine_id, &origin, &s.token, s.resolve_pin().as_ref());
+        let id = crate::plex::register_origin(
+            &s.machine_id,
+            &origin,
+            &s.token,
+            s.resolve_pin().as_ref(),
+        );
         if !id.is_set() {
             continue;
         }
@@ -3431,7 +3449,12 @@ fn merge_profile_roster(
         if !same_session_identity(&c.session, expected) {
             return None;
         }
-        let sources = profile_sources(&c.session.sources, reached, resources, &c.session.household_ids());
+        let sources = profile_sources(
+            &c.session.sources,
+            reached,
+            resources,
+            &c.session.household_ids(),
+        );
         let Some(primary) = sources
             .iter()
             .find(|s| s.machine_id == c.session.server.machine_id)
@@ -3944,7 +3967,8 @@ mod tests {
             }
         }
         let _g = crate::testlock::serial();
-        let dir = std::env::temp_dir().join(format!("plxnative-signout-consent-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("plxnative-signout-consent-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("a writable temp dir");
         let _redirects = Redirects {
@@ -3957,11 +3981,17 @@ mod tests {
         crate::telemetry::spool::set_test_path(Some(dir.join("spool.jsonl")));
 
         // Account A answers yes to both, which mints both identifiers and persists the decision.
-        crate::telemetry::record(consent::apply(&consent::Consent::default(), true, true, || {
-            Some("a".repeat(32))
-        }));
+        crate::telemetry::record(consent::apply(
+            &consent::Consent::default(),
+            true,
+            true,
+            || Some("a".repeat(32)),
+        ));
         assert!(consent::allows_usage() && consent::errors_id().is_some());
-        assert!(consent_file.exists(), "the decision was persisted for account A");
+        assert!(
+            consent_file.exists(),
+            "the decision was persisted for account A"
+        );
 
         forget_account();
 
@@ -4967,7 +4997,8 @@ mod tests {
             ("192.168.0.10", 200, identity_json("aaaa1111")),
             ("203.0.113.9", 200, identity_json("bbbb2222")),
         ]);
-        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
+        let Resolved::Reached(roster) =
+            resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
         else {
             panic!("both servers answer: {:?}", d.seen())
         };
@@ -5048,7 +5079,8 @@ mod tests {
             ("plex-relay.example.net", 200, identity_json("aaaa1111")),
             ("203-0-113-9.h.plex.direct", 200, identity_json("bbbb2222")),
         ]);
-        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
+        let Resolved::Reached(roster) =
+            resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
         else {
             panic!("both servers answer over TLS: {:?}", d.seen())
         };
@@ -5103,7 +5135,8 @@ mod tests {
             ("192.168.0.10", 200, identity_json("aaaa1111")),
             ("203.0.113.9", 200, identity_json("bbbb2222")),
         ]);
-        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
+        let Resolved::Reached(roster) =
+            resolve_roster(&a_two_server_account(), &[], &|o| d.dial(o))
         else {
             panic!("both servers answer")
         };
@@ -5159,7 +5192,8 @@ mod tests {
         // a share that answers while OUR server is off still signs in — a friend's library beats
         // "no server found" — and it becomes the primary because it is the only thing there is
         let one = Dialled::new(vec![("203.0.113.9", 200, identity_json("bbbb2222"))]);
-        let Resolved::Reached(roster) = resolve_roster(&a_two_server_account(), &[], &|o| one.dial(o))
+        let Resolved::Reached(roster) =
+            resolve_roster(&a_two_server_account(), &[], &|o| one.dial(o))
         else {
             panic!("the share answered")
         };
@@ -5237,7 +5271,11 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(seated_uuid(&u, &tile("u-kid", false)), "u-kid");
-        assert_eq!(seated_uuid(&u, &tile("", false)), "u-other", "no roster uuid: the response's");
+        assert_eq!(
+            seated_uuid(&u, &tile("", false)),
+            "u-other",
+            "no roster uuid: the response's"
+        );
     }
 
     /// The plaintext twin may answer first, but a store build cannot make it live: only an
@@ -5248,7 +5286,10 @@ mod tests {
         let tls = Origin::parse("https://192-168-0-10.abc.plex.direct:32400").unwrap();
         assert!(!activation_allowed_by_policy(&plain, false));
         assert!(activation_allowed_by_policy(&tls, false));
-        assert!(activation_allowed_by_policy(&plain, true), "a developer build keeps its lab server");
+        assert!(
+            activation_allowed_by_policy(&plain, true),
+            "a developer build keeps its lab server"
+        );
     }
 
     fn tile(uuid: &str, protected: bool) -> UserTile {
@@ -5268,7 +5309,10 @@ mod tests {
         match offline_activation(&stored, &tile("u-admin", true), Some("4821")) {
             OfflineSwitch::Seat(next) => {
                 assert_eq!(next.user.token, "admin-token");
-                assert_eq!(next.client_id, "cid", "the account and its roster ride through");
+                assert_eq!(
+                    next.client_id, "cid",
+                    "the account and its roster ride through"
+                );
                 assert_eq!(next.account_token, "acct");
             }
             _ => panic!("the right PIN seats the cached profile"),
@@ -5307,7 +5351,11 @@ mod tests {
                 assert_eq!(next.user.token, "kid-token");
                 assert_eq!(next.server.token, "kid-token");
                 assert_eq!(next.sources[0].token, "kid-token");
-                assert_eq!(next.profiles.len(), 2, "the cache itself is kept for the next pick");
+                assert_eq!(
+                    next.profiles.len(),
+                    2,
+                    "the cache itself is kept for the next pick"
+                );
             }
             _ => panic!("an unprotected cached profile seats without a network"),
         }
@@ -5329,7 +5377,8 @@ mod tests {
     /// The seating paths that never see a PIN still write the record for a PIN-free profile,
     /// so a session stored before the cache existed becomes seatable offline on first use.
     #[test]
-    fn seating_an_unprotected_active_profile_records_it_and_a_protected_one_is_left_to_the_switch() {
+    fn seating_an_unprotected_active_profile_records_it_and_a_protected_one_is_left_to_the_switch()
+    {
         let mut s = cached_session(None);
         s.profiles.clear();
         s.home_users = vec![session::HomeUserRef {
@@ -5339,7 +5388,10 @@ mod tests {
         }];
         remember_unprotected_active(&mut s);
         assert_eq!(s.profiles.len(), 1);
-        assert_eq!(s.cached_profile("u-admin").unwrap().user.token, "admin-token");
+        assert_eq!(
+            s.cached_profile("u-admin").unwrap().user.token,
+            "admin-token"
+        );
 
         let mut p = cached_session(None);
         p.profiles.clear();
@@ -5349,11 +5401,17 @@ mod tests {
             ..Default::default()
         }];
         remember_unprotected_active(&mut p);
-        assert!(p.profiles.is_empty(), "no PIN in hand, no verifier to write");
+        assert!(
+            p.profiles.is_empty(),
+            "no PIN in hand, no verifier to write"
+        );
 
         let mut none = Session::default();
         remember_unprotected_active(&mut none);
-        assert!(none.profiles.is_empty(), "an account without Plex Home names no profile");
+        assert!(
+            none.profiles.is_empty(),
+            "an account without Plex Home names no profile"
+        );
     }
 
     fn source(machine_id: &str, owned: bool, token: &str) -> SourceRef {
@@ -5929,7 +5987,10 @@ mod tests {
         // the rule itself, as a table
         assert!(!may_resume(Picker::Boot, true), "the escalation");
         assert!(may_resume(Picker::Boot, false));
-        assert!(!may_resume(Picker::ChangeProfile, true), "the same escalation");
+        assert!(
+            !may_resume(Picker::ChangeProfile, true),
+            "the same escalation"
+        );
         assert!(!may_resume(Picker::ChangeProfile, false));
         assert!(!may_resume(Picker::SignedIn, true));
         assert!(!may_resume(Picker::SignedIn, false));

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -183,10 +183,8 @@ impl TempSession {
     /// observable at all; leaving the profile unset is the neutral start, since a test that cares
     /// which profile it is says so with [`TempSession::watching`].
     pub(crate) fn new(tag: &str) -> TempSession {
-        let dir = std::env::temp_dir().join(format!(
-            "plxnative-session-{}-{tag}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("plxnative-session-{}-{tag}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("a writable temp dir");
         redirect_for_test(Some(dir.join("auth.json")));
@@ -350,6 +348,16 @@ pub struct Session {
     /// instead of making the credentials file fail to parse.
     #[serde(default, deserialize_with = "de_soft_playback_quality")]
     pub(crate) playback_quality: Option<PlaybackQuality>,
+    /// **Automatically Sign In** — skip the boot who's-watching picker and enter as
+    /// [`Session::user`]. Install-wide, not per profile: the boot gate reads it before anyone is
+    /// seated this run. Absence is **off**, which is today's picker. Enabling it from Settings
+    /// while a profile is already active is an explicit opt-in to skip that profile's PIN on the
+    /// next launch; BACK out of the picker still refuses a protected resume when this is off.
+    ///
+    /// Soft-parsed so a hand-edited or future-shaped value costs the preference, never the
+    /// credentials.
+    #[serde(default, deserialize_with = "de_soft_bool")]
+    pub(crate) auto_sign_in: bool,
     /// **Device-wide ambient memory**: the last hero `UltraBlurColors` envelope Home actually
     /// rendered on this television, so a route in the Settings/first-run family that opens
     /// BEFORE Home has fetched anything this boot — first-run consent moved ahead of the
@@ -391,6 +399,17 @@ pub(crate) fn record_last_hero(blur: [[f32; 3]; 4]) -> bool {
 /// never rendered one.
 pub(crate) fn last_hero() -> Option<[[f32; 3]; 4]> {
     load().last_hero_blur
+}
+
+/// Persist Automatically Sign In through [`update`], so a concurrent roster/recents write cannot
+/// lose the switch. Returns whether the file was rewritten.
+pub(crate) fn set_auto_sign_in(on: bool) -> bool {
+    update(|cur| {
+        if cur.auto_sign_in == on {
+            return None;
+        }
+        Some(cur.with_auto_sign_in(on))
+    })
 }
 
 /// The persisted playback-quality modes. The spelling on disk is explicit rather than derived
@@ -931,6 +950,17 @@ where
     Ok(serde_json::from_value::<Option<PlaybackQuality>>(v).unwrap_or(None))
 }
 
+/// A preference switch: garbage degrades to off rather than failing the enclosing [`Session`].
+fn de_soft_bool<'de, D>(d: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Ok(v) = serde_json::Value::deserialize(d) else {
+        return Ok(false);
+    };
+    Ok(v.as_bool().unwrap_or(false))
+}
+
 impl Session {
     /// Record (or replace) the cached credentials for one profile — the online switch's write.
     pub fn remember_profile(&mut self, creds: ProfileCreds) {
@@ -971,9 +1001,9 @@ impl Session {
         if uuid.is_empty() {
             return None;
         }
-        self.profiles
-            .iter()
-            .find(|p| p.uuid == uuid && !p.user.token.is_empty() && !p.server.origin().host().is_empty())
+        self.profiles.iter().find(|p| {
+            p.uuid == uuid && !p.user.token.is_empty() && !p.server.origin().host().is_empty()
+        })
     }
 
     /// The effective persisted playback quality. Absence is the literal legacy migration rule:
@@ -987,6 +1017,36 @@ impl Session {
         let mut next = self.clone();
         next.playback_quality = Some(quality);
         next
+    }
+
+    pub(crate) fn auto_sign_in(&self) -> bool {
+        self.auto_sign_in
+    }
+
+    /// Record the Settings switch while leaving every unrelated session field intact.
+    pub(crate) fn with_auto_sign_in(&self, on: bool) -> Self {
+        let mut next = self.clone();
+        next.auto_sign_in = on;
+        next
+    }
+
+    /// Interactive boot with a multi-user Plex Home shows the who's-watching picker unless
+    /// Automatically Sign In is on and a profile is already seated.
+    ///
+    /// `force_pick` is `/tmp/plxnative-pickuser`: it wins even on an automated boot. An empty
+    /// `user.uuid` still raises the picker when the switch is on — that is the abandoned-at-picker
+    /// session whose PMS token falls back to the owner.
+    pub(crate) fn boot_shows_picker(&self, automated: bool, force_pick: bool) -> bool {
+        if !self.can_go_local() || self.home_users.len() <= 1 {
+            return false;
+        }
+        if force_pick {
+            return true;
+        }
+        if automated {
+            return false;
+        }
+        !(self.auto_sign_in && !self.user.uuid.is_empty())
     }
 
     /// True once we have a LAN server + a usable PMS token — i.e. we can run offline.
@@ -1997,6 +2057,114 @@ mod tests {
         assert_eq!(legacy.playback_quality(), PlaybackQuality::Original);
     }
 
+    /// A missing Automatically Sign In field is today's picker, not an invitation to skip it.
+    #[test]
+    fn a_legacy_session_with_no_auto_sign_in_stays_off() {
+        let s: Session = serde_json::from_str(two_server_json()).expect("the legacy file parses");
+        assert!(
+            !s.auto_sign_in(),
+            "absence is off, which is the picker every existing television already knows"
+        );
+    }
+
+    /// Garbage on a preference switch must not sign the device out.
+    #[test]
+    fn invalid_auto_sign_in_is_soft_and_off() {
+        for value in [r#""yes""#, "null", "1", r#"{"on":true}"#] {
+            let json = format!(
+                r#"{{"client_id":"c","account_token":"acct",
+                     "server":{{"address":"192.168.0.10","port":32400,"token":"t"}},
+                     "auto_sign_in":{value}}}"#
+            );
+            let s: Session = serde_json::from_str(&json)
+                .expect("bad preference metadata cannot fail credentials");
+            assert_eq!(s.account_token, "acct");
+            assert!(s.can_go_local());
+            assert!(!s.auto_sign_in(), "{value}");
+        }
+    }
+
+    fn dialable_home(users: usize, uuid: &str, auto: bool) -> Session {
+        let home_users = (0..users)
+            .map(|i| HomeUserRef {
+                uuid: format!("u-{i}"),
+                title: format!("User {i}"),
+                protected: i == 0,
+                admin: i == 0,
+                ..Default::default()
+            })
+            .collect();
+        Session {
+            client_id: "c".into(),
+            account_token: "acct".into(),
+            server: ServerRef {
+                address: "192.168.0.10".into(),
+                port: 32400,
+                token: "t".into(),
+                ..Default::default()
+            },
+            user: UserRef {
+                uuid: uuid.into(),
+                token: "ut".into(),
+                ..Default::default()
+            },
+            home_users,
+            auto_sign_in: auto,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn boot_shows_picker_table() {
+        let multi_off = dialable_home(2, "u-0", false);
+        assert!(
+            multi_off.boot_shows_picker(false, false),
+            "multi-user interactive still raises the picker when the switch is off"
+        );
+        assert!(
+            !multi_off.boot_shows_picker(true, false),
+            "an automated boot still skips the picker"
+        );
+        assert!(
+            multi_off.boot_shows_picker(true, true),
+            "pickuser forces the picker even on an automated boot"
+        );
+
+        let multi_on = dialable_home(2, "u-0", true);
+        assert!(
+            multi_on.home_users[0].protected,
+            "u-0 is the PIN-protected admin in this fixture"
+        );
+        assert!(
+            !multi_on.boot_shows_picker(false, false),
+            "the switch skips the picker when a profile is seated, PIN included"
+        );
+        assert!(
+            multi_on.boot_shows_picker(false, true),
+            "pickuser still forces the picker when the switch is on"
+        );
+
+        let abandoned = dialable_home(2, "", true);
+        assert!(
+            abandoned.boot_shows_picker(false, false),
+            "an empty uuid still raises the picker so the owner's token is not handed out"
+        );
+
+        let solo = dialable_home(1, "u-0", false);
+        assert!(
+            !solo.boot_shows_picker(false, false),
+            "a one-person account already skips the picker"
+        );
+        assert!(!dialable_home(1, "u-0", true).boot_shows_picker(false, false));
+
+        let mut undialable = dialable_home(2, "u-0", false);
+        undialable.server = ServerRef::default();
+        assert!(
+            !undialable.boot_shows_picker(false, false),
+            "this helper is not the QR path: no local session, no picker"
+        );
+    }
+
     /// The other side of the gate: once an origin IS written down it is what gets dialled, and it
     /// beats the address pair beside it. That is not a tie-break for its own sake — for an https
     /// server the two genuinely differ (the certificate is issued for the `plex.direct` NAME, not
@@ -2639,7 +2807,10 @@ mod tests {
         );
 
         let second = [[0.9, 0.8, 0.7]; 4];
-        assert!(record_last_hero(second), "a genuinely different hero writes");
+        assert!(
+            record_last_hero(second),
+            "a genuinely different hero writes"
+        );
         assert_eq!(last_hero(), Some(second), "…and replaces the stored one");
     }
 
@@ -2750,6 +2921,61 @@ mod tests {
         assert_eq!(landed.account_token, "acct");
         assert_eq!(landed.sources.len(), 1);
         assert_eq!(landed.sources[0].machine_id, "server-a");
+    }
+
+    #[test]
+    fn auto_sign_in_persists_without_replacing_other_session_state() {
+        let _g = crate::testlock::serial();
+        let _t = TempSession::new("auto-sign-in");
+        let mut s = signed_in();
+        s.user.uuid = "u-kid".into();
+        s.sources.push(SourceRef {
+            machine_id: "server-a".into(),
+            token: "server-token".into(),
+            address: "192.168.0.10".into(),
+            port: 32400,
+            ..Default::default()
+        });
+        save(&s);
+        assert!(!peek().auto_sign_in());
+
+        assert!(set_auto_sign_in(true));
+        let landed = peek();
+        assert!(landed.auto_sign_in());
+        assert_eq!(landed.account_token, "acct");
+        assert_eq!(landed.user.uuid, "u-kid");
+        assert_eq!(landed.sources.len(), 1);
+
+        assert!(
+            !set_auto_sign_in(true),
+            "setting the same value again must not touch the file"
+        );
+        assert!(set_auto_sign_in(false));
+        assert!(!peek().auto_sign_in());
+    }
+
+    /// `take_ready` / a profile switch `save` a whole snapshot they loaded at the start of the
+    /// flow. That snapshot must carry the switch, or the next boot forgets it.
+    #[test]
+    fn a_full_save_of_a_switch_snapshot_keeps_auto_sign_in() {
+        let _g = crate::testlock::serial();
+        let _t = TempSession::new("auto-sign-in-save");
+        let mut s = signed_in();
+        s.user.uuid = "u-admin".into();
+        save(&s);
+        assert!(set_auto_sign_in(true));
+
+        let mut snap = peek();
+        snap.user.uuid = "u-kid".into();
+        save(&snap);
+
+        let landed = peek();
+        assert!(
+            landed.auto_sign_in(),
+            "a whole-file replace of a loaded snapshot must not drop the switch"
+        );
+        assert_eq!(landed.user.uuid, "u-kid");
+        assert_eq!(landed.account_token, "acct");
     }
 
     #[test]
@@ -2990,13 +3216,19 @@ mod profile_cache_tests {
     #[test]
     fn a_malformed_verifier_admits_nobody() {
         let none = PinVerifier::default();
-        assert!(!none.verify(""), "an empty record must not match an empty PIN");
+        assert!(
+            !none.verify(""),
+            "an empty record must not match an empty PIN"
+        );
         let mut v = PinVerifier::new("1234");
         v.iters = 0;
         assert!(!v.verify("1234"));
         let mut v = PinVerifier::new("1234");
         v.iters = u32::MAX;
-        assert!(!v.verify("1234"), "an unbounded count is refused before it is run");
+        assert!(
+            !v.verify("1234"),
+            "an unbounded count is refused before it is run"
+        );
         let mut v = PinVerifier::new("1234");
         v.iters = PinVerifier::MAX_ITERS + 1;
         assert!(!v.verify("1234"));
@@ -3015,9 +3247,19 @@ mod profile_cache_tests {
         s.remember_profile(creds("u-kid", "t2", None));
         s.remember_profile(creds("u-admin", "t3", Some("2222")));
         s.remember_profile(creds("", "t4", None));
-        assert_eq!(s.profiles.len(), 2, "replace by uuid; an empty uuid is never cached");
+        assert_eq!(
+            s.profiles.len(),
+            2,
+            "replace by uuid; an empty uuid is never cached"
+        );
         assert_eq!(s.cached_profile("u-admin").unwrap().user.token, "t3");
-        assert!(s.cached_profile("u-admin").unwrap().pin.as_ref().unwrap().verify("2222"));
+        assert!(s
+            .cached_profile("u-admin")
+            .unwrap()
+            .pin
+            .as_ref()
+            .unwrap()
+            .verify("2222"));
         assert!(s.cached_profile("u-kid").unwrap().pin.is_none());
         assert!(s.cached_profile("u-nobody").is_none());
         assert!(s.cached_profile("").is_none());
@@ -3025,7 +3267,13 @@ mod profile_cache_tests {
         let json = serde_json::to_string(&s).unwrap();
         let back: Session = serde_json::from_str(&json).unwrap();
         assert_eq!(back.profiles.len(), 2);
-        assert!(back.cached_profile("u-admin").unwrap().pin.as_ref().unwrap().verify("2222"));
+        assert!(back
+            .cached_profile("u-admin")
+            .unwrap()
+            .pin
+            .as_ref()
+            .unwrap()
+            .verify("2222"));
         assert_eq!(back.cached_profile("u-kid").unwrap().server.port, 32400);
     }
 
@@ -3034,31 +3282,73 @@ mod profile_cache_tests {
         let mut s = Session::default();
         s.remember_profile(creds("u-admin", "t1", Some("1111")));
         s.remember_profile(creds("u-kid", "t2", None));
-        s.user = UserRef { uuid: "u-admin".into(), token: "t9".into(), ..Default::default() };
-        s.server = ServerRef { machine_id: "m2".into(), address: "10.0.0.9".into(), port: 32400, token: "t9".into(), ..Default::default() };
-        s.sources = vec![SourceRef { machine_id: "m2".into(), token: "t9".into(), address: "10.0.0.9".into(), port: 32400, ..Default::default() }, SourceRef { machine_id: "share".into(), token: "s".into(), address: "10.0.0.7".into(), port: 32400, ..Default::default() }];
+        s.user = UserRef {
+            uuid: "u-admin".into(),
+            token: "t9".into(),
+            ..Default::default()
+        };
+        s.server = ServerRef {
+            machine_id: "m2".into(),
+            address: "10.0.0.9".into(),
+            port: 32400,
+            token: "t9".into(),
+            ..Default::default()
+        };
+        s.sources = vec![
+            SourceRef {
+                machine_id: "m2".into(),
+                token: "t9".into(),
+                address: "10.0.0.9".into(),
+                port: 32400,
+                ..Default::default()
+            },
+            SourceRef {
+                machine_id: "share".into(),
+                token: "s".into(),
+                address: "10.0.0.7".into(),
+                port: 32400,
+                ..Default::default()
+            },
+        ];
         assert!(s.refresh_profile_record(), "a stale record changes");
         assert!(!s.refresh_profile_record(), "a current one does not");
         let c = s.cached_profile("u-admin").unwrap();
         assert_eq!(c.user.token, "t9");
         assert_eq!(c.server.machine_id, "m2");
         assert_eq!(c.sources.len(), 2, "the share found late is in the record");
-        assert!(c.pin.as_ref().unwrap().verify("1111"), "the verifier survives");
-        assert_eq!(s.cached_profile("u-kid").unwrap().user.token, "t2", "other records untouched");
+        assert!(
+            c.pin.as_ref().unwrap().verify("1111"),
+            "the verifier survives"
+        );
+        assert_eq!(
+            s.cached_profile("u-kid").unwrap().user.token,
+            "t2",
+            "other records untouched"
+        );
         s.user.uuid = "u-nobody".into();
         assert!(!s.refresh_profile_record());
-        assert_eq!(s.profiles.len(), 2, "no record for the active user: nothing invented");
+        assert_eq!(
+            s.profiles.len(),
+            2,
+            "no record for the active user: nothing invented"
+        );
     }
 
     #[test]
     fn an_unusable_entry_is_not_offered() {
         let mut s = Session::default();
         s.remember_profile(creds("u-empty", "", None));
-        assert!(s.cached_profile("u-empty").is_none(), "no token, nothing to seat");
+        assert!(
+            s.cached_profile("u-empty").is_none(),
+            "no token, nothing to seat"
+        );
         let mut c = creds("u-noorigin", "t", None);
         c.server = ServerRef::default();
         s.remember_profile(c);
-        assert!(s.cached_profile("u-noorigin").is_none(), "no primary, nothing to seat");
+        assert!(
+            s.cached_profile("u-noorigin").is_none(),
+            "no primary, nothing to seat"
+        );
     }
 
     /// The shapes the APP writes — a real primary with a tier and an https origin, a roster
@@ -3111,8 +3401,15 @@ mod profile_cache_tests {
         });
         let bytes = serde_json::to_vec_pretty(&s).unwrap();
         let back: Session = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(back.profiles.len(), 1, "{}", String::from_utf8_lossy(&bytes));
-        let c = back.cached_profile("u-admin").expect("the record is offered back");
+        assert_eq!(
+            back.profiles.len(),
+            1,
+            "{}",
+            String::from_utf8_lossy(&bytes)
+        );
+        let c = back
+            .cached_profile("u-admin")
+            .expect("the record is offered back");
         assert_eq!(c.server.tier, Some(Location::Local));
         assert!(c.pin.as_ref().unwrap().verify("1234"));
     }
@@ -3120,12 +3417,16 @@ mod profile_cache_tests {
     /// A file written before the field existed parses with an empty cache, never fails.
     #[test]
     fn a_legacy_file_has_an_empty_cache() {
-        let back: Session = serde_json::from_str(r#"{"client_id":"c","account_token":"a"}"#).unwrap();
+        let back: Session =
+            serde_json::from_str(r#"{"client_id":"c","account_token":"a"}"#).unwrap();
         assert!(back.profiles.is_empty());
         let back: Session = serde_json::from_str(
             r#"{"client_id":"c","profiles":[{"uuid":"u","user":{"token":"t"},"server":{"address":"10.0.0.1","port":"nope"}}, 7]}"#,
         )
         .unwrap();
-        assert!(back.profiles.is_empty(), "a malformed entry costs the entry, not the session");
+        assert!(
+            back.profiles.is_empty(),
+            "a malformed entry costs the entry, not the session"
+        );
     }
 }

--- a/rust-modules/src/plex/session.rs
+++ b/rust-modules/src/plex/session.rs
@@ -1035,7 +1035,9 @@ impl Session {
     ///
     /// `force_pick` is `/tmp/plxnative-pickuser`: it wins even on an automated boot. An empty
     /// `user.uuid` still raises the picker when the switch is on — that is the abandoned-at-picker
-    /// session whose PMS token falls back to the owner.
+    /// session whose PMS token falls back to the owner. A uuid that is no longer in
+    /// [`Session::home_users`] (removed Home user, stale roster) raises it too: the switch is an
+    /// opt-in to skip the list for someone still on it, not a licence to boot leftover tokens.
     pub(crate) fn boot_shows_picker(&self, automated: bool, force_pick: bool) -> bool {
         if !self.can_go_local() || self.home_users.len() <= 1 {
             return false;
@@ -1046,7 +1048,13 @@ impl Session {
         if automated {
             return false;
         }
-        !(self.auto_sign_in && !self.user.uuid.is_empty())
+        !(self.auto_sign_in && self.seated_in_roster())
+    }
+
+    /// True when [`Session::user`]'s uuid names someone still on the cached Plex Home roster.
+    pub(crate) fn seated_in_roster(&self) -> bool {
+        !self.user.uuid.is_empty()
+            && self.home_users.iter().any(|u| u.uuid == self.user.uuid)
     }
 
     /// True once we have a LAN server + a usable PMS token — i.e. we can run offline.
@@ -2148,6 +2156,12 @@ mod tests {
         assert!(
             abandoned.boot_shows_picker(false, false),
             "an empty uuid still raises the picker so the owner's token is not handed out"
+        );
+
+        let gone = dialable_home(2, "u-gone", true);
+        assert!(
+            gone.boot_shows_picker(false, false),
+            "a uuid no longer on the roster still raises the picker — leftover tokens are not a seat"
         );
 
         let solo = dialable_home(1, "u-0", false);

--- a/rust-modules/src/screens/settings.rs
+++ b/rust-modules/src/screens/settings.rs
@@ -42,7 +42,7 @@ use crate::ui::motion;
 use crate::ui::present::Provenance;
 use crate::ui::route_screen::{RouteGround, RouteLayout};
 use crate::ui::screen::{
-    At, Dir, DrawFrame, Enter, Focusable, FocusSource, FocusTarget, GroupSpec, HitSource, Mounter,
+    At, Dir, DrawFrame, Enter, FocusSource, FocusTarget, Focusable, GroupSpec, HitSource, Mounter,
     Placed, RenderStrategy, ReturnState, Screen, ScreenEvent, Step,
 };
 use crate::ui::table::{Row, Section, TableView};
@@ -109,11 +109,13 @@ impl Push {
     }
     fn parent(&self, p: Painter) -> Painter {
         let t = self.amount();
-        p.alpha(1.0 - t).translate(-PARENT_TRAVEL * Rect::FULL.w * t, 0.0)
+        p.alpha(1.0 - t)
+            .translate(-PARENT_TRAVEL * Rect::FULL.w * t, 0.0)
     }
     fn child(&self, p: Painter) -> Painter {
         let t = self.amount();
-        p.alpha(t).translate(CHILD_LEAD * Rect::FULL.w * (1.0 - t), 0.0)
+        p.alpha(t)
+            .translate(CHILD_LEAD * Rect::FULL.w * (1.0 - t), 0.0)
     }
 }
 
@@ -192,8 +194,16 @@ impl RouteSurface {
                     let icx = inner_cx(cx);
                     let mut out: Vec<Stamped<InnerHost>> = Vec::new();
                     let screen = {
-                        let mut ifx = Effects::from_handle(&mut out, MachineId::Instance(inst_id), fx.present());
-                        let arg = self.inner.entry(eid).map(|e| e.arg).unwrap_or(SettingsPage::Root);
+                        let mut ifx = Effects::from_handle(
+                            &mut out,
+                            MachineId::Instance(inst_id),
+                            fx.present(),
+                        );
+                        let arg = self
+                            .inner
+                            .entry(eid)
+                            .map(|e| e.arg)
+                            .unwrap_or(SettingsPage::Root);
                         mount_page(entry, arg, &icx, &mut ifx)
                     };
                     if let Some(e) = self.inner.entry_mut(eid) {
@@ -240,14 +250,21 @@ impl RouteSurface {
     }
 
     /// Step one inner body under the outer context and forward what it emitted.
-    fn deliver<H: AppLike>(&mut self, eid: EntryId, ev: ScreenEvent<InnerHost>, cx: &Cx<'_, H>, fx: &mut Effects<'_, H>) -> Handled {
+    fn deliver<H: AppLike>(
+        &mut self,
+        eid: EntryId,
+        ev: ScreenEvent<InnerHost>,
+        cx: &Cx<'_, H>,
+        fx: &mut Effects<'_, H>,
+    ) -> Handled {
         let mut out: Vec<Stamped<InnerHost>> = Vec::new();
         let handled = {
             let icx = inner_cx(cx);
             let Some(inst) = self.inner.entry_mut(eid).and_then(|e| e.inst.as_mut()) else {
                 return Handled::No;
             };
-            let mut ifx = Effects::from_handle(&mut out, MachineId::Instance(inst.id), fx.present());
+            let mut ifx =
+                Effects::from_handle(&mut out, MachineId::Instance(inst.id), fx.present());
             inst.screen.step(&ev, &icx, &mut ifx)
         };
         self.forward(out, cx, fx);
@@ -255,7 +272,12 @@ impl RouteSurface {
     }
 
     /// Step the TOP page.
-    fn step_top<H: AppLike>(&mut self, ev: ScreenEvent<InnerHost>, cx: &Cx<'_, H>, fx: &mut Effects<'_, H>) -> Handled {
+    fn step_top<H: AppLike>(
+        &mut self,
+        ev: ScreenEvent<InnerHost>,
+        cx: &Cx<'_, H>,
+        fx: &mut Effects<'_, H>,
+    ) -> Handled {
         match self.inner.top().map(|e| e.id) {
             Some(eid) => self.deliver(eid, ev, cx, fx),
             None => Handled::No,
@@ -264,7 +286,12 @@ impl RouteSurface {
 
     /// An inner page's emissions, translated to the outer sink: a `Nav` op is the inner stack's
     /// (§6.2), everything else passes through unchanged (same bundle, same element type).
-    fn forward<H: AppLike>(&mut self, out: Vec<Stamped<InnerHost>>, cx: &Cx<'_, H>, fx: &mut Effects<'_, H>) {
+    fn forward<H: AppLike>(
+        &mut self,
+        out: Vec<Stamped<InnerHost>>,
+        cx: &Cx<'_, H>,
+        fx: &mut Effects<'_, H>,
+    ) {
         for s in out {
             match s.fx {
                 // an inner page's Dismiss is the SURFACE's dismissal (consent's final answer)
@@ -326,7 +353,12 @@ impl RouteSurface {
     /// above it, so it becomes `Dismiss(self.entry)` — the same effect `forward` already
     /// translates an inner `Dismiss` into for consent's final answer, so both roads out of the
     /// family end at one op.
-    fn request<H: AppLike>(&mut self, op: NavOp<SettingsPage>, cx: &Cx<'_, H>, fx: &mut Effects<'_, H>) {
+    fn request<H: AppLike>(
+        &mut self,
+        op: NavOp<SettingsPage>,
+        cx: &Cx<'_, H>,
+        fx: &mut Effects<'_, H>,
+    ) {
         if matches!(op, NavOp::Pop) && self.inner.depth() <= 1 {
             fx.push(Fx::Nav(NavOp::Dismiss(self.entry)));
             return;
@@ -347,7 +379,8 @@ impl RouteSurface {
         // for a MOUNTED or merely EVICTED entry (an evicted body keeps its cursor for exactly
         // this kind of remount, `containers::stack`'s own CAP doc), so this drops only the ids
         // that are gone for good and never the ones a later `PopTo`/`Root` could still reach.
-        self.remembered.retain(|(e, _)| self.inner.entry(*e).is_some());
+        self.remembered
+            .retain(|(e, _)| self.inner.entry(*e).is_some());
         // the spring: a push runs 0 → 1 with the new page in the child role; a pop runs 1 → 0
         // with the retired page in the child role
         if popping {
@@ -364,7 +397,12 @@ impl RouteSurface {
                 .remembered
                 .iter()
                 .find(|(e, _)| *e == eid)
-                .map(|(_, elem)| FocusTarget::Elem(FocusKey { entry: self.entry, elem: *elem }))
+                .map(|(_, elem)| {
+                    FocusTarget::Elem(FocusKey {
+                        entry: self.entry,
+                        elem: *elem,
+                    })
+                })
                 .unwrap_or(FocusTarget::ContainerGroup(GroupId(0))),
             _ => FocusTarget::ContainerGroup(GroupId(0)),
         };
@@ -382,7 +420,12 @@ impl RouteSurface {
 }
 
 /// The mounter's one `match` for the family (§6.1).
-fn mount_page(entry: EntryId, arg: SettingsPage, cx: &Cx<'_, InnerHost>, fx: &mut Effects<'_, InnerHost>) -> Box<dyn Screen<InnerHost>> {
+fn mount_page(
+    entry: EntryId,
+    arg: SettingsPage,
+    cx: &Cx<'_, InnerHost>,
+    fx: &mut Effects<'_, InnerHost>,
+) -> Box<dyn Screen<InnerHost>> {
     match arg {
         SettingsPage::Root => Box::new(RootPage::new(entry)),
         SettingsPage::Legal => Box::new(super::legal::LegalIndex::new(entry)),
@@ -390,7 +433,9 @@ fn mount_page(entry: EntryId, arg: SettingsPage, cx: &Cx<'_, InnerHost>, fx: &mu
         SettingsPage::Document(i) => Box::new(super::legal::DocumentPage::legal(entry, i)),
         SettingsPage::Privacy => Box::new(super::consent::ConsentPage::settings(entry, cx, fx)),
         SettingsPage::Preview(i) => Box::new(super::consent::PreviewPage::new(entry, i)),
-        SettingsPage::ConsentStage(i) => Box::new(super::consent::ConsentPage::first_run(entry, i, cx, fx)),
+        SettingsPage::ConsentStage(i) => {
+            Box::new(super::consent::ConsentPage::first_run(entry, i, cx, fx))
+        }
         SettingsPage::Favourites => Box::new(super::onboard::OnboardScreen::settings(entry)),
     }
 }
@@ -423,7 +468,7 @@ fn mount_page(entry: EntryId, arg: SettingsPage, cx: &Cx<'_, InnerHost>, fx: &mu
 /// census, as of 2026-09-07, one line per page kind, so the next reader can check it instead of
 /// trusting it:
 ///
-///  * `RootPage` → `RootState`: the selected row.
+///  * `RootPage` → `RootState`: the selected row and the Automatically Sign In switch.
 ///  * `ConsentPage` (Privacy & data, and each first-run stage) → `ConsentState`: the mode, both
 ///    halves of the draft decision, and whether the delete alert is up.
 ///  * `OnboardScreen` (Favorite libraries) → `OnboardState`: whether it is the Settings or the
@@ -538,7 +583,13 @@ impl<H: AppLike> Machine<H> for RouteSurface {
             }
             ScreenEvent::Enter(_) => {
                 // the engine seats on this (after_step); the top page hears it too
-                self.step_top(ScreenEvent::Enter(Enter::Fresh { focus: FocusTarget::ContainerGroup(GroupId(0)) }), cx, fx);
+                self.step_top(
+                    ScreenEvent::Enter(Enter::Fresh {
+                        focus: FocusTarget::ContainerGroup(GroupId(0)),
+                    }),
+                    cx,
+                    fx,
+                );
                 Handled::Yes
             }
             ScreenEvent::Input(iev) => {
@@ -571,7 +622,14 @@ impl<H: AppLike> Machine<H> for RouteSurface {
                 // container a `Dismiss` it never got first refusal on; `back_at_the_surface_s_own_
                 // root_is_not_handled` and `left_at_the_surfaces_own_root_dismisses_it` are the
                 // two ends of that.
-                let back = matches!(iev.kind, crate::ui::machine::InputKind::Key { key: Key::Back, edge: crate::ui::machine::Edge::Down, .. });
+                let back = matches!(
+                    iev.kind,
+                    crate::ui::machine::InputKind::Key {
+                        key: Key::Back,
+                        edge: crate::ui::machine::Edge::Down,
+                        ..
+                    }
+                );
                 if back && self.inner.depth() > 1 {
                     self.request(NavOp::Pop, cx, fx);
                     return Handled::Yes;
@@ -579,7 +637,15 @@ impl<H: AppLike> Machine<H> for RouteSurface {
                 Handled::No
             }
             ScreenEvent::FocusMoved { from, to, by } => {
-                self.step_top(ScreenEvent::FocusMoved { from: *from, to: *to, by: *by }, cx, fx);
+                self.step_top(
+                    ScreenEvent::FocusMoved {
+                        from: *from,
+                        to: *to,
+                        by: *by,
+                    },
+                    cx,
+                    fx,
+                );
                 fx.invalidate(Provenance::Input);
                 Handled::Yes
             }
@@ -642,7 +708,14 @@ impl RouteSurface {
     fn tick<H: AppLike>(&mut self, t: Tick, cx: &Cx<'_, H>, fx: &mut Effects<'_, H>) {
         if !self.push.settled() {
             let mut ph: PresentHandle<'_> = fx.present();
-            motion::spring(&mut self.push.pos, &mut self.push.vel, self.push.target, PUSH_K, t, &mut ph);
+            motion::spring(
+                &mut self.push.pos,
+                &mut self.push.vel,
+                self.push.target,
+                PUSH_K,
+                t,
+                &mut ph,
+            );
             if self.push.settled() {
                 self.push.pos = self.push.target;
                 self.push.vel = 0.0;
@@ -671,7 +744,8 @@ impl RouteSurface {
         {
             let icx = inner_cx(cx);
             if let Some(inst) = self.push.leaving.as_mut() {
-                let mut ifx = Effects::from_handle(&mut out, MachineId::Instance(inst.id), fx.present());
+                let mut ifx =
+                    Effects::from_handle(&mut out, MachineId::Instance(inst.id), fx.present());
                 inst.screen.step(&ScreenEvent::Tick(t), &icx, &mut ifx);
             }
         }
@@ -686,16 +760,20 @@ impl<H: AppLike> Focusable<H> for RouteSurface {
         }
     }
     fn group_of(&self, key: &u32, cx: &Cx<'_, H>) -> Option<GroupId> {
-        self.top().and_then(|t| t.screen.group_of(key, &inner_cx(cx)))
+        self.top()
+            .and_then(|t| t.screen.group_of(key, &inner_cx(cx)))
     }
     fn neighbour(&self, key: FocusKey<u32>, dir: Dir, cx: &Cx<'_, H>) -> Step<u32> {
-        self.top().map_or(Step::Edge, |t| t.screen.neighbour(key, dir, &inner_cx(cx)))
+        self.top()
+            .map_or(Step::Edge, |t| t.screen.neighbour(key, dir, &inner_cx(cx)))
     }
     fn place(&self, key: &u32, cx: &Cx<'_, H>, at: At) -> Option<Placed> {
-        self.top().and_then(|t| t.screen.place(key, &inner_cx(cx), at))
+        self.top()
+            .and_then(|t| t.screen.place(key, &inner_cx(cx), at))
     }
     fn reconcile(&self, want: FocusKey<u32>, cx: &Cx<'_, H>) -> FocusKey<u32> {
-        self.top().map_or(want, |t| t.screen.reconcile(want, &inner_cx(cx)))
+        self.top()
+            .map_or(want, |t| t.screen.reconcile(want, &inner_cx(cx)))
     }
     fn seat(&self, g: GroupId, from: Placed, cx: &Cx<'_, H>) -> FocusKey<u32> {
         self.top().map_or(
@@ -800,7 +878,11 @@ impl RouteSurface {
                 }
             }
             if t > 0.01 {
-                let child = if popping { self.push.leaving.as_mut() } else { self.top_mut() };
+                let child = if popping {
+                    self.push.leaving.as_mut()
+                } else {
+                    self.top_mut()
+                };
                 if let Some(inst) = child {
                     let mut inner = DrawFrame::with_navigation(&icx, child_p, navigation);
                     inst.screen.draw(&mut inner);
@@ -821,7 +903,14 @@ impl RouteSurface {
 /// The surface's mounter is itself — `mount_page` — but the CONTAINER mounts the surface
 /// through the app's mounter; this impl exists so a test bundle can mount family pages alone.
 impl Mounter<InnerHost> for RouteSurface {
-    fn mount(&mut self, _id: InstanceId, arg: &SettingsPage, _ret: &ReturnState<u32>, cx: &Cx<'_, InnerHost>, fx: &mut Effects<'_, InnerHost>) -> Box<dyn Screen<InnerHost>> {
+    fn mount(
+        &mut self,
+        _id: InstanceId,
+        arg: &SettingsPage,
+        _ret: &ReturnState<u32>,
+        cx: &Cx<'_, InnerHost>,
+        fx: &mut Effects<'_, InnerHost>,
+    ) -> Box<dyn Screen<InnerHost>> {
         mount_page(self.entry, *arg, cx, fx)
     }
 }
@@ -835,6 +924,7 @@ enum Action {
     Favourites,
     Privacy,
     Legal,
+    AutoSignIn,
     About,
 }
 
@@ -848,14 +938,18 @@ pub(crate) struct RootPage {
 
 struct RootState {
     sel: i32,
+    auto_sign_in: bool,
 }
 
 impl LogicalState for RootState {
     fn write(&self, w: &mut Canon) {
-        w.u32(self.sel as u32);
+        w.u32(self.sel as u32).bool(self.auto_sign_in);
     }
     fn probe(&self, out: &mut String) {
-        out.push_str(&format!("root sel={}", self.sel));
+        out.push_str(&format!(
+            "root sel={} auto_sign_in={}",
+            self.sel, self.auto_sign_in
+        ));
     }
 }
 
@@ -879,22 +973,32 @@ fn signed_in() -> bool {
         .signed_in
 }
 
+
 impl RootPage {
     fn new(entry: EntryId) -> Self {
         let mut s = Self {
             entry,
             table: TableView::new(),
             rows: Vec::new(),
-            state: RootState { sel: 0 },
+            state: RootState {
+                sel: 0,
+                auto_sign_in: false,
+            },
         };
         s.rebuild(0);
         s
     }
 
     fn rebuild(&mut self, sel: i32) {
+        let sess = crate::plex::session::peek();
+        let signed_in = signed_in();
+        let auto_sign_in = sess.auto_sign_in();
+        let multi_user = sess.home_users.len() > 1;
+        self.state.auto_sign_in = auto_sign_in;
+
         let mut actions = Vec::new();
         let mut sections = Vec::new();
-        if signed_in() {
+        if signed_in {
             let n = crate::browse::pinned_count();
             // The section is Libraries and the row is Favorite libraries: the switch governs the
             // whole app — Home's shelves, the top tab strip and the Library's Sources picker.
@@ -902,7 +1006,10 @@ impl RootPage {
                 Section::new("Libraries").row(
                     Row::new("Favorite libraries")
                         .detail("Which libraries this television shows.")
-                        .value(format!("{n} {}", if n == 1 { "favorite" } else { "favorites" }))
+                        .value(format!(
+                            "{n} {}",
+                            if n == 1 { "favorite" } else { "favorites" }
+                        ))
                         .chevron(true),
                 ),
             );
@@ -922,13 +1029,22 @@ impl RootPage {
                 ),
         );
         actions.extend([Action::Privacy, Action::Legal]);
-        sections.push(
-            Section::new("System").row(
-                Row::new("About PlxNative")
-                    .detail("Version, copyright and project information.")
-                    .chevron(true),
-            ),
+        let mut system = Section::new("System");
+        // A one-person account already skips the picker; the switch only changes a multi-user boot.
+        if signed_in && multi_user {
+            system = system.row(
+                Row::new("Automatically Sign In")
+                    .detail("Skip the profile list and enter as this profile when the app starts.")
+                    .toggle(auto_sign_in),
+            );
+            actions.push(Action::AutoSignIn);
+        }
+        system = system.row(
+            Row::new("About PlxNative")
+                .detail("Version, copyright and project information.")
+                .chevron(true),
         );
+        sections.push(system);
         actions.push(Action::About);
         self.rows = actions;
         self.table.compact = false;
@@ -951,23 +1067,31 @@ impl RootPage {
         )
     }
 
-    fn open(&self, row: i32, fx: &mut Effects<'_, InnerHost>) {
-        let Some(action) = usize::try_from(row).ok().and_then(|i| self.rows.get(i)) else {
+    fn activate(&mut self, row: i32, fx: &mut Effects<'_, InnerHost>) {
+        let Some(&action) = usize::try_from(row).ok().and_then(|i| self.rows.get(i)) else {
             return;
         };
-        let page = match action {
-            Action::Favourites => SettingsPage::Favourites,
-            Action::Privacy => SettingsPage::Privacy,
-            Action::Legal => SettingsPage::Legal,
-            Action::About => SettingsPage::About,
-        };
-        fx.push(Fx::Nav(NavOp::Push(page)));
+        match action {
+            Action::AutoSignIn => {
+                crate::plex::session::set_auto_sign_in(!self.state.auto_sign_in);
+                self.rebuild(self.table.sel);
+            }
+            Action::Favourites => fx.push(Fx::Nav(NavOp::Push(SettingsPage::Favourites))),
+            Action::Privacy => fx.push(Fx::Nav(NavOp::Push(SettingsPage::Privacy))),
+            Action::Legal => fx.push(Fx::Nav(NavOp::Push(SettingsPage::Legal))),
+            Action::About => fx.push(Fx::Nav(NavOp::Push(SettingsPage::About))),
+        }
     }
 }
 
 impl Machine<InnerHost> for RootPage {
     type Ev = ScreenEvent<InnerHost>;
-    fn step(&mut self, ev: &Self::Ev, cx: &Cx<'_, InnerHost>, fx: &mut Effects<'_, InnerHost>) -> Handled {
+    fn step(
+        &mut self,
+        ev: &Self::Ev,
+        cx: &Cx<'_, InnerHost>,
+        fx: &mut Effects<'_, InnerHost>,
+    ) -> Handled {
         match ev {
             ScreenEvent::Enter(_) => {
                 // a return from a child: the favourite count may have changed
@@ -976,7 +1100,8 @@ impl Machine<InnerHost> for RootPage {
                 Handled::Yes
             }
             ScreenEvent::Tick(t) => {
-                self.table.update(t.dt(), RouteLayout::screen().sectioned_table().h);
+                self.table
+                    .update(t.dt(), RouteLayout::screen().sectioned_table().h);
                 Handled::Yes
             }
             ScreenEvent::FocusMoved { to, .. } => {
@@ -985,17 +1110,22 @@ impl Machine<InnerHost> for RootPage {
                 Handled::Yes
             }
             ScreenEvent::Activate(e) => {
-                self.open(*e as i32, fx);
+                self.activate(*e as i32, fx);
                 Handled::Yes
             }
             ScreenEvent::Input(crate::ui::machine::InputEvent {
-                kind: crate::ui::machine::InputKind::Key { key: Key::Right, at_edge: true, .. },
+                kind:
+                    crate::ui::machine::InputKind::Key {
+                        key: Key::Right,
+                        at_edge: true,
+                        ..
+                    },
                 ..
             }) => {
                 // rule 8: RIGHT on a row that opens nested content enters it, exactly as OK does
                 if let Some(k) = cx.focus.current {
                     if self.table.row_opens(k.elem as i32) {
-                        self.open(k.elem as i32, fx);
+                        self.activate(k.elem as i32, fx);
                     }
                 }
                 Handled::Yes
@@ -1057,9 +1187,11 @@ mod tests {
     // a pointer, a restore) — belongs to `ui::screen` beside `ScreenEvent::FocusMoved`, the only
     // thing that carries one. Writing it as `ui::machine::By` compiles nowhere and is invisible
     // to every non-test gate, since this module is `cfg(test)`.
-    use crate::ui::machine::{Edge, FocusRead, InputEvent, InputKind, InputOwner, PressRead, Source};
-    use crate::ui::screen::By;
+    use crate::ui::machine::{
+        Edge, FocusRead, InputEvent, InputKind, InputOwner, PressRead, Source,
+    };
     use crate::ui::present::Present;
+    use crate::ui::screen::By;
 
     /// Spec §14 phase 8: `Family::Settings`'s scrim/entrance composition reads
     /// `DrawFrame::nav_page_alpha` rather than the `ui::nav` statics — these two pin the
@@ -1107,7 +1239,11 @@ mod tests {
 
     /// Step the surface once and return what it emitted, the way `RouteSurface::forward` would
     /// hand effects up to whatever mounted it.
-    fn step(s: &mut RouteSurface, ev: ScreenEvent<InnerHost>, focus: Option<FocusKey<u32>>) -> Vec<Stamped<InnerHost>> {
+    fn step(
+        s: &mut RouteSurface,
+        ev: ScreenEvent<InnerHost>,
+        focus: Option<FocusKey<u32>>,
+    ) -> Vec<Stamped<InnerHost>> {
         let mut out = Vec::new();
         let mut present = Present::new();
         let mut fx = Effects::new(&mut out, MachineId::Instance(InstanceId(0)), &mut present);
@@ -1265,17 +1401,178 @@ mod tests {
         assert_eq!(before.len(), after.len(), "and nothing about its contents moved either");
     }
 
+    fn multi_user_session(tag: &str) -> crate::plex::session::TempSession {
+        let t = crate::plex::session::TempSession::new(tag);
+        crate::plex::session::save(&crate::plex::session::Session {
+            client_id: "cid-test".into(),
+            account_token: "acct".into(),
+            server: crate::plex::session::ServerRef {
+                address: "192.168.0.10".into(),
+                port: 32400,
+                token: "t".into(),
+                ..Default::default()
+            },
+            user: crate::plex::session::UserRef {
+                uuid: "u-0".into(),
+                token: "ut".into(),
+                title: "Admin".into(),
+                ..Default::default()
+            },
+            home_users: vec![
+                crate::plex::session::HomeUserRef {
+                    uuid: "u-0".into(),
+                    title: "Admin".into(),
+                    admin: true,
+                    ..Default::default()
+                },
+                crate::plex::session::HomeUserRef {
+                    uuid: "u-1".into(),
+                    title: "Kid".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        });
+        t.watching("u-0");
+        t
+    }
+
+    /// Signed-in with a Plex Home roster, row 3 is Automatically Sign In (after Favorite libraries,
+    /// Privacy & data, Legal notices).
+    const AUTO_SIGN_IN_ROW: u32 = 3;
+
     /// Mounting the surface at its `Root` page runs the inner stack's own lifecycle (§3.4) and
     /// names the root — the heartbeat's `overlay=` before anything has been pressed.
     #[test]
     fn mounting_the_surface_names_its_root_page() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-mount");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
         assert_eq!(name(&s), word::SETTINGS);
         assert_eq!(s.inner.depth(), 1);
         assert_eq!(s.kind, Family::Settings);
+    }
+
+    #[test]
+    fn signed_out_root_does_not_offer_automatically_sign_in() {
+        let _g = crate::testlock::serial();
+        let _sess = scratch_session("root-signed-out-auto");
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
+        step(&mut s, ScreenEvent::Mount, None);
+        // Privacy / Legal / About — row 2 is About, not a switch.
+        let about = FocusKey {
+            entry: EntryId(0),
+            elem: 2,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: about,
+                by: By::Dir,
+            },
+            Some(about),
+        );
+        step(&mut s, ScreenEvent::Activate(about.elem), Some(about));
+        assert_eq!(
+            s.inner.depth(),
+            2,
+            "signed out, row 2 is About — a document push"
+        );
+        assert_eq!(name(&s), word::LEGAL);
+        assert!(!crate::plex::session::peek().auto_sign_in());
+    }
+
+    #[test]
+    fn a_multi_user_root_toggles_automatically_sign_in_in_place() {
+        let _g = crate::testlock::serial();
+        let _sess = multi_user_session("root-auto-toggle");
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
+        step(&mut s, ScreenEvent::Mount, None);
+        let row = FocusKey {
+            entry: EntryId(0),
+            elem: AUTO_SIGN_IN_ROW,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: row,
+                by: By::Dir,
+            },
+            Some(row),
+        );
+        step(&mut s, ScreenEvent::Activate(row.elem), Some(row));
+        assert_eq!(
+            name(&s),
+            word::SETTINGS,
+            "OK on the switch must not push a page"
+        );
+        assert_eq!(s.inner.depth(), 1);
+        assert!(
+            crate::plex::session::peek().auto_sign_in(),
+            "OK commits the switch immediately"
+        );
+        step(&mut s, ScreenEvent::Activate(row.elem), Some(row));
+        assert!(!crate::plex::session::peek().auto_sign_in());
+        assert_eq!(s.inner.depth(), 1);
+    }
+
+    #[test]
+    fn right_on_automatically_sign_in_does_not_push() {
+        let _g = crate::testlock::serial();
+        let _sess = multi_user_session("root-auto-right");
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
+        step(&mut s, ScreenEvent::Mount, None);
+        let row = FocusKey {
+            entry: EntryId(0),
+            elem: AUTO_SIGN_IN_ROW,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: row,
+                by: By::Dir,
+            },
+            Some(row),
+        );
+        let right: ScreenEvent<InnerHost> = ScreenEvent::Input(InputEvent {
+            at: Tick::default(),
+            source: Source::Sdl,
+            kind: InputKind::Key {
+                key: Key::Right,
+                sym: 0,
+                wcode: 0,
+                edge: Edge::Down,
+                at_edge: true,
+            },
+        });
+        let _ = step(&mut s, right, Some(row));
+        assert_eq!(s.inner.depth(), 1, "RIGHT on a switch is not rule 8");
+        assert!(!crate::plex::session::peek().auto_sign_in());
+        assert_eq!(name(&s), word::SETTINGS);
     }
 
     /// **BACK at the surface's own root does not touch the inner stack, and it is not swallowed
@@ -1287,19 +1584,38 @@ mod tests {
     fn back_at_the_surface_s_own_root_is_not_handled() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-back-root");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
         let back: ScreenEvent<InnerHost> = ScreenEvent::Input(InputEvent {
             at: Tick::default(),
             source: Source::Sdl,
-            kind: InputKind::Key { key: Key::Back, sym: 0, wcode: 0, edge: Edge::Down, at_edge: false },
+            kind: InputKind::Key {
+                key: Key::Back,
+                sym: 0,
+                wcode: 0,
+                edge: Edge::Down,
+                at_edge: false,
+            },
         });
         let mut out = Vec::new();
         let mut present = Present::new();
         let mut fx = Effects::new(&mut out, MachineId::Instance(InstanceId(0)), &mut present);
         let handled = <RouteSurface as Machine<InnerHost>>::step(&mut s, &back, &cx(None), &mut fx);
-        assert_eq!(handled, Handled::No, "the surface's own stack has nothing to pop at depth 1");
-        assert_eq!(s.inner.depth(), 1, "…and nothing about the stack moved while deciding that");
+        assert_eq!(
+            handled,
+            Handled::No,
+            "the surface's own stack has nothing to pop at depth 1"
+        );
+        assert_eq!(
+            s.inner.depth(),
+            1,
+            "…and nothing about the stack moved while deciding that"
+        );
     }
 
     /// **The remembered-focus round trip (spec §7.3 step 4).** Signed out, the root's rows are
@@ -1311,30 +1627,65 @@ mod tests {
     fn a_pop_from_legal_restores_focus_to_the_row_that_opened_it() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-pop-focus");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
 
-        let legal_row = FocusKey { entry: EntryId(0), elem: 1 };
+        let legal_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
         step(
             &mut s,
-            ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir },
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
             Some(legal_row),
         );
-        step(&mut s, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
-        assert_eq!(name(&s), word::LEGAL, "OK on Legal notices pushed the index");
+        step(
+            &mut s,
+            ScreenEvent::Activate(legal_row.elem),
+            Some(legal_row),
+        );
+        assert_eq!(
+            name(&s),
+            word::LEGAL,
+            "OK on Legal notices pushed the index"
+        );
         assert_eq!(s.inner.depth(), 2);
 
         let back: ScreenEvent<InnerHost> = ScreenEvent::Input(InputEvent {
             at: Tick::default(),
             source: Source::Sdl,
-            kind: InputKind::Key { key: Key::Back, sym: 0, wcode: 0, edge: Edge::Down, at_edge: false },
+            kind: InputKind::Key {
+                key: Key::Back,
+                sym: 0,
+                wcode: 0,
+                edge: Edge::Down,
+                at_edge: false,
+            },
         });
         let out = step(&mut s, back, None);
-        assert_eq!(name(&s), word::SETTINGS, "BACK popped the inner stack, not the surface");
+        assert_eq!(
+            name(&s),
+            word::SETTINGS,
+            "BACK popped the inner stack, not the surface"
+        );
         assert_eq!(s.inner.depth(), 1);
 
         let reseat = out.iter().find_map(|st| match &st.fx {
-            Fx::Deliver(_, Delivery::Screen(ScreenEvent::Enter(Enter::Fresh { focus: FocusTarget::Elem(k) }))) => Some(*k),
+            Fx::Deliver(
+                _,
+                Delivery::Screen(ScreenEvent::Enter(Enter::Fresh {
+                    focus: FocusTarget::Elem(k),
+                })),
+            ) => Some(*k),
             _ => None,
         });
         assert_eq!(
@@ -1352,13 +1703,31 @@ mod tests {
     fn a_push_seats_the_new_page_fresh_rather_than_from_the_remembered_list() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-push-seat");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
-        let root_row = FocusKey { entry: EntryId(0), elem: 1 };
-        step(&mut s, ScreenEvent::FocusMoved { from: None, to: root_row, by: By::Dir }, Some(root_row));
+        let root_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: root_row,
+                by: By::Dir,
+            },
+            Some(root_row),
+        );
         let out = step(&mut s, ScreenEvent::Activate(root_row.elem), Some(root_row));
         let seat = out.iter().find_map(|st| match &st.fx {
-            Fx::Deliver(_, Delivery::Screen(ScreenEvent::Enter(Enter::Fresh { focus }))) => Some(*focus),
+            Fx::Deliver(_, Delivery::Screen(ScreenEvent::Enter(Enter::Fresh { focus }))) => {
+                Some(*focus)
+            }
             _ => None,
         });
         assert!(
@@ -1375,17 +1744,43 @@ mod tests {
     fn remembered_does_not_grow_across_repeated_visits_to_the_same_page() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-remembered");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
-        let legal_row = FocusKey { entry: EntryId(0), elem: 1 };
+        let legal_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
         for _ in 0..5 {
-            step(&mut s, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
-            step(&mut s, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
+            step(
+                &mut s,
+                ScreenEvent::FocusMoved {
+                    from: None,
+                    to: legal_row,
+                    by: By::Dir,
+                },
+                Some(legal_row),
+            );
+            step(
+                &mut s,
+                ScreenEvent::Activate(legal_row.elem),
+                Some(legal_row),
+            );
             assert_eq!(name(&s), word::LEGAL);
             let back: ScreenEvent<InnerHost> = ScreenEvent::Input(InputEvent {
                 at: Tick::default(),
                 source: Source::Sdl,
-                kind: InputKind::Key { key: Key::Back, sym: 0, wcode: 0, edge: Edge::Down, at_edge: false },
+                kind: InputKind::Key {
+                    key: Key::Back,
+                    sym: 0,
+                    wcode: 0,
+                    edge: Edge::Down,
+                    at_edge: false,
+                },
             });
             step(&mut s, back, None);
             assert_eq!(name(&s), word::SETTINGS);
@@ -1401,7 +1796,14 @@ mod tests {
     /// fails the test rather than hanging the suite.
     fn settle(s: &mut RouteSurface) {
         for i in 1..600u32 {
-            step(s, ScreenEvent::Tick(Tick { ms: i * 16, dt_us: 16_000 }), None);
+            step(
+                s,
+                ScreenEvent::Tick(Tick {
+                    ms: i * 16,
+                    dt_us: 16_000,
+                }),
+                None,
+            );
             if s.at_rest() {
                 return;
             }
@@ -1424,27 +1826,74 @@ mod tests {
     fn a_settled_pop_leaves_the_surface_at_rest_at_depth_two() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-at-rest");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
-        assert!(s.at_rest(), "a freshly mounted surface has no push in flight");
+        assert!(
+            s.at_rest(),
+            "a freshly mounted surface has no push in flight"
+        );
 
         // root → Legal notices → About-style document: two pushes, so the pop below lands on a
         // stack that still has something UNDER its top
-        let legal_row = FocusKey { entry: EntryId(0), elem: 1 };
-        step(&mut s, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
-        step(&mut s, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
-        assert!(!s.at_rest(), "the push is in flight the frame it is requested");
+        let legal_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
+            Some(legal_row),
+        );
+        step(
+            &mut s,
+            ScreenEvent::Activate(legal_row.elem),
+            Some(legal_row),
+        );
+        assert!(
+            !s.at_rest(),
+            "the push is in flight the frame it is requested"
+        );
         settle(&mut s);
-        let doc_row = FocusKey { entry: EntryId(0), elem: 0 };
-        step(&mut s, ScreenEvent::FocusMoved { from: None, to: doc_row, by: By::Dir }, Some(doc_row));
+        let doc_row = FocusKey {
+            entry: EntryId(0),
+            elem: 0,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: doc_row,
+                by: By::Dir,
+            },
+            Some(doc_row),
+        );
         step(&mut s, ScreenEvent::Activate(doc_row.elem), Some(doc_row));
         settle(&mut s);
-        assert_eq!(s.inner.depth(), 3, "root → Legal index → one Legal document");
+        assert_eq!(
+            s.inner.depth(),
+            3,
+            "root → Legal index → one Legal document"
+        );
 
         let back: ScreenEvent<InnerHost> = ScreenEvent::Input(InputEvent {
             at: Tick::default(),
             source: Source::Sdl,
-            kind: InputKind::Key { key: Key::Back, sym: 0, wcode: 0, edge: Edge::Down, at_edge: false },
+            kind: InputKind::Key {
+                key: Key::Back,
+                sym: 0,
+                wcode: 0,
+                edge: Edge::Down,
+                at_edge: false,
+            },
         });
         step(&mut s, back, None);
         assert_eq!(s.inner.depth(), 2, "BACK popped the document");
@@ -1455,7 +1904,10 @@ mod tests {
             "with the spring settled and nothing leaving, the Legal index is the only page on \
              screen — even though `below()` still answers the Settings root"
         );
-        assert!(s.push.leaving.is_none(), "the outgoing body is released when the spring lands");
+        assert!(
+            s.push.leaving.is_none(),
+            "the outgoing body is released when the spring lands"
+        );
     }
 
     /// **The surface's logical state covers its inner stack — the whole reason phase 5b re-pinned
@@ -1477,13 +1929,33 @@ mod tests {
     fn the_logical_state_follows_the_inner_stack() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-state-hash");
-        let mut s = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
         let at_root = <RouteSurface as Screen<InnerHost>>::state(&s).hash();
 
-        let legal_row = FocusKey { entry: EntryId(0), elem: 1 };
-        step(&mut s, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
-        step(&mut s, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
+        let legal_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
+            Some(legal_row),
+        );
+        step(
+            &mut s,
+            ScreenEvent::Activate(legal_row.elem),
+            Some(legal_row),
+        );
         let at_legal = <RouteSurface as Screen<InnerHost>>::state(&s).hash();
         assert_ne!(
             at_root, at_legal,
@@ -1506,7 +1978,13 @@ mod tests {
         ScreenEvent::Input(InputEvent {
             at: Tick::default(),
             source: Source::Sdl,
-            kind: InputKind::Key { key: Key::Back, sym: 0, wcode: 0, edge: Edge::Down, at_edge: false },
+            kind: InputKind::Key {
+                key: Key::Back,
+                sym: 0,
+                wcode: 0,
+                edge: Edge::Down,
+                at_edge: false,
+            },
         })
     }
 
@@ -1570,16 +2048,30 @@ mod tests {
     fn a_pop_that_would_empty_the_stack_dismisses_the_surface_instead() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-pop-empty");
-        let mut s = RouteSurface::new(EntryId(7), InstanceId(0), Family::Settings, SettingsPage::Privacy);
+        let mut s = RouteSurface::new(
+            EntryId(7),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Privacy,
+        );
         step(&mut s, ScreenEvent::Mount, None);
-        assert_eq!(s.inner.depth(), 1, "rooted at Privacy, there is nothing under it");
+        assert_eq!(
+            s.inner.depth(),
+            1,
+            "rooted at Privacy, there is nothing under it"
+        );
 
         let out = forwarded(&mut s, Fx::Nav(NavOp::Pop));
         assert!(
-            out.iter().any(|st| matches!(&st.fx, Fx::Nav(NavOp::Dismiss(e)) if *e == EntryId(7))),
+            out.iter()
+                .any(|st| matches!(&st.fx, Fx::Nav(NavOp::Dismiss(e)) if *e == EntryId(7))),
             "the Pop must become this surface's own dismissal, emitted against its entry"
         );
-        assert_eq!(s.inner.depth(), 1, "…and the stack must NOT have been emptied on the way");
+        assert_eq!(
+            s.inner.depth(),
+            1,
+            "…and the stack must NOT have been emptied on the way"
+        );
         assert!(
             s.top().is_some(),
             "a surface with no top page draws its ground over nothing and cannot be left"
@@ -1594,20 +2086,45 @@ mod tests {
     fn a_pop_with_a_page_under_it_pops_the_inner_stack_and_stays_up() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-pop-inner");
-        let mut s = RouteSurface::new(EntryId(7), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut s = RouteSurface::new(
+            EntryId(7),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut s, ScreenEvent::Mount, None);
-        let legal_row = FocusKey { entry: EntryId(7), elem: 1 };
-        step(&mut s, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
-        step(&mut s, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
+        let legal_row = FocusKey {
+            entry: EntryId(7),
+            elem: 1,
+        };
+        step(
+            &mut s,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
+            Some(legal_row),
+        );
+        step(
+            &mut s,
+            ScreenEvent::Activate(legal_row.elem),
+            Some(legal_row),
+        );
         assert_eq!(s.inner.depth(), 2, "Legal is up");
 
         let out = forwarded(&mut s, Fx::Nav(NavOp::Pop));
         assert!(
-            !out.iter().any(|st| matches!(&st.fx, Fx::Nav(NavOp::Dismiss(_)))),
+            !out.iter()
+                .any(|st| matches!(&st.fx, Fx::Nav(NavOp::Dismiss(_)))),
             "a Pop with something under it is the INNER stack's, never the surface's"
         );
         assert_eq!(s.inner.depth(), 1);
-        assert_eq!(name(&s), word::SETTINGS, "it landed back on the Settings root");
+        assert_eq!(
+            name(&s),
+            word::SETTINGS,
+            "it landed back on the Settings root"
+        );
     }
 
     /// **`remembered` is in the hash, and this is the arrangement that isolates it.** Two
@@ -1623,21 +2140,64 @@ mod tests {
     fn the_remembered_seats_are_part_of_the_hash() {
         let _g = crate::testlock::serial();
         let _sess = scratch_session("surface-seat-hash");
-        let legal_row = FocusKey { entry: EntryId(0), elem: 1 };
+        let legal_row = FocusKey {
+            entry: EntryId(0),
+            elem: 1,
+        };
 
-        let mut seated = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut seated = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut seated, ScreenEvent::Mount, None);
-        step(&mut seated, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
-        step(&mut seated, ScreenEvent::Activate(legal_row.elem), Some(legal_row));
+        step(
+            &mut seated,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
+            Some(legal_row),
+        );
+        step(
+            &mut seated,
+            ScreenEvent::Activate(legal_row.elem),
+            Some(legal_row),
+        );
 
-        let mut unseated = RouteSurface::new(EntryId(0), InstanceId(0), Family::Settings, SettingsPage::Root);
+        let mut unseated = RouteSurface::new(
+            EntryId(0),
+            InstanceId(0),
+            Family::Settings,
+            SettingsPage::Root,
+        );
         step(&mut unseated, ScreenEvent::Mount, None);
-        step(&mut unseated, ScreenEvent::FocusMoved { from: None, to: legal_row, by: By::Dir }, Some(legal_row));
+        step(
+            &mut unseated,
+            ScreenEvent::FocusMoved {
+                from: None,
+                to: legal_row,
+                by: By::Dir,
+            },
+            Some(legal_row),
+        );
         step(&mut unseated, ScreenEvent::Activate(legal_row.elem), None);
 
-        assert_eq!(seated.inner.depth(), unseated.inner.depth(), "the same stack, by construction");
-        assert!(!seated.remembered.is_empty(), "the seated push recorded where focus was");
-        assert!(unseated.remembered.is_empty(), "the unseated one had nothing to record");
+        assert_eq!(
+            seated.inner.depth(),
+            unseated.inner.depth(),
+            "the same stack, by construction"
+        );
+        assert!(
+            !seated.remembered.is_empty(),
+            "the seated push recorded where focus was"
+        );
+        assert!(
+            unseated.remembered.is_empty(),
+            "the unseated one had nothing to record"
+        );
         assert_ne!(
             <RouteSurface as Screen<InnerHost>>::state(&seated).hash(),
             <RouteSurface as Screen<InnerHost>>::state(&unseated).hash(),
@@ -1651,12 +2211,17 @@ mod tests {
         let b = step(&mut unseated, back_key(), None);
         let seat_of = |out: &[Stamped<InnerHost>]| {
             out.iter().find_map(|st| match &st.fx {
-                Fx::Deliver(_, Delivery::Screen(ScreenEvent::Enter(Enter::Fresh { focus }))) => Some(*focus),
+                Fx::Deliver(_, Delivery::Screen(ScreenEvent::Enter(Enter::Fresh { focus }))) => {
+                    Some(*focus)
+                }
                 _ => None,
             })
         };
         assert!(matches!(seat_of(&a), Some(FocusTarget::Elem(k)) if k == legal_row));
-        assert!(matches!(seat_of(&b), Some(FocusTarget::ContainerGroup(GroupId(0)))));
+        assert!(matches!(
+            seat_of(&b),
+            Some(FocusTarget::ContainerGroup(GroupId(0)))
+        ));
     }
 
     /// **THE LEFT ROAD, EXECUTED** (§7.3 step 2 + rule 9) — the one road into this surface that
@@ -1755,11 +2320,31 @@ mod tests {
                     measure: &self.measure,
                 }
             }
-            fn deliver(&mut self, _to: MachineId, _msg: &AppMsg, _parts: &CxParts<u32>, _fx: &mut Effects<'_, InnerHost>) -> Handled {
+            fn deliver(
+                &mut self,
+                _to: MachineId,
+                _msg: &AppMsg,
+                _parts: &CxParts<u32>,
+                _fx: &mut Effects<'_, InnerHost>,
+            ) -> Handled {
                 Handled::No
             }
-            fn timer(&mut self, _owner: MachineId, _id: TimerId, _parts: &CxParts<u32>, _fx: &mut Effects<'_, InnerHost>) {}
-            fn app_fx(&mut self, _from: MachineId, _fx: AppFx, _parts: &CxParts<u32>, _out: &mut Effects<'_, InnerHost>) {}
+            fn timer(
+                &mut self,
+                _owner: MachineId,
+                _id: TimerId,
+                _parts: &CxParts<u32>,
+                _fx: &mut Effects<'_, InnerHost>,
+            ) {
+            }
+            fn app_fx(
+                &mut self,
+                _from: MachineId,
+                _fx: AppFx,
+                _parts: &CxParts<u32>,
+                _out: &mut Effects<'_, InnerHost>,
+            ) {
+            }
             fn log(&mut self, _line: &str) {}
             fn prepare(&mut self, _b: &mut Budget, _present: &mut Present) {}
             fn ls2_pump(&mut self) {}
@@ -1779,7 +2364,12 @@ mod tests {
         /// what this module grades (ingest, the engine, the drain, the nav commit), and step 10
         /// is the only one it cannot run. The prepare pass still runs, which is safe: every
         /// `prepare` in this family is empty.
-        fn frame(d: &mut Dispatcher<InnerHost>, rig: &mut SurfaceRig, ms: u32, inputs: Vec<crate::ui::machine::InputEvent<u32>>) {
+        fn frame(
+            d: &mut Dispatcher<InnerHost>,
+            rig: &mut SurfaceRig,
+            ms: u32,
+            inputs: Vec<crate::ui::machine::InputEvent<u32>>,
+        ) {
             d.frame_with(rig, tick(ms), inputs, vec![], &mut NoTap, false);
         }
 
@@ -1797,7 +2387,13 @@ mod tests {
             d.nav.next_style = Style::Opaque { snapshot: true };
             d.request(MachineId::Nav, NavOp::Present(SettingsPage::Root));
             frame(&mut d, &mut rig, 16, vec![]);
-            let id = d.nav.modals.top().expect("the surface is presented").entry.id;
+            let id = d
+                .nav
+                .modals
+                .top()
+                .expect("the surface is presented")
+                .entry
+                .id;
             (d, rig, id)
         }
 
@@ -1806,7 +2402,15 @@ mod tests {
         /// `&dyn Screen`, so there is no downcast to a `RouteSurface`).
         fn path(d: &Dispatcher<InnerHost>, id: EntryId) -> String {
             let mut s = String::new();
-            d.nav.entry(id).unwrap().inst.as_ref().unwrap().screen.state().probe(&mut s);
+            d.nav
+                .entry(id)
+                .unwrap()
+                .inst
+                .as_ref()
+                .unwrap()
+                .screen
+                .state()
+                .probe(&mut s);
             s
         }
 
@@ -1827,17 +2431,31 @@ mod tests {
             let _g = crate::testlock::serial();
             let _sess = scratch_session("composed-left-inner");
             let (mut d, mut rig, id) = opened();
-            assert!(path(&d, id).starts_with("settings/root:"), "{}", path(&d, id));
+            assert!(
+                path(&d, id).starts_with("settings/root:"),
+                "{}",
+                path(&d, id)
+            );
 
             seat(&mut d, id, 1);
             frame(&mut d, &mut rig, 32, vec![key(Key::Ok, tick(32))]);
-            assert!(path(&d, id).contains("/legal:"), "OK on Legal notices pushed the index: {}", path(&d, id));
+            assert!(
+                path(&d, id).contains("/legal:"),
+                "OK on Legal notices pushed the index: {}",
+                path(&d, id)
+            );
 
             seat(&mut d, id, 0);
             frame(&mut d, &mut rig, 48, vec![key(Key::Left, tick(48))]);
             let p = path(&d, id);
-            assert!(!p.contains("/legal:"), "LEFT popped the index off the surface's stack: {p}");
-            assert!(p.starts_with("settings/root:"), "…and landed on the Settings root: {p}");
+            assert!(
+                !p.contains("/legal:"),
+                "LEFT popped the index off the surface's stack: {p}"
+            );
+            assert!(
+                p.starts_with("settings/root:"),
+                "…and landed on the Settings root: {p}"
+            );
             assert_ne!(
                 d.nav.modals.top().unwrap().phase,
                 Phase::Closing,
@@ -1864,14 +2482,25 @@ mod tests {
             let (mut d, mut rig, id) = opened();
             seat(&mut d, id, 0);
             frame(&mut d, &mut rig, 32, vec![key(Key::Left, tick(32))]);
-            assert!(path(&d, id).starts_with("settings/root:"), "the stack never moved: {}", path(&d, id));
+            assert!(
+                path(&d, id).starts_with("settings/root:"),
+                "the stack never moved: {}",
+                path(&d, id)
+            );
             assert_eq!(
                 d.nav.modals.top().unwrap().phase,
                 Phase::Closing,
                 "the refusal became the container's BACK, in the same frame"
             );
-            assert_ne!(d.nav.input_owner(), Some(InputOwner::Entry(id)), "input left with it");
-            assert_eq!(rig.roots, 0, "a surface dismissal is not the platform's BACK");
+            assert_ne!(
+                d.nav.input_owner(),
+                Some(InputOwner::Entry(id)),
+                "input left with it"
+            );
+            assert_eq!(
+                rig.roots, 0,
+                "a surface dismissal is not the platform's BACK"
+            );
         }
     }
 }


### PR DESCRIPTION
On a multiuser Plex Home, every interactive boot still asked who's watching. Solo accounts already skipped that screen. This adds the opt in toggle to automatically select a profile.

Settings -> System gets an **Automatically Sign In** switch when you're signed in and the roster has more than one profile. It sticks on the session file as `auto_sign_in` (missing or junk counts as off, which is the picker everyone already knows), written through `session::update` so a roster or recents write can't quietly drop it. A full profile-switch `save` keeps it too.

Boot goes through `Session::boot_shows_picker`. The switch only skips the picker when the seated uuid is still on the roster. Empty uuid (walked away at the picker) and a uuid that isn't in `home_users` any more (removed user, stale roster) still get the list. Automated boots and `plxnative-pickuser` behave as before. 

Note: Turning this on while a PIN protected profile is active means the next launch skips that PIN on purpose.

Change Profile -> BACK still won't resume for you.

`docs/agent-reference.md` and `docs/plex-pass-audit.md` mention the new gate.

Host tests cover the soft-parse, the persist/`save` keep, the picker table(including `u-gone`), and the Settings row (toggle in place, RIGHT doesn't push, signed-out hides it). On a set: turn it on under a PIN profile, relaunch straight into Home. turn it off and the picker comes back. Change Profile, relaunch, you land as whoever you just picked.


https://github.com/user-attachments/assets/6c0be010-6b73-4ad6-8bc3-9313585e4dd8

