### PR TITLE
ui: a thicker white rim on the focused chapter so it reads over the video plane

### DIFF
--- a/rust-modules/src/ui/chapters_panel.rs
+++ b/rust-modules/src/ui/chapters_panel.rs
@@ -19,6 +19,13 @@ const CH_W: f32 = 288.0;
 const CH_H: f32 = 162.0; // 16:9 still
 const CH_GAP: f32 = 24.0;
 const CH_TOP: f32 = 684.0; // thumbnail top — name/time fit above the tabs (SCR_H-128)
+const CH_RAD: f32 = 10.0;
+/// Focus rim on the selected chapter. The card family's resting sheen ([`theme::CARD_SHEEN`] .22 /
+/// 1px) washes out over the hardware video plane the same way an unkeyed control's edge did — pure
+/// white and a thicker stroke are what keep "which chapter" readable from the couch while scrolling.
+/// Colour is the unkeyed focus edge ([`theme::CONTROL_RIM_FOCUS_UNKEYED`]); width is deliberately a
+/// step over that control's 1.25 so a 288-wide still reads as selected, not merely edged.
+const CH_FOCUS_RING_W: f32 = 2.5;
 use crate::ui::widgets::CARD_FOCUS_SCALE;
 
 /// The strip's whole state, owned by the container that mounts this panel — the modal PHASE and
@@ -133,10 +140,21 @@ impl ChaptersState {
                 crate::route::item_sid(crate::route::cur_sid(ps)),
                 &ch.thumb,
                 (480, 270),
-                10.0,
+                CH_RAD,
                 focused,
                 scale,
             );
+            if focused {
+                // Same scaled frame `card()` draws into, so the rim rides the focus pop rather than
+                // lagging a resting box. Full strength whenever focused — the pop already animates the
+                // geometry; fading the rim with it would blank the selection mark on every LEFT/RIGHT.
+                p.rring(
+                    card.scaled(scale),
+                    CH_RAD,
+                    CH_FOCUS_RING_W,
+                    theme::CONTROL_RIM_FOCUS_UNKEYED,
+                );
+            }
             // name + timestamp beneath the card
             let ty = CH_TOP + CH_H + 26.0;
             let titc = if focused {


### PR DESCRIPTION
The Chapters strip sits on the hardware video plane. The card family's resting sheen (`theme::CARD_SHEEN`, .22 / 1px) washes out there the same way an unkeyed control's edge did, so LEFT/RIGHT through the strip did not say which still was selected from the couch.

## What this PR changes

The focused chapter now draws a round-rect rim in `theme::CONTROL_RIM_FOCUS_UNKEYED` (the unkeyed control's pure-white focus edge) at **2.5px**. That width is a step over the control family's 1.25: a 288-wide still needs more than an edge to read as selected, not merely edged.

The rim is painted on the same scaled frame `card()` draws into, so it rides the focus pop instead of lagging a resting box. Full strength whenever focused: the pop already animates the geometry, and fading the rim with it would blank the selection mark on every LEFT/RIGHT.

`CH_RAD` and `CH_FOCUS_RING_W` name the numbers that were previously a bare `10.0` into `draw_card`.

## Verification

Layout and colour over a moving picture. `make check` cannot see a pixel. The simulator cannot see the video plane, which is the whole reason the sheen failed.

- `make check`
- `CARGO_INCREMENTAL=0 cargo +nightly check --manifest-path rust-modules/Cargo.toml --lib --no-default-features`
- Simulator: open Chapters during playback, walk LEFT/RIGHT, confirm the rim rides the pop and does not vanish mid-move

### Before

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/545925b0-3707-4805-9a19-21a601a19479" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/2f157937-4266-4d16-9ec5-dae193f3f079" />

### After

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/ca7355d4-0419-4a05-be92-946d11fa95f5" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/1a37b194-cc18-4971-b1ba-5b64882ec889" />
